### PR TITLE
Add closestToIndex

### DIFF
--- a/src/closest_to_index/index.js
+++ b/src/closest_to_index/index.js
@@ -1,0 +1,45 @@
+var parse = require('../parse')
+
+/**
+ * @category Common Helpers
+ * @summary Return an index of closest date from array comparing to given date.
+ *
+ * @description
+ * Return an index of closest date from array comparing to given date.
+ *
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {Date[]|String[]|Number[]} datesArray - the array to search
+ * @returns {Number} index of the date closest to the given date
+ * @throws {TypeError} second argument must be an instance of Array
+ *
+ * @example
+ * // Which date is closer to 6 October 2015
+ * var dateToCompare = new Date(2015, 8, 6)
+ * var datesArray = [new Date(2015, 0, 1), new Date(2016, 0, 1), new Date(2017, 0, 1)]
+ * var result = closestToIndex(dateToCompare, datesArray)
+ * //=> 1
+ */
+function closestToIndex (dirtyDateToCompare, dirtyDatesArray) {
+  if (!(dirtyDatesArray instanceof Array)) {
+    throw new TypeError(toString.call(dirtyDatesArray) + ' is not an instance of Array')
+  }
+
+  var dateToCompare = parse(dirtyDateToCompare)
+  var timeToCompare = dateToCompare.getTime()
+
+  var result
+  var minDistance
+
+  dirtyDatesArray.forEach(function (dirtyDate, index) {
+    var currentDate = parse(dirtyDate)
+    var distance = Math.abs(timeToCompare - currentDate.getTime())
+    if (result === undefined || distance < minDistance) {
+      result = index
+      minDistance = distance
+    }
+  })
+
+  return result
+}
+
+module.exports = closestToIndex

--- a/src/closest_to_index/index.js.flow
+++ b/src/closest_to_index/index.js.flow
@@ -1,0 +1,3 @@
+// @flow
+
+declare module.exports: (dateToCompare: Date|string|number, datesArray: (Date|string|number)[]) => number

--- a/src/closest_to_index/test.js
+++ b/src/closest_to_index/test.js
@@ -1,0 +1,57 @@
+// @flow
+/* eslint-env mocha */
+
+var assert = require('power-assert')
+var closestToIndex = require('./')
+
+describe('closestToIndex', function () {
+  it('returns the date index from the given array closest to the given date', function () {
+    var date = new Date(2014, 6 /* Jul */, 2)
+    var result = closestToIndex(date, [
+      new Date(2015, 7 /* Aug */, 31),
+      new Date(2012, 6 /* Jul */, 2)
+    ])
+    assert.equal(result, 0)
+  })
+
+  it('works if the closest date from the given array is before the given date', function () {
+    var date = new Date(2014, 6 /* Jul */, 2, 6, 30, 4, 500)
+    var result = closestToIndex(date, [
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 5, 900),
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 3, 900),
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 10)
+    ])
+    assert.equal(result, 1)
+  })
+
+  it('accepts strings', function () {
+    var date = new Date(2014, 6 /* Jul */, 2).toISOString()
+    var result = closestToIndex(date, [
+      new Date(2012, 6 /* Jul */, 2).toISOString(),
+      new Date(2015, 7 /* Aug */, 31).toISOString()
+    ])
+    assert.equal(result, 1)
+  })
+
+  it('accepts timestamps', function () {
+    var date = new Date(2014, 6 /* Jul */, 2).getTime()
+    var result = closestToIndex(date, [
+      new Date(2015, 7 /* Aug */, 31).getTime(),
+      new Date(2012, 6 /* Jul */, 2).getTime()
+    ])
+    assert.equal(result, 0)
+  })
+
+  it('returns undefined if the given array is empty', function () {
+    var date = new Date(2014, 6 /* Jul */, 2).getTime()
+    var result = closestToIndex(date, [])
+    assert(result === undefined)
+  })
+
+  it('throws an exception if the second argument is not an instance of Array', function () {
+    var date = new Date(2014, 6 /* Jul */, 2).getTime()
+    // $ExpectedMistake
+    var block = closestToIndex.bind(null, date, '')
+    assert.throws(block, TypeError, '[object String] is not an instance of Array')
+  })
+})


### PR DESCRIPTION
Similar to `closestTo` function, `closestToIndex` would return index of the closest date in array.

```
var dateToCompare = new Date(2015, 8, 6)
var datesArray = [new Date(2015, 0, 1), new Date(2016, 0, 1), new Date(2017, 0, 1)]
var result = closestToIndex(dateToCompare, datesArray)
// 1
```