### PR TITLE
Fix leap day bug with add/sub years

### DIFF
--- a/src/add_years/index.js
+++ b/src/add_years/index.js
@@ -1,4 +1,4 @@
-var parse = require('../parse')
+var addMonths = require('../add_months')
 
 /**
  * @category Year Helpers
@@ -17,9 +17,7 @@ var parse = require('../parse')
  * //=> Sun Sep 01 2019 00:00:00
  */
 var addYears = function(dirtyDate, amount) {
-  var date = parse(dirtyDate)
-  date.setFullYear(date.getFullYear() + amount)
-  return date
+  return addMonths(dirtyDate, amount * 12)
 }
 
 module.exports = addYears

--- a/src/add_years/test.js
+++ b/src/add_years/test.js
@@ -22,5 +22,10 @@ describe('addYears', function() {
     addYears(date, 12)
     assert.deepEqual(date, new Date(2014, 8 /* Sep */, 1))
   })
+
+  it('handles leap years', function() {
+    var result = addYears(new Date(2016, 1 /* Feb */, 29), 1)
+    assert.deepEqual(result, new Date(2017, 1 /* Feb */, 28))
+  })
 })
 

--- a/src/sub_years/test.js
+++ b/src/sub_years/test.js
@@ -22,5 +22,10 @@ describe('subYears', function() {
     subYears(date, 12)
     assert.deepEqual(date, new Date(2014, 8 /* Sep */, 1))
   })
+
+  it('handles leap years', function() {
+    var result = subYears(new Date(2016, 1 /* Feb */, 29), 1)
+    assert.deepEqual(result, new Date(2015, 1 /* Feb */, 28))
+  })
 })
 


### PR DESCRIPTION
Consider:

```javascript
console.log(format(addMonths('2016-02-29', 12), 'YYYY-MM-DD')); // 2017-02-28
console.log(format(addYears('2016-02-29', 1), 'YYYY-MM-DD'));   // 2017-03-01

console.log(format(subMonths('2016-02-29', 12), 'YYYY-MM-DD')); // 2015-02-28
console.log(format(subYears('2016-02-29', 1), 'YYYY-MM-DD'));   // 2015-03-01
```

Since February 29th does not exist in a common year, the Date object advances it forward to March 1st.  Feb 28th is usually expected in most scenarios (IMHO).

See also:
http://codeofmatt.com/2016/01/01/happy-new-leap-year/

(Scroll down to "Adding a year in JavaScript")
