### PR TITLE
Add Korean language support (ko)

### DIFF
--- a/src/locale/ko/build_distance_in_words_locale/index.js
+++ b/src/locale/ko/build_distance_in_words_locale/index.js
@@ -1,0 +1,99 @@
+function buildDistanceInWordsLocale () {
+  var distanceInWordsLocale = {
+    lessThanXSeconds: {
+      one: '1초 미만',
+      other: '{{count}}초 미만'
+    },
+
+    xSeconds: {
+      one: '1초',
+      other: '{{count}}초'
+    },
+
+    halfAMinute: '30초',
+
+    lessThanXMinutes: {
+      one: '1분 미만',
+      other: '{{count}}분 미만'
+    },
+
+    xMinutes: {
+      one: '1분',
+      other: '{{count}}분'
+    },
+
+    aboutXHours: {
+      one: '약 1시간',
+      other: '약 {{count}}시간'
+    },
+
+    xHours: {
+      one: '1시간',
+      other: '{{count}}시간'
+    },
+
+    xDays: {
+      one: '1일',
+      other: '{{count}}일'
+    },
+
+    aboutXMonths: {
+      one: '약 1개월',
+      other: '약 {{count}}개월'
+    },
+
+    xMonths: {
+      one: '1개월',
+      other: '{{count}}개월'
+    },
+
+    aboutXYears: {
+      one: '약 1년',
+      other: '약 {{count}}년'
+    },
+
+    xYears: {
+      one: '1년',
+      other: '{{count}}년'
+    },
+
+    overXYears: {
+      one: '1년 이상',
+      other: '{{count}}년 이상'
+    },
+
+    almostXYears: {
+      one: '거의 1년',
+      other: '거의 {{count}}년'
+    }
+  }
+
+  function localize (token, count, options) {
+    options = options || {}
+
+    var result
+    if (typeof distanceInWordsLocale[token] === 'string') {
+      result = distanceInWordsLocale[token]
+    } else if (count === 1) {
+      result = distanceInWordsLocale[token].one
+    } else {
+      result = distanceInWordsLocale[token].other.replace('{{count}}', count)
+    }
+
+    if (options.addSuffix) {
+      if (options.comparison > 0) {
+        return result + ' 후'
+      } else {
+        return result + ' 전'
+      }
+    }
+
+    return result
+  }
+
+  return {
+    localize: localize
+  }
+}
+
+module.exports = buildDistanceInWordsLocale

--- a/src/locale/ko/build_distance_in_words_locale/test.js
+++ b/src/locale/ko/build_distance_in_words_locale/test.js
@@ -1,0 +1,227 @@
+// @flow
+/* eslint-env mocha */
+
+var assert = require('power-assert')
+var buildDistanceInWordsLocale = require('./')
+
+describe('ko locale > buildDistanceInWordsLocale', function () {
+  it('returns an object', function () {
+    assert(typeof buildDistanceInWordsLocale() === 'object')
+  })
+
+  it('localize property is a function', function () {
+    assert(typeof buildDistanceInWordsLocale().localize === 'function')
+  })
+
+  describe('lessThanXSeconds', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 1) === '1초 미만')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 2) === '2초 미만')
+      })
+    })
+  })
+
+  describe('xSeconds', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xSeconds', 1) === '1초')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xSeconds', 2) === '2초')
+      })
+    })
+  })
+
+  describe('halfAMinute', function () {
+    it('returns a proper string', function () {
+      assert(buildDistanceInWordsLocale().localize('halfAMinute') === '30초')
+    })
+
+    it('ignores the second argument', function () {
+      assert(buildDistanceInWordsLocale().localize('halfAMinute', 123) === '30초')
+    })
+  })
+
+  describe('lessThanXMinutes', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 1) === '1분 미만')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 2) === '2분 미만')
+      })
+    })
+  })
+
+  describe('xMinutes', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xMinutes', 1) === '1분')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xMinutes', 2) === '2분')
+      })
+    })
+  })
+
+  describe('aboutXHours', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('aboutXHours', 1) === '약 1시간')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('aboutXHours', 2) === '약 2시간')
+      })
+    })
+  })
+
+  describe('xHours', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xHours', 1) === '1시간')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xHours', 2) === '2시간')
+      })
+    })
+  })
+
+  describe('xDays', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xDays', 1) === '1일')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xDays', 2) === '2일')
+      })
+    })
+  })
+
+  describe('aboutXMonths', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('aboutXMonths', 1) === '약 1개월')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('aboutXMonths', 2) === '약 2개월')
+      })
+    })
+  })
+
+  describe('xMonths', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xMonths', 1) === '1개월')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xMonths', 2) === '2개월')
+      })
+    })
+  })
+
+  describe('aboutXYears', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('aboutXYears', 1) === '약 1년')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('aboutXYears', 2) === '약 2년')
+      })
+    })
+  })
+
+  describe('xYears', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xYears', 1) === '1년')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('xYears', 2) === '2년')
+      })
+    })
+  })
+
+  describe('overXYears', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('overXYears', 1) === '1년 이상')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('overXYears', 2) === '2년 이상')
+      })
+    })
+  })
+
+  describe('almostXYears', function () {
+    context('when the count equals 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('almostXYears', 1) === '거의 1년')
+      })
+    })
+
+    context('when the count is more than 1', function () {
+      it('returns a proper string', function () {
+        assert(buildDistanceInWordsLocale().localize('almostXYears', 2) === '거의 2년')
+      })
+    })
+  })
+
+  context('with a past suffix', function () {
+    it('adds `ago` to a string', function () {
+      var result = buildDistanceInWordsLocale().localize('aboutXYears', 1, {
+        addSuffix: true,
+        comparison: -1
+      })
+      assert(result === '약 1년 전')
+    })
+  })
+
+  context('with a future suffix', function () {
+    it('adds `in` to a string', function () {
+      var result = buildDistanceInWordsLocale().localize('halfAMinute', null, {
+        addSuffix: true,
+        comparison: 1
+      })
+      assert(result === '30초 후')
+    })
+  })
+})

