### PR TITLE
German translations: Add support for cases in nominative (without suffix)

### DIFF
--- a/src/locale/de/build_distance_in_words_locale/index.js
+++ b/src/locale/de/build_distance_in_words_locale/index.js
@@ -1,83 +1,169 @@
 function buildDistanceInWordsLocale () {
   var distanceInWordsLocale = {
     lessThanXSeconds: {
-      one: 'weniger als einer Sekunde',
-      other: 'weniger als {{count}} Sekunden'
+      standalone: {
+        one: 'weniger als eine Sekunde',
+        other: 'weniger als {{count}} Sekunden'
+      },
+      withPreposition: {
+        one: 'weniger als einer Sekunde',
+        other: 'weniger als {{count}} Sekunden'
+      }
     },
 
     xSeconds: {
-      one: '1 Sekunde',
-      other: '{{count}} Sekunden'
+      standalone: {
+        one: 'eine Sekunde',
+        other: '{{count}} Sekunden'
+      },
+      withPreposition: {
+        one: 'einer Sekunde',
+        other: '{{count}} Sekunden'
+      }
     },
 
-    halfAMinute: 'einer halben Minute',
+    halfAMinute: {
+      standalone: 'eine halbe Minute',
+      withPreposition: 'einer halben Minute'
+    },
 
     lessThanXMinutes: {
-      one: 'weniger als einer Minute',
-      other: 'weniger als {{count}} Minuten'
+      standalone: {
+        one: 'weniger als eine Minute',
+        other: 'weniger als {{count}} Minuten'
+      },
+      withPreposition: {
+        one: 'weniger als einer Minute',
+        other: 'weniger als {{count}} Minuten'
+      }
     },
 
     xMinutes: {
-      one: '1 Minute',
-      other: '{{count}} Minuten'
+      standalone: {
+        one: 'eine Minute',
+        other: '{{count}} Minuten'
+      },
+      withPreposition: {
+        one: 'einer Minute',
+        other: '{{count}} Minuten'
+      }
     },
 
     aboutXHours: {
-      one: 'etwa 1 Stunde',
-      other: 'etwa {{count}} Stunden'
+      standalone: {
+        one: 'etwa eine Stunde',
+        other: 'etwa {{count}} Stunden'
+      },
+      withPreposition: {
+        one: 'etwa einer Stunde',
+        other: 'etwa {{count}} Stunden'
+      }
     },
 
     xHours: {
-      one: '1 Stunde',
-      other: '{{count}} Stunden'
+      standalone: {
+        one: 'eine Stunde',
+        other: '{{count}} Stunden'
+      },
+      withPreposition: {
+        one: 'einer Stunde',
+        other: '{{count}} Stunden'
+      }
     },
 
     xDays: {
-      one: '1 Tag',
-      other: '{{count}} Tagen'
+      standalone: {
+        one: 'ein Tag',
+        other: '{{count}} Tage'
+      },
+      withPreposition: {
+        one: 'einem Tag',
+        other: '{{count}} Tagen'
+      }
+
     },
 
     aboutXMonths: {
-      one: 'etwa 1 Monat',
-      other: 'etwa {{count}} Monaten'
+      standalone: {
+        one: 'etwa ein Monat',
+        other: 'etwa {{count}} Monate'
+      },
+      withPreposition: {
+        one: 'etwa einem Monat',
+        other: 'etwa {{count}} Monaten'
+      }
     },
 
     xMonths: {
-      one: '1 Monat',
-      other: '{{count}} Monaten'
+      standalone: {
+        one: 'ein Monat',
+        other: '{{count}} Monate'
+      },
+      withPreposition: {
+        one: 'einem Monat',
+        other: '{{count}} Monaten'
+      }
     },
 
     aboutXYears: {
-      one: 'etwa 1 Jahr',
-      other: 'etwa {{count}} Jahren'
+      standalone: {
+        one: 'etwa ein Jahr',
+        other: 'etwa {{count}} Jahre'
+      },
+      withPreposition: {
+        one: 'etwa einem Jahr',
+        other: 'etwa {{count}} Jahren'
+      }
     },
 
     xYears: {
-      one: '1 Jahr',
-      other: '{{count}} Jahren'
+      standalone: {
+        one: 'ein Jahr',
+        other: '{{count}} Jahre'
+      },
+      withPreposition: {
+        one: 'einem Jahr',
+        other: '{{count}} Jahren'
+      }
     },
 
     overXYears: {
-      one: 'mehr als 1 Jahr',
-      other: 'mehr als {{count}} Jahren'
+      standalone: {
+        one: 'mehr als ein Jahr',
+        other: 'mehr als {{count}} Jahre'
+      },
+      withPreposition: {
+        one: 'mehr als einem Jahr',
+        other: 'mehr als {{count}} Jahren'
+      }
     },
 
     almostXYears: {
-      one: 'fast 1 Jahr',
-      other: 'fast {{count}} Jahren'
+      standalone: {
+        one: 'fast ein Jahr',
+        other: 'fast {{count}} Jahre'
+      },
+      withPreposition: {
+        one: 'fast einem Jahr',
+        other: 'fast {{count}} Jahren'
+      }
     }
   }
 
   function localize (token, count, options) {
     options = options || {}
 
+    var usageGroup = options.addSuffix
+      ? distanceInWordsLocale[token].withPreposition
+      : distanceInWordsLocale[token].standalone
+
     var result
-    if (typeof distanceInWordsLocale[token] === 'string') {
-      result = distanceInWordsLocale[token]
+    if (typeof usageGroup === 'string') {
+      result = usageGroup
     } else if (count === 1) {
-      result = distanceInWordsLocale[token].one
+      result = usageGroup.one
     } else {
-      result = distanceInWordsLocale[token].other.replace('{{count}}', count)
+      result = usageGroup.other.replace('{{count}}', count)
     }
 
     if (options.addSuffix) {

--- a/src/locale/de/build_distance_in_words_locale/test.js
+++ b/src/locale/de/build_distance_in_words_locale/test.js
@@ -4,6 +4,8 @@
 var assert = require('power-assert')
 var buildDistanceInWordsLocale = require('./')
 
+var optionsWithSuffix = { addSuffix: true, comparison: 1 }
+
 describe('de locale > buildDistanceInWordsLocale', function () {
   it('returns an object', function () {
     assert(typeof buildDistanceInWordsLocale() === 'object')
@@ -14,194 +16,420 @@ describe('de locale > buildDistanceInWordsLocale', function () {
   })
 
   describe('lessThanXSeconds', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 1) === 'weniger als einer Sekunde')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 1) === 'weniger als eine Sekunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 2) === 'weniger als 2 Sekunden')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 2) === 'weniger als 2 Sekunden')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 1, optionsWithSuffix) === 'in weniger als einer Sekunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 2, optionsWithSuffix) === 'in weniger als 2 Sekunden')
+        })
       })
     })
   })
 
   describe('xSeconds', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xSeconds', 1) === '1 Sekunde')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xSeconds', 1) === 'eine Sekunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xSeconds', 2) === '2 Sekunden')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xSeconds', 2) === '2 Sekunden')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xSeconds', 1, optionsWithSuffix) === 'in einer Sekunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xSeconds', 2, optionsWithSuffix) === 'in 2 Sekunden')
