### PR TITLE
Make `format` return String('Invalid Date') if date isn't valid

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -2,6 +2,7 @@ var getDayOfYear = require('../get_day_of_year/index.js')
 var getISOWeek = require('../get_iso_week/index.js')
 var getISOYear = require('../get_iso_year/index.js')
 var parse = require('../parse/index.js')
+var isValid = require('../is_valid/index.js')
 var enLocale = require('../locale/en/index.js')
 
 /**
@@ -95,6 +96,11 @@ function format (dirtyDate, formatStr, options) {
   var formatLocale = locale.format
 
   var date = parse(dirtyDate)
+
+  if (!isValid(date)) {
+    return 'Invalid Date'
+  }
+
   var formatFn = buildFormatFn(formatStr, formatLocale)
 
   return formatFn(date)

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -296,10 +296,16 @@ describe('format', function () {
     })
   })
 
-  it('handles dates before 100 AD', function () {
-    var initialDate = new Date(0)
-    initialDate.setFullYear(7, 11 /* Dec */, 31)
-    initialDate.setHours(0, 0, 0, 0)
-    assert(format(initialDate, 'GGGG WW E') === '8 01 1')
+  describe('edge cases', function () {
+    it('returns String(\'Invalid Date\') if the date isn\'t valid', function () {
+      assert(format(new Date(NaN), 'MMMM D, YYYY') === 'Invalid Date')
+    })
+
+    it('handles dates before 100 AD', function () {
+      var initialDate = new Date(0)
+      initialDate.setFullYear(7, 11 /* Dec */, 31)
+      initialDate.setHours(0, 0, 0, 0)
+      assert(format(initialDate, 'GGGG WW E') === '8 01 1')
+    })
   })
 })


### PR DESCRIPTION
Temporary dirty fix for #304