### PR TITLE
closestTo (closes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Code is fully documented, check the source for the reference.
 * [`compareDesc`](./src/compare_desc.js) - compare the two dates reverse chronologically and return -1, 0 or 1.
 * [`max`]('./src/max') - return the latest of the given dates.
 * [`min`]('./src/min') - return the earliest of the given dates.
+* [`closestTo`](./src/closest_to.js) - return a date from the array closest to the given date.
 * [`parse`](./src/parse.js) - parse the ISO-8601-formatted date.
 * [`isValid`](./src/is_valid.js) - is the given date valid?
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
   addSeconds: require('./src/add_seconds'),
   addWeeks: require('./src/add_weeks'),
   addYears: require('./src/add_years'),
+  closestTo: require('./src/closest_to'),
   compareAsc: require('./src/compare_asc'),
   compareDesc: require('./src/compare_desc'),
   differenceInDays: require('./src/difference_in_days'),

--- a/src/__tests__/closest_to_test.js
+++ b/src/__tests__/closest_to_test.js
@@ -1,0 +1,54 @@
+var assert = require('power-assert')
+var closestTo = require('../closest_to')
+
+describe('closestTo', function() {
+  it('returns date from array closest to given date', function() {
+    var date = new Date(2014, 6 /* Jul */, 2)
+    var result = closestTo(date, [
+      new Date(2015, 7 /* Aug */, 31),
+      new Date(2012, 6 /* Jul */, 2)
+    ])
+    assert.deepEqual(result, new Date(2015, 7 /* Aug */, 31))
+  })
+
+  it('works if closest date from array is before given date', function() {
+    var date = new Date(2014, 6 /* Jul */, 2, 6, 30, 4, 500)
+    var result = closestTo(date, [
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 5, 900),
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 3, 900),
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 10),
+    ])
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 2, 6, 30, 3, 900))
+  })
+
+  it('accepts strings', function() {
+    var date = new Date(2014, 6 /* Jul */, 2).toISOString()
+    var result = closestTo(date, [
+      new Date(2012, 6 /* Jul */, 2).toISOString(),
+      new Date(2015, 7 /* Aug */, 31).toISOString()
+    ])
+    assert.deepEqual(result, new Date(2015, 7 /* Aug */, 31))
+  })
+
+  it('accepts timestamps', function() {
+    var date = new Date(2014, 6 /* Jul */, 2).getTime()
+    var result = closestTo(date, [
+      new Date(2015, 7 /* Aug */, 31).getTime(),
+      new Date(2012, 6 /* Jul */, 2).getTime()
+    ])
+    assert.deepEqual(result, new Date(2015, 7 /* Aug */, 31))
+  })
+
+  it('returns undefined if array is empty', function() {
+    var date = new Date(2014, 6 /* Jul */, 2).getTime()
+    var result = closestTo(date, [])
+    assert(result === undefined)
+  })
+
+  it('throws exception if second argument is not array', function() {
+    var date = new Date(2014, 6 /* Jul */, 2).getTime()
+    var block = closestTo.bind(null, date, '')
+    assert.throws(block, TypeError, '[object String] is not an array')
+  })
+})
+

--- a/src/closest_to.js
+++ b/src/closest_to.js
@@ -1,0 +1,42 @@
+var parse = require('./parse')
+
+/**
+ * Return a date from the array closest to the given date.
+ *
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {(Date|String|Number)[]} datesArray - the array to search
+ * @returns {Date} date from the array closest to the given date
+ *
+ * @example what is closer to the 6 Oct 2015: 1 Jan 2000 or 1 Jan 2030
+ * var dateToCompare = new Date(2015, 8, 6)
+ * var result = closestTo(dateToCompare, [
+ *   new Date(2000, 0, 1),
+ *   new Date(2030, 0, 1)
+ * ])
+ * //=> Tue Jan 01 2030 00:00:00
+ */
+var closestTo = function(dirtyDateToCompare, dirtyDatesArray) {
+  if (!(dirtyDatesArray instanceof Array)) {
+    throw new TypeError(toString.call(dirtyDatesArray) + ' is not an array')
+  }
+
+  var dateToCompare = parse(dirtyDateToCompare)
+  var timeToCompare = dateToCompare.getTime()
+
+  var result
+  var minDistance
+
+  dirtyDatesArray.forEach(function(dirtyDate) {
+    var currentDate = parse(dirtyDate)
+    var distance = Math.abs(timeToCompare - currentDate.getTime())
+    if (result === undefined || distance < minDistance) {
+      result = currentDate
+      minDistance = distance
+    }
+  })
+
+  return result
+}
+
+module.exports = closestTo
+


### PR DESCRIPTION
`returns undefined if array is empty` — the same as `Array.prototype.find()` returns `undefined` if element is not found