### PR TITLE
Add distanceInWordsStrict() for simple difference formatting

### DIFF
--- a/src/distance_in_words_strict/index.js
+++ b/src/distance_in_words_strict/index.js
@@ -1,0 +1,171 @@
+var compareDesc = require('../compare_desc/index.js')
+var parse = require('../parse/index.js')
+var differenceInSeconds = require('../difference_in_seconds/index.js')
+var enLocale = require('../locale/en/index.js')
+
+var MINUTES_IN_DAY = 1440
+var MINUTES_IN_MONTH = 43200
+var MINUTES_IN_YEAR = 525600
+
+/**
+ * @category Common Helpers
+ * @summary Return the distance between the given dates in words.
+ *
+ * @description
+ * Return the distance between the given dates in words, using strict units.
+ * This is like `distanceInWords`, but does not use helpers like 'almost', 'over',
+ * 'less than' and the like.
+ *
+ * | Distance between dates                                            | Result              |
+ * |-------------------------------------------------------------------|---------------------|
+ * | 0 ... 59 secs                                                     | [0..59] seconds     |
+ * | 1 ... 59 mins                                                     | [1..59] minutes     |
+ * | 1 ... 23 hrs                                                      | [1..23] hours       |
+ * | 1 ... 29 days                                                     | [1..29] days        |
+ * | 1 ... 11 months                                                   | [1..11] months      |
+ * | 1 ... N years                                                     | [1..N]  years       |
+ *
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {Date|String|Number} date - the other date
+ * @param {Object} [options] - the object with options
+ * @param {Boolean} [options.addSuffix=false] - result indicates if the second date is earlier or later than the first
+ * @param {String}  [options.unit=null] - if specified, will force a unit. Options: 's', 'm', 'h', 'd', 'M', 'Y'
+ * @param {String}  [options.partialMethod=floor] - which way to round partial units. Options: 'floor', 'ceil', 'round'
+ * @param {Object}  [options.locale=enLocale] - the locale object
+ * @returns {String} the distance in words
+ *
+ * @example
+ * // What is the distance between 2 July 2014 and 1 January 2015?
+ * var result = distanceInWordsStrict(
+ *   new Date(2014, 6, 2),
+ *   new Date(2015, 0, 2)
+ * )
+ * //=> '6 months'
+ *
+ * @example
+ * // What is the distance between 1 January 2015 00:00:15
+ * // and 1 January 2015 00:00:00?
+ * var result = distanceInWordsStrict(
+ *   new Date(2015, 0, 1, 0, 0, 15),
+ *   new Date(2015, 0, 1, 0, 0, 0),
+ * )
+ * //=> '15 seconds'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 1 January 2015, with a suffix?
+ * var result = distanceInWordsStrict(
+ *   new Date(2016, 0, 1),
+ *   new Date(2015, 0, 1),
+ *   {addSuffix: true}
+ * )
+ * //=> '1 year ago'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 1 January 2015, in minutes?
+ * var result = distanceInWordsStrict(
+ *   new Date(2016, 0, 1),
+ *   new Date(2015, 0, 1),
+ *   {unit: 'm'}
+ * )
+ * //=> '525600 minutes'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 28 January 2015, in months, rounded up?
+ * var result = distanceInWordsStrict(
+ *   new Date(2015, 0, 28),
+ *   new Date(2015, 0, 1),
+ *   {unit: 'M', partialMethod: 'ceil'}
+ * )
+ * //=> '1 month'
+ *
+ * @example
+ * // What is the distance between 1 August 2016 and 1 January 2015 in Esperanto?
+ * var eoLocale = require('date-fns/locale/eo')
+ * var result = distanceInWordsStrict(
+ *   new Date(2016, 7, 1),
+ *   new Date(2015, 0, 1),
+ *   {locale: eoLocale}
+ * )
+ * //=> 'ol 1 jaro'
+ */
+function distanceInWordsStrict (dirtyDateToCompare, dirtyDate, options) {
+  options = options || {}
+
+  var comparison = compareDesc(dirtyDateToCompare, dirtyDate)
+
+  var locale = options.locale || enLocale
+  var localize = locale.distanceInWords.localize
+
+  var localizeOptions = {
+    addSuffix: options.addSuffix,
+    comparison: comparison
+  }
+
+  var dateLeft, dateRight
+  if (comparison > 0) {
+    dateLeft = parse(dirtyDateToCompare)
+    dateRight = parse(dirtyDate)
+  } else {
+    dateLeft = parse(dirtyDate)
+    dateRight = parse(dirtyDateToCompare)
+  }
+
+  var unit = options.unit
+  var mathPartial = Math[options.partialMethod || 'floor']
+  var seconds = differenceInSeconds(dateRight, dateLeft)
+  var offset = dateRight.getTimezoneOffset() - dateLeft.getTimezoneOffset()
+  var minutes = mathPartial(seconds / 60) - offset
+  var hours, days, months, years
+
+  if (!unit) {
+    if (minutes < 1) {
+      unit = 's'
+    } else if (minutes < 60) {
+      unit = 'm'
+    } else if (minutes < MINUTES_IN_DAY) {
+      unit = 'h'
+    } else if (minutes < MINUTES_IN_MONTH) {
+      unit = 'd'
+    } else if (minutes < MINUTES_IN_YEAR) {
+      unit = 'M'
+    } else {
+      unit = 'Y'
+    }
+  }
+
+  // 0 up to 60 seconds
+  if (unit === 's') {
+    return localize('xSeconds', seconds, localizeOptions)
+
+  // 1 up to 60 mins
+  } else if (unit === 'm') {
+    return localize('xMinutes', minutes, localizeOptions)
+
+  // 1 up to 24 hours
+  } else if (unit === 'h') {
+    hours = mathPartial(minutes / 60)
+    return localize('xHours', hours, localizeOptions)
+
+  // 1 up to 30 days
+  } else if (unit === 'd') {
+    days = mathPartial(minutes / MINUTES_IN_DAY)
+    return localize('xDays', days, localizeOptions)
+
+  // 1 up to 12 months
+  } else if (unit === 'M') {
+    months = mathPartial(minutes / MINUTES_IN_MONTH)
+    return localize('xMonths', months, localizeOptions)
+
+  // 1 year up to max Date
+  } else if (unit === 'Y') {
+    years = mathPartial(minutes / MINUTES_IN_YEAR)
+    return localize('xYears', years, localizeOptions)
+  }
+
+  throw new Error('Unknown unit: ' + unit)
+}
+
+module.exports = distanceInWordsStrict