+        })
       })
     })
   })
 
   describe('halfAMinute', function () {
-    it('returns a proper string', function () {
-      assert(buildDistanceInWordsLocale().localize('halfAMinute') === 'einer halben Minute')
+    describe('no suffix', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('halfAMinute') === 'eine halbe Minute')
+      })
     })
 
-    it('ignores the second argument', function () {
-      assert(buildDistanceInWordsLocale().localize('halfAMinute', 123) === 'einer halben Minute')
+    describe('past or future suffix', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('halfAMinute', null, optionsWithSuffix) === 'in einer halben Minute')
+      })
+
+      it('ignores the second argument', function () {
+        assert(buildDistanceInWordsLocale().localize('halfAMinute', 123, optionsWithSuffix) === 'in einer halben Minute')
+      })
     })
   })
 
   describe('lessThanXMinutes', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 1) === 'weniger als einer Minute')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 1) === 'weniger als eine Minute')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 2) === 'weniger als 2 Minuten')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 2) === 'weniger als 2 Minuten')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 1, optionsWithSuffix) === 'in weniger als einer Minute')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 2, optionsWithSuffix) === 'in weniger als 2 Minuten')
+        })
       })
     })
   })
 
   describe('xMinutes', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMinutes', 1) === '1 Minute')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMinutes', 1) === 'eine Minute')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMinutes', 2) === '2 Minuten')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMinutes', 2) === '2 Minuten')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMinutes', 1, optionsWithSuffix) === 'in einer Minute')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMinutes', 2, optionsWithSuffix) === 'in 2 Minuten')