--- a/src/locale/ko/build_format_locale/index.js
+++ b/src/locale/ko/build_format_locale/index.js
@@ -1,0 +1,77 @@
+var buildFormattingTokensRegExp = require('../../_lib/build_formatting_tokens_reg_exp/index.js')
+
+function buildFormatLocale () {
+  // Note: in English, the names of days of the week and months are capitalized.
+  // If you are making a new locale based on this one, check if the same is true for the language you're working on.
+  // Generally, formatted dates should look like they are in the middle of a sentence,
+  // e.g. in Spanish language the weekdays and months should be in the lowercase.
+  var months3char = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
+  var monthsFull = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
+  var weekdays2char = ['일', '월', '화', '수', '목', '금', '토']
+  var weekdays3char = ['일', '월', '화', '수', '목', '금', '토']
+  var weekdaysFull = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
+  var meridiemUppercase = ['오전', '오후']
+  var meridiemLowercase = ['오전', '오후']
+  var meridiemFull = ['오전', '오후']
+
+  var formatters = {
+    // Month: Jan, Feb, ..., Dec
+    'MMM': function (date) {
+      return months3char[date.getMonth()]
+    },
+
+    // Month: January, February, ..., December
+    'MMMM': function (date) {
+      return monthsFull[date.getMonth()]
+    },
+
+    // Day of week: Su, Mo, ..., Sa
+    'dd': function (date) {
+      return weekdays2char[date.getDay()]
+    },
+
+    // Day of week: Sun, Mon, ..., Sat
+    'ddd': function (date) {
+      return weekdays3char[date.getDay()]
+    },
+
+    // Day of week: Sunday, Monday, ..., Saturday
+    'dddd': function (date) {
+      return weekdaysFull[date.getDay()]
+    },
+
+    // AM, PM
+    'A': function (date) {
+      return (date.getHours() / 12) >= 1 ? meridiemUppercase[1] : meridiemUppercase[0]
+    },
+
+    // am, pm
+    'a': function (date) {
+      return (date.getHours() / 12) >= 1 ? meridiemLowercase[1] : meridiemLowercase[0]
+    },
+
+    // a.m., p.m.
+    'aa': function (date) {
+      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
+    }
+  }
+
+  // Generate ordinal version of formatters: M -> Mo, D -> Do, etc.
+  var ordinalFormatters = ['M', 'D', 'DDD', 'd', 'Q', 'W']
+  ordinalFormatters.forEach(function (formatterToken) {
+    formatters[formatterToken + 'o'] = function (date, formatters) {
+      return ordinal(formatters[formatterToken](date))
+    }
+  })
+
+  return {
+    formatters: formatters,
+    formattingTokensRegExp: buildFormattingTokensRegExp(formatters)
+  }
+}
+
+function ordinal (number) {
+  return number + '일'
+}
+
+module.exports = buildFormatLocale