--- a/src/distance_in_words_strict/index.js.flow
+++ b/src/distance_in_words_strict/index.js.flow
@@ -1,0 +1,12 @@
+// @flow
+
+declare module.exports: (
+  dateToCompare: Date|string|number,
+  date: Date|string|number,
+  options?: {
+    addSuffix?: boolean,
+    locale?: Object,
+    unit?: 's' | 'm' | 'h' | 'd' | 'M' | 'Y',
+    partialMethod?: 'floor' | 'ceil' | 'round'
+  }
+) => string

--- a/src/distance_in_words_strict/test.js
+++ b/src/distance_in_words_strict/test.js
@@ -1,0 +1,361 @@
+// @flow
+/* eslint-env mocha */
+
+var assert = require('power-assert')
+var distanceInWordsStrict = require('./')
+
+describe('distanceInWordsStrict', function () {
+  describe('seconds', function () {
+    context('when no unit is set', function () {
+      it('0 seconds', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 5),
+          new Date(1986, 3, 4, 10, 32, 5)
+        )
+        assert(result === '0 seconds')
+      })
+
+      it('5 seconds', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 5)
+        )
+        assert(result === '5 seconds')
+      })
+    })
+  })
+
+  describe('minutes', function () {
+    it('1 minute', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 33, 0)
+      )
+      assert(result === '1 minute')
+    })
+
+    it('n minutes', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 35, 0)
+      )
+      assert(result === '3 minutes')
+    })
+  })
+
+  describe('hours', function () {
+    it('1 hour', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 11, 32, 0)
+      )
+      assert(result === '1 hour')
+    })
+
+    it('n hours', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 13, 32, 0)
+      )
+      assert(result === '3 hours')
+    })
+  })
+
+  describe('days', function () {
+    it('1 day', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 5, 10, 32, 0)
+      )
+      assert(result === '1 day')
+    })
+
+    it('n days', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 7, 10, 32, 0)
+      )
+      assert(result === '3 days')
+    })
+  })
+
+  describe('months', function () {
+    it('1 month', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 4, 4, 10, 32, 0)
+      )
+      assert(result === '1 month')
+    })
+
+    it('n months', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 6, 4, 10, 32, 0)
+      )
+      assert(result === '3 months')
+    })
+  })
+
+  describe('years', function () {
+    it('1 year', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1987, 3, 4, 10, 32, 0)
+      )
+      assert(result === '1 year')
+    })
+
+    it('n years', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1991, 3, 4, 10, 32, 0)
+      )
+      assert(result === '5 years')
+    })
+  })
+
+  describe('when the unit option is supplied', function () {
+    context('s', function () {
+      it('0 seconds', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {unit: 's'}
+        )
+        assert(result === '0 seconds')
+      })
+
+      it('5 seconds', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 5),
+          {unit: 's'}
+        )
+        assert(result === '5 seconds')
+      })
+
+      it('120 seconds', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 34, 0),
+          {unit: 's'}
+        )
+        assert(result === '120 seconds')
+      })
+    })
+    context('m', function () {
+      it('0 minutes', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {unit: 'm'}
+        )
+        assert(result === '0 minutes')
+      })
+
+      it('5 minutes', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 37, 0),
+          {unit: 'm'}
+        )
+        assert(result === '5 minutes')
+      })
+
+      it('120 minutes', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 12, 32, 0),
+          {unit: 'm'}
+        )
+        assert(result === '120 minutes')
+      })
+    })
+    context('h', function () {
+      it('0 hours', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {unit: 'h'}
+        )
+        assert(result === '0 hours')
+      })
+
+      it('5 hours', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 15, 32, 0),
+          {unit: 'h'}
+        )
+        assert(result === '5 hours')
+      })
+
+      it('48 hours', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 6, 10, 32, 0),
+          {unit: 'h'}
+        )
+        assert(result === '48 hours')
+      })
+    })
+    context('d', function () {
+      it('0 days', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {unit: 'd'}
+        )
+        assert(result === '0 days')
+      })
+
+      it('5 days', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 9, 10, 32, 0),
+          {unit: 'd'}
+        )
+        assert(result === '5 days')
+      })
+
+      it('60 days', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 5, 3, 10, 32, 0),
+          {unit: 'd'}
+        )
+        assert(result === '60 days')
+      })
+    })
+    context('M', function () {
+      it('0 months', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {unit: 'M'}
+        )
+        assert(result === '0 months')
+      })
+
+      it('5 months', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 7, 4, 10, 32, 0),
+          {unit: 'M'}
+        )
+        assert(result === '4 months')
+      })
+
+      it('24 months', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1988, 3, 4, 10, 32, 0),
+          {unit: 'M'}
+        )
+        assert(result === '24 months')
+      })
+    })
+    context('Y', function () {
+      it('0 years', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {unit: 'Y'}
+        )
+        assert(result === '0 years')
+      })
+
+      it('5 years', function () {
+        var result = distanceInWordsStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1991, 3, 4, 15, 32, 0),
+          {unit: 'Y'}
+        )
+        assert(result === '5 years')
+      })
+    })
+  })
+
+  it('accepts strings', function () {
+    var result = distanceInWordsStrict(
+      new Date(1986, 3, 4, 10, 32, 0).toISOString(),
+      new Date(1986, 3, 4, 11, 32, 0).toISOString()
+    )
+    assert(result === '1 hour')
+  })
+
+  it('accepts timestamps', function () {
+    var result = distanceInWordsStrict(
+      new Date(1986, 3, 4, 10, 32, 0).getTime(),
+      new Date(1986, 3, 4, 11, 32, 0).getTime()
+    )
+    assert(result === '1 hour')
+  })
+
+  describe('when the addSuffix option is true', function () {
+    it('adds a past suffix', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 25),
+        new Date(1986, 3, 4, 10, 32, 0),
+        {addSuffix: true}
+      )
+      assert(result === '25 seconds ago')
+    })
+
+    it('adds a future suffix', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 11, 32, 0),
+        {addSuffix: true}
+      )
+      assert(result === 'in 1 hour')
+    })
+  })
+
+  describe('when the partialMethod option is supplied', function () {
+    it('default is "floor"', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 33, 59)
+      )
+      assert(result === '1 minute')
+    })
+
+    it('"floor"', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 33, 59),
+        {partialMethod: 'floor'}
+      )
+      assert(result === '1 minute')
+    })
+
+    it('"ceil"', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 33, 1),
+        {partialMethod: 'ceil'}
+      )
+      assert(result === '2 minutes')
+    })
+
+    it('"round" (down)', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 33, 29),
+        {partialMethod: 'round'}
+      )
+      assert(result === '1 minute')
+    })
+
+    it('"round" (up)', function () {
+      var result = distanceInWordsStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 10, 33, 30),
+        {partialMethod: 'round'}
+      )
+      assert(result === '2 minutes')
+    })
+  })
+})