+        })
       })
     })
   })
 
   describe('aboutXHours', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXHours', 1) === 'etwa 1 Stunde')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXHours', 1) === 'etwa eine Stunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXHours', 2) === 'etwa 2 Stunden')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXHours', 2) === 'etwa 2 Stunden')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXHours', 1, optionsWithSuffix) === 'in etwa einer Stunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXHours', 2, optionsWithSuffix) === 'in etwa 2 Stunden')
+        })
       })
     })
   })
 
   describe('xHours', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xHours', 1) === '1 Stunde')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xHours', 1) === 'eine Stunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xHours', 2) === '2 Stunden')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xHours', 2) === '2 Stunden')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xHours', 1, optionsWithSuffix) === 'in einer Stunde')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xHours', 2, optionsWithSuffix) === 'in 2 Stunden')
+        })
       })
     })
   })
 
   describe('xDays', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xDays', 1) === '1 Tag')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xDays', 1) === 'ein Tag')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xDays', 2) === '2 Tage')
+        })
+      })
+
+      describe('past or future suffix', function () {
+        context('when the count equals 1', function () {
+          it('returns a proper string', function () {
+            assert(buildDistanceInWordsLocale().localize('xDays', 1, optionsWithSuffix) === 'in einem Tag')
+          })
+        })
+
+        context('when the count is more than 1', function () {
+          it('returns a proper string', function () {
+            assert(buildDistanceInWordsLocale().localize('xDays', 2, optionsWithSuffix) === 'in 2 Tagen')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xDays', 2) === '2 Tagen')
-      })
-    })
-  })
+    describe('aboutXMonths', function () {
+      describe('no suffix', function () {
+        context('when the count equals 1', function () {
+          it('returns a proper string', function () {
+            assert(buildDistanceInWordsLocale().localize('aboutXMonths', 1) === 'etwa ein Monat')
+          })
+        })
 
-  describe('aboutXMonths', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXMonths', 1) === 'etwa 1 Monat')
+        context('when the count is more than 1', function () {
+          it('returns a proper string', function () {
+            assert(buildDistanceInWordsLocale().localize('aboutXMonths', 2) === 'etwa 2 Monate')
+          })
+        })
       })
-    })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXMonths', 2) === 'etwa 2 Monaten')
+      describe('past or future suffix', function () {
+        context('when the count equals 1', function () {
+          it('returns a proper string', function () {
+            assert(buildDistanceInWordsLocale().localize('aboutXMonths', 1, optionsWithSuffix) === 'in etwa einem Monat')
+          })
+        })
+
+        context('when the count is more than 1', function () {
+          it('returns a proper string', function () {
+            assert(buildDistanceInWordsLocale().localize('aboutXMonths', 2, optionsWithSuffix) === 'in etwa 2 Monaten')
+          })
+        })
       })
     })
   })
 
   describe('xMonths', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMonths', 1) === '1 Monat')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMonths', 1) === 'ein Monat')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMonths', 2) === '2 Monate')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMonths', 2) === '2 Monaten')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMonths', 1, optionsWithSuffix) === 'in einem Monat')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xMonths', 2, optionsWithSuffix) === 'in 2 Monaten')