--- a/src/locale/ko/build_format_locale/test.js
+++ b/src/locale/ko/build_format_locale/test.js
@@ -1,0 +1,333 @@
+// @flow
+/* eslint-env mocha */
+
+var assert = require('power-assert')
+var buildFormatLocale = require('./')
+
+describe('ko locale > buildFormatLocale', function () {
+  it('returns an object', function () {
+    assert(typeof buildFormatLocale() === 'object')
+  })
+
+  describe('formatters property', function () {
+    it('is an object', function () {
+      assert(typeof buildFormatLocale().formatters === 'object')
+    })
+
+    describe('MMM', function () {
+      it('returns the correct string for January', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 0)) === '1월')
+      })
+
+      it('returns the correct string for February', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 1)) === '2월')
+      })
+
+      it('returns the correct string for March', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 2)) === '3월')
+      })
+
+      it('returns the correct string for April', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2015, 3)) === '4월')
+      })
+
+      it('returns the correct string for May', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 4)) === '5월')
+      })
+
+      it('returns the correct string for June', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 5)) === '6월')
+      })
+
+      it('returns the correct string for July', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 6)) === '7월')
+      })
+
+      it('returns the correct string for August', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 7)) === '8월')
+      })
+
+      it('returns the correct string for September', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 8)) === '9월')
+      })
+
+      it('returns the correct string for October', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 9)) === '10월')
+      })
+
+      it('returns the correct string for November', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 10)) === '11월')
+      })
+
+      it('returns the correct string for December', function () {
+        assert(buildFormatLocale().formatters.MMM(new Date(2016, 11)) === '12월')
+      })
+    })
+
+    describe('MMMM', function () {
+      it('returns the correct string for January', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 0)) === '1월')
+      })
+
+      it('returns the correct string for February', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 1)) === '2월')
+      })
+
+      it('returns the correct string for March', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 2)) === '3월')
+      })
+
+      it('returns the correct string for April', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2015, 3)) === '4월')
+      })
+
+      it('returns the correct string for May', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 4)) === '5월')
+      })
+
+      it('returns the correct string for June', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 5)) === '6월')
+      })
+
+      it('returns the correct string for July', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 6)) === '7월')
+      })
+
+      it('returns the correct string for August', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 7)) === '8월')
+      })
+
+      it('returns the correct string for September', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 8)) === '9월')
+      })
+
+      it('returns the correct string for October', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 9)) === '10월')
+      })
+
+      it('returns the correct string for November', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 10)) === '11월')
+      })
+
+      it('returns the correct string for December', function () {
+        assert(buildFormatLocale().formatters.MMMM(new Date(2016, 11)) === '12월')
+      })
+    })
+
+    describe('dd', function () {
+      it('returns the correct string for Sunday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 7)) === '일')
+      })
+
+      it('returns the correct string for Monday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 1)) === '월')
+      })
+
+      it('returns the correct string for Tuesday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 2)) === '화')
+      })
+
+      it('returns the correct string for Wednesday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 3)) === '수')
+      })
+
+      it('returns the correct string for Thursday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 4)) === '목')
+      })
+
+      it('returns the correct string for Friday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 5)) === '금')
+      })
+
+      it('returns the correct string for Saturday', function () {
+        assert(buildFormatLocale().formatters.dd(new Date(2016, 1 /* Feb */, 6)) === '토')
+      })
+    })
+
+    describe('ddd', function () {
+      it('returns the correct string for Sunday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 7)) === '일')
+      })
+
+      it('returns the correct string for Monday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 1)) === '월')
+      })
+
+      it('returns the correct string for Tuesday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 2)) === '화')
+      })
+
+      it('returns the correct string for Wednesday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 3)) === '수')
+      })
+
+      it('returns the correct string for Thursday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 4)) === '목')
+      })
+
+      it('returns the correct string for Friday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 5)) === '금')
+      })
+
+      it('returns the correct string for Saturday', function () {
+        assert(buildFormatLocale().formatters.ddd(new Date(2016, 1 /* Feb */, 6)) === '토')
+      })
+    })
+
+    describe('dddd', function () {
+      it('returns the correct string for Sunday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 7)) === '일요일')
+      })
+
+      it('returns the correct string for Monday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 1)) === '월요일')
+      })
+
+      it('returns the correct string for Tuesday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 2)) === '화요일')
+      })
+
+      it('returns the correct string for Wednesday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 3)) === '수요일')
+      })
+
+      it('returns the correct string for Thursday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 4)) === '목요일')
+      })
+
+      it('returns the correct string for Friday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 5)) === '금요일')
+      })
+
+      it('returns the correct string for Saturday', function () {
+        assert(buildFormatLocale().formatters.dddd(new Date(2016, 1 /* Feb */, 6)) === '토요일')
+      })
+    })
+
+    describe('A', function () {
+      it('returns the correct string for 1-11 a.m.', function () {
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 1)) === '오전')
+      })
+
+      it('returns the correct string for 12 a.m.', function () {
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 0)) === '오전')
+      })
+
+      it('returns the correct string for 1-11 p.m.', function () {
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 13)) === '오후')
+      })
+
+      it('returns the correct string for 12 p.m.', function () {
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 12)) === '오후')
+      })
+    })
+
+    describe('a', function () {
+      it('returns the correct string for 1-11 a.m.', function () {
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 1)) === '오전')
+      })
+
+      it('returns the correct string for 12 a.m.', function () {
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 0)) === '오전')
+      })
+
+      it('returns the correct string for 1-11 p.m.', function () {
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 13)) === '오후')
+      })
+
+      it('returns the correct string for 12 p.m.', function () {
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 12)) === '오후')
+      })
+    })
+
+    describe('aa', function () {
+      it('returns the correct string for 1-11 a.m.', function () {
+        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 1)) === '오전')
+      })
+
+      it('returns the correct string for 12 a.m.', function () {
+        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 0)) === '오전')
+      })
+
+      it('returns the correct string for 1-11 p.m.', function () {
+        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 13)) === '오후')
+      })
+
+      it('returns the correct string for 12 p.m.', function () {
+        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 12)) === '오후')
+      })
+    })
+
+    describe('Mo', function () {
+      it('returns ordinal result of M formatter', function () {
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 1 }}) === '1일')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 2 }}) === '2일')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 3 }}) === '3일')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 11 }}) === '11일')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 101 }}) === '101일')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 111 }}) === '111일')
+      })
+    })
+
+    describe('Do', function () {
+      it('returns ordinal result of D formatter', function () {
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 1 }}) === '1일')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 2 }}) === '2일')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 3 }}) === '3일')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 11 }}) === '11일')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 101 }}) === '101일')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 111 }}) === '111일')
+      })
+    })
+
+    describe('DDDo', function () {
+      it('returns ordinal result of DDD formatter', function () {
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 1 }}) === '1일')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 2 }}) === '2일')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 3 }}) === '3일')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 11 }}) === '11일')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 101 }}) === '101일')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 111 }}) === '111일')
+      })
+    })
+
+    describe('do', function () {
+      it('returns ordinal result of d formatter', function () {
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 1 }}) === '1일')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 2 }}) === '2일')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 3 }}) === '3일')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 11 }}) === '11일')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 101 }}) === '101일')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 111 }}) === '111일')
+      })
+    })
+
+    describe('Qo', function () {
+      it('returns ordinal result of Q formatter', function () {
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 1 }}) === '1일')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 2 }}) === '2일')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 3 }}) === '3일')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 11 }}) === '11일')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 101 }}) === '101일')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 111 }}) === '111일')
+      })
+    })
+
+    describe('Wo', function () {
+      it('returns ordinal result of W formatter', function () {
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 1 }}) === '1일')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 2 }}) === '2일')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 3 }}) === '3일')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 11 }}) === '11일')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 101 }}) === '101일')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 111 }}) === '111일')
+      })
+    })
+  })
+
+  describe('formattingTokensRegExp property', function () {
+    it('is an instance of RegExp', function () {
+      assert(buildFormatLocale().formattingTokensRegExp instanceof RegExp)
+    })
+  })
+})