--- a/src/locale/de/build_distance_in_words_locale/index.js
+++ b/src/locale/de/build_distance_in_words_locale/index.js
@@ -5,6 +5,11 @@ function buildDistanceInWordsLocale () {
       other: 'weniger als {{count}} Sekunden'
     },
 
+    xSeconds: {
+      one: '1 Sekunde',
+      other: '{{count}} Sekunden'
+    },
+
     halfAMinute: 'einer halben Minute',
 
     lessThanXMinutes: {
@@ -20,6 +25,11 @@ function buildDistanceInWordsLocale () {
     aboutXHours: {
       one: 'etwa 1 Stunde',
       other: 'etwa {{count}} Stunden'
+    },
+
+    xHours: {
+      one: '1 Stunde',
+      other: '{{count}} Stunden'
     },
 
     xDays: {
@@ -40,6 +50,11 @@ function buildDistanceInWordsLocale () {
     aboutXYears: {
       one: 'etwa 1 Jahr',
       other: 'etwa {{count}} Jahren'
+    },
+
+    xYears: {
+      one: '1 Jahr',
+      other: '{{count}} Jahren'
     },
 
     overXYears: {

--- a/src/locale/en/build_distance_in_words_locale/index.js
+++ b/src/locale/en/build_distance_in_words_locale/index.js
@@ -5,6 +5,11 @@ function buildDistanceInWordsLocale () {
       other: 'less than {{count}} seconds'
     },
 
+    xSeconds: {
+      one: '1 second',
+      other: '{{count}} seconds'
+    },
+
     halfAMinute: 'half a minute',
 
     lessThanXMinutes: {
@@ -20,6 +25,11 @@ function buildDistanceInWordsLocale () {
     aboutXHours: {
       one: 'about 1 hour',
       other: 'about {{count}} hours'
+    },
+
+    xHours: {
+      one: '1 hour',
+      other: '{{count}} hours'
     },
 
     xDays: {
@@ -40,6 +50,11 @@ function buildDistanceInWordsLocale () {
     aboutXYears: {
       one: 'about 1 year',
       other: 'about {{count}} years'
+    },
+
+    xYears: {
+      one: '1 year',
+      other: '{{count}} years'
     },
 
     overXYears: {

--- a/src/locale/zh_cn/build_distance_in_words_locale/index.js
+++ b/src/locale/zh_cn/build_distance_in_words_locale/index.js
@@ -5,6 +5,11 @@ function buildDistanceInWordsLocale () {
       other: '不到 {{count}} 秒'
     },
 
+    xSeconds: {
+      one: '1 秒',
+      other: '{{count}} 秒'
+    },
+
     halfAMinute: '半分钟',
 
     lessThanXMinutes: {
@@ -15,6 +20,11 @@ function buildDistanceInWordsLocale () {
     xMinutes: {
       one: '1 分钟',
       other: '{{count}} 分钟'
+    },
+
+    xHours: {
+      one: '1 小时',
+      other: '{{count}} 小时'
     },
 
     aboutXHours: {
@@ -40,6 +50,11 @@ function buildDistanceInWordsLocale () {
     aboutXYears: {
       one: '大约 1 年',
       other: '大约 {{count}} 年'
+    },
+
+    xYears: {
+      one: '1 年',
+      other: '{{count}} 年'
     },
 
     overXYears: {


### PR DESCRIPTION
This is a simpler version of `distanceInWords` that allows the user to specify advanced options to format the output.

It does emit "fuzzy" output like "less than x", "about x", etc.

Signature:

```jsx
(
  dateToCompare: Date|string|number,
  date: Date|string|number,
  options?: {
    includeSeconds?: boolean,
    addSuffix?: boolean,
    locale?: Object,
    unit?: 's' | 'm' | 'h' | 'd' | 'M' | 'Y',
    partialMethod?: 'floor' | 'ceil' | 'round'
  }
) => string
```

For example:

```js
// What is the distance from 1 January 2016
// to 1 January 2015, in minutes?
var result = distanceInWordsStrict(
  new Date(2016, 0, 1),
  new Date(2015, 0, 1),
  {unit: 'm'}
)
//=> '525600 minutes'

// What is the distance from 1 January 2016
// to 28 January 2015, in months, rounded up?
var result = distanceInWordsStrict(
  new Date(2015, 0, 28),
  new Date(2015, 0, 1),
  {unit: 'M', partialMethod: 'ceil'}
)
//=> '1 month'
```

This adds `xSeconds`, `xHours`, and `xYears` to locale data. I have edited the `en`, `de`, and `zh-cn` locales, as I know them, but I don't know enough about the rest to confidently edit them.