+        })
       })
     })
   })
 
   describe('aboutXYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXYears', 1) === 'etwa 1 Jahr')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXYears', 1) === 'etwa ein Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXYears', 2) === 'etwa 2 Jahre')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXYears', 2) === 'etwa 2 Jahren')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXYears', 1, optionsWithSuffix) === 'in etwa einem Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('aboutXYears', 2, optionsWithSuffix) === 'in etwa 2 Jahren')
+        })
       })
     })
   })
 
   describe('xYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xYears', 1) === '1 Jahr')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xYears', 1) === 'ein Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xYears', 2) === '2 Jahre')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xYears', 2) === '2 Jahren')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xYears', 1, optionsWithSuffix) === 'in einem Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('xYears', 2, optionsWithSuffix) === 'in 2 Jahren')
+        })
       })
     })
   })
 
   describe('overXYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('overXYears', 1) === 'mehr als 1 Jahr')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('overXYears', 1) === 'mehr als ein Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('overXYears', 2) === 'mehr als 2 Jahre')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('overXYears', 2) === 'mehr als 2 Jahren')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('overXYears', 1, optionsWithSuffix) === 'in mehr als einem Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('overXYears', 2, optionsWithSuffix) === 'in mehr als 2 Jahren')
+        })
       })
     })
   })
 
   describe('almostXYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('almostXYears', 1) === 'fast 1 Jahr')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('almostXYears', 1) === 'fast ein Jahr')
+        })
+      })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('almostXYears', 2) === 'fast 2 Jahre')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('almostXYears', 2) === 'fast 2 Jahren')
+    describe('past or future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('almostXYears', 1, optionsWithSuffix) === 'in fast einem Jahr')
+        })
       })
+
+      context('when the count is more than 1', function () {
+        it('returns a proper string', function () {
+          assert(buildDistanceInWordsLocale().localize('almostXYears', 2, optionsWithSuffix) === 'in fast 2 Jahren')
+        })
+      })
+    })
+  })
+
+  context('with no suffix', function () {
+    it('returns a plain version of the string', function () {
+      var result = buildDistanceInWordsLocale().localize('aboutXYears', 1, {
+        addSuffix: false,
+        comparison: -1
+      })
+      assert(result === 'etwa ein Jahr')
     })
   })
 
@@ -211,7 +439,7 @@ describe('de locale > buildDistanceInWordsLocale', function () {
         addSuffix: true,
         comparison: -1
       })
-      assert(result === 'vor etwa 1 Jahr')
+      assert(result === 'vor etwa einem Jahr')
     })
   })
 

--- a/src/locale/de/build_format_locale/index.js
+++ b/src/locale/de/build_format_locale/index.js
@@ -2,7 +2,7 @@ var buildFormattingTokensRegExp = require('../../_lib/build_formatting_tokens_re
 
 function buildFormatLocale () {
   // Note: in German, the names of days of the week and months are capitalized.
-  // If you are making a new locale based on this one, check if the same is true for the langugage you're working on.
+  // If you are making a new locale based on this one, check if the same is true for the language you're working on.
   // Generally, formatted dates should look like they are in the middle of a sentence,
   // e.g. in Spanish language the weekdays and months should be in the lowercase.
   var months3char = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez']


### PR DESCRIPTION

In the current translations for the German locale there are cases missing for the regular no suffix case (nominative). This PR will add support for cases like `one hour` (rather than `one hour ago` or `before one hour`).