--- a/src/locale/ko/index.js
+++ b/src/locale/ko/index.js
@@ -1,0 +1,12 @@
+var buildDistanceInWordsLocale = require('./build_distance_in_words_locale/index.js')
+var buildFormatLocale = require('./build_format_locale/index.js')
+
+/**
+ * @category Locales
+ * @summary Korean locale.
+ * @author Hong Chulju [@angdev]{@link https://github.com/angdev}
+ */
+module.exports = {
+  distanceInWords: buildDistanceInWordsLocale(),
+  format: buildFormatLocale()
+}

--- a/src/locale/ko/test.js
+++ b/src/locale/ko/test.js
@@ -1,0 +1,15 @@
+// @flow
+/* eslint-env mocha */
+
+var assert = require('power-assert')
+var enLocale = require('./')
+
+describe('ko locale', function () {
+  it('exports distanceInWords object', function () {
+    assert(typeof enLocale.distanceInWords === 'object')
+  })
+
+  it('exports format object', function () {
+    assert(typeof enLocale.format === 'object')
+  })
+})


### PR DESCRIPTION
Thanks for great library, but there weren't any korean translation yet. Here's my contribution.

FYI: I referenced [moment ko locale](https://github.com/moment/moment/blob/develop/locale/ko.js), [rails ko locale](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ko.yml), and [python arrow ko locale](https://github.com/crsmithdev/arrow/blob/master/arrow/locales.py#L553) for this work.