### PR TITLE
Min/Max accepts array instead of spread arguments (resolves #266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This change log follows the format documented in [Keep a CHANGELOG].
 [Keep a CHANGELOG]: http://keepachangelog.com/
 
 ## [Unreleased]
+### Changed
+
+- **BREAKING**: min and max functions now accept an array of dates
+rather than spread arguments.
+
+  ```javascript
+  // Before v1.15.2
+  var minDate = min(new Date(1989, 6 /* Jul */, 10), new Date(1987, 1 /* Feb */, 11))
+  var maxDate = min(new Date(1989, 6 /* Jul */, 10), new Date(1987, 1 /* Feb */, 11))
+
+  // v1.15.2 onward
+  var minDate = min([new Date(1989, 6 /* Jul */, 10), new Date(1987, 1 /* Feb */, 11)])
+  var maxDate = min([new Date(1989, 6 /* Jul */, 10), new Date(1987, 1 /* Feb */, 11)])
+  ```
+
 
 ## [1.15.1] - 2016-12-07
 

--- a/src/max/index.js
+++ b/src/max/index.js
@@ -13,16 +13,18 @@ var parse = require('../parse/index.js')
  * @example
  * // Which of these dates is the latest?
  * var result = max(
- *   new Date(1989, 6, 10),
- *   new Date(1987, 1, 11),
- *   new Date(1995, 6, 2),
- *   new Date(1990, 0, 1)
+ *  [
+ *    new Date(1989, 6, 10),
+ *    new Date(1987, 1, 11),
+ *    new Date(1995, 6, 2),
+ *    new Date(1990, 0, 1)
+ *  ]
  * )
  * //=> Sun Jul 02 1995 00:00:00
+ * @param datesArray
  */
-function max () {
-  var dirtyDates = Array.prototype.slice.call(arguments)
-  var dates = dirtyDates.map(function (dirtyDate) {
+function max (datesArray) {
+  var dates = datesArray.map(function (dirtyDate) {
     return parse(dirtyDate)
   })
   var latestTimestamp = Math.max.apply(null, dates)

--- a/src/max/index.js.flow
+++ b/src/max/index.js.flow
@@ -1,3 +1,3 @@
 // @flow
 
-declare module.exports: (...dates: (Date|string|number)[]) => Date
+declare module.exports: (datesArray: (Date|string|number)[]) => Date

--- a/src/max/test.js
+++ b/src/max/test.js
@@ -7,34 +7,42 @@ var max = require('./')
 describe('max', function () {
   it('returns the latest date', function () {
     var result = max(
-      new Date(1989, 6 /* Jul */, 10),
-      new Date(1987, 1 /* Feb */, 11)
+      [
+        new Date(1989, 6 /* Jul */, 10),
+        new Date(1987, 1 /* Feb */, 11)
+      ]
     )
     assert.deepEqual(result, new Date(1989, 6 /* Jul */, 10))
   })
 
   it('allows to pass more than 2 arguments', function () {
     var result = max(
-      new Date(1987, 1 /* Feb */, 11),
-      new Date(1989, 6 /* Jul */, 10),
-      new Date(1995, 6 /* Jul */, 2),
-      new Date(1990, 0 /* Jan */, 1)
+      [
+        new Date(1987, 1 /* Feb */, 11),
+        new Date(1989, 6 /* Jul */, 10),
+        new Date(1995, 6 /* Jul */, 2),
+        new Date(1990, 0 /* Jan */, 1)
+      ]
     )
     assert.deepEqual(result, new Date(1995, 6 /* Jul */, 2))
   })
 
   it('accepts strings', function () {
     var result = max(
-      new Date(1987, 1 /* Feb */, 11).toISOString(),
-      new Date(1989, 6 /* Jul */, 10).toISOString()
+      [
+        new Date(1987, 1 /* Feb */, 11).toISOString(),
+        new Date(1989, 6 /* Jul */, 10).toISOString()
+      ]
     )
     assert.deepEqual(result, new Date(1989, 6 /* Jul */, 10))
   })
 
   it('accepts timestamps', function () {
     var result = max(
-      new Date(1989, 6 /* Jul */, 10).getTime(),
-      new Date(1987, 1 /* Feb */, 11).getTime()
+      [
+        new Date(1989, 6 /* Jul */, 10).getTime(),
+        new Date(1987, 1 /* Feb */, 11).getTime()
+      ]
     )
     assert.deepEqual(result, new Date(1989, 6 /* Jul */, 10))
   })

--- a/src/min/index.js
+++ b/src/min/index.js
@@ -13,16 +13,18 @@ var parse = require('../parse/index.js')
  * @example
  * // Which of these dates is the earliest?
  * var result = min(
- *   new Date(1989, 6, 10),
- *   new Date(1987, 1, 11),
- *   new Date(1995, 6, 2),
- *   new Date(1990, 0, 1)
+ *  [
+ *    new Date(1989, 6, 10),
+ *    new Date(1987, 1, 11),
+ *    new Date(1995, 6, 2),
+ *    new Date(1990, 0, 1)
+ *  ]
  * )
  * //=> Wed Feb 11 1987 00:00:00
+ * @param datesArray
  */
-function min () {
-  var dirtyDates = Array.prototype.slice.call(arguments)
-  var dates = dirtyDates.map(function (dirtyDate) {
+function min (datesArray) {
+  var dates = datesArray.map(function (dirtyDate) {
     return parse(dirtyDate)
   })
   var earliestTimestamp = Math.min.apply(null, dates)

--- a/src/min/index.js.flow
+++ b/src/min/index.js.flow
@@ -1,3 +1,3 @@
 // @flow
 
-declare module.exports: (...dates: (Date|string|number)[]) => Date
+declare module.exports: (datesArray: (Date|string|number)[]) => Date

--- a/src/min/test.js
+++ b/src/min/test.js
@@ -7,34 +7,42 @@ var min = require('./')
 describe('min', function () {
   it('returns the earliest date', function () {
     var result = min(
-      new Date(1989, 6 /* Jul */, 10),
-      new Date(1987, 1 /* Feb */, 11)
+      [
+        new Date(1989, 6 /* Jul */, 10),
+        new Date(1987, 1 /* Feb */, 11)
+      ]
     )
     assert.deepEqual(result, new Date(1987, 1 /* Feb */, 11))
   })
 
   it('allows to pass more than 2 arguments', function () {
     var result = min(
-      new Date(1987, 1 /* Feb */, 11),
-      new Date(1989, 6 /* Jul */, 10),
-      new Date(1985, 6 /* Jul */, 2),
-      new Date(1990, 0 /* Jan */, 1)
+      [
+        new Date(1987, 1 /* Feb */, 11),
+        new Date(1989, 6 /* Jul */, 10),
+        new Date(1985, 6 /* Jul */, 2),
+        new Date(1990, 0 /* Jan */, 1)
+      ]
     )
     assert.deepEqual(result, new Date(1985, 6 /* Jul */, 2))
   })
 
   it('accepts strings', function () {
     var result = min(
-      new Date(1987, 1 /* Feb */, 11).toISOString(),
-      new Date(1989, 6 /* Jul */, 10).toISOString()
+      [
+        new Date(1987, 1 /* Feb */, 11).toISOString(),
+        new Date(1989, 6 /* Jul */, 10).toISOString()
+      ]
     )
     assert.deepEqual(result, new Date(1987, 1 /* Feb */, 11))
   })
 
   it('accepts timestamps', function () {
     var result = min(
-      new Date(1989, 6 /* Jul */, 10).getTime(),
-      new Date(1987, 1 /* Feb */, 11).getTime()
+      [
+        new Date(1989, 6 /* Jul */, 10).getTime(),
+        new Date(1987, 1 /* Feb */, 11).getTime()
+      ]
     )
     assert.deepEqual(result, new Date(1987, 1 /* Feb */, 11))
   })


### PR DESCRIPTION
See the parent PR: https://github.com/date-fns/date-fns/pull/308