### PR TITLE
Add leading zeroes for small years

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -164,12 +164,12 @@ var formats = {
 
   // Year: 00, 01, ..., 99
   'YY': function () {
-    return String(this.getFullYear()).substr(2)
+    return addLeadingZeros(this.getFullYear(), 4).substr(2)
   },
 
   // Year: 1900, 1901, ..., 2099
   'YYYY': function () {
-    return this.getFullYear()
+    return addLeadingZeros(this.getFullYear(), 4)
   },
 
   // ISO week-numbering year: 00, 01, ..., 99

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -187,6 +187,11 @@ describe('format', function () {
       var result = format(this._date, 'YY YYYY')
       assert(result === '86 1986')
     })
+
+    it('years less than 100', function () {
+      var result = format(new Date('0001-01-01'), 'YY YYYY')
+      assert(result === '01 0001')
+    })
   })
 
   describe('ISO week-numbering years', function () {


### PR DESCRIPTION
Now `format` function for small values return year without leading zeroes.

This is not okay, beacause sometimes it produces wrong output

```js
format(new Date("0001-01-01"), "YYYY-MM-DD") // returns "1-01-01"
```

It causes also issues with `<input type="date">` which accepts only strings with year as 0001