### PR TITLE
Dutch locale: fix hours/years plural and in/over confusion

### DIFF
--- a/src/locale/nl/build_distance_in_words_locale/index.js
+++ b/src/locale/nl/build_distance_in_words_locale/index.js
@@ -10,7 +10,7 @@ function buildDistanceInWordsLocale () {
       other: '{{count}} seconden'
     },
 
-    halfAMinute: 'halve minuut',
+    halfAMinute: 'een halve minuut',
 
     lessThanXMinutes: {
       one: 'minder dan een minuut',
@@ -24,12 +24,12 @@ function buildDistanceInWordsLocale () {
 
     aboutXHours: {
       one: 'ongeveer 1 uur',
-      other: 'ongeveer {{count}} uren'
+      other: 'ongeveer {{count}} uur'
     },
 
     xHours: {
       one: '1 uur',
-      other: '{{count}} uren'
+      other: '{{count}} uur'
     },
 
     xDays: {
@@ -49,22 +49,22 @@ function buildDistanceInWordsLocale () {
 
     aboutXYears: {
       one: 'ongeveer 1 jaar',
-      other: 'ongeveer {{count}} jaren'
+      other: 'ongeveer {{count}} jaar'
     },
 
     xYears: {
       one: '1 jaar',
-      other: '{{count}} jaren'
+      other: '{{count}} jaar'
     },
 
     overXYears: {
-      one: 'over 1 jaar',
-      other: 'over {{count}} jaren'
+      one: 'meer dan 1 jaar',
+      other: 'meer dan {{count}} jaar'
     },
 
     almostXYears: {
       one: 'bijna 1 jaar',
-      other: 'bijna {{count}} jaren'
+      other: 'bijna {{count}} jaar'
     }
   }
 
@@ -82,7 +82,7 @@ function buildDistanceInWordsLocale () {
 
     if (options.addSuffix) {
       if (options.comparison > 0) {
-        return 'in ' + result
+        return 'over ' + result
       } else {
         return result + ' geleden'
       }

--- a/src/locale/nl/build_distance_in_words_locale/test.js
+++ b/src/locale/nl/build_distance_in_words_locale/test.js
@@ -43,11 +43,11 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
 
   describe('halfAMinute', function () {
     it('returns a proper string', function () {
-      assert(buildDistanceInWordsLocale().localize('halfAMinute') === 'halve minuut')
+      assert(buildDistanceInWordsLocale().localize('halfAMinute') === 'een halve minuut')
     })
 
     it('ignores the second argument', function () {
-      assert(buildDistanceInWordsLocale().localize('halfAMinute', 123) === 'halve minuut')
+      assert(buildDistanceInWordsLocale().localize('halfAMinute', 123) === 'een halve minuut')
     })
   })
 
@@ -88,7 +88,7 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
 
     context('when the count is more than 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXHours', 2) === 'ongeveer 2 uren')
+        assert(buildDistanceInWordsLocale().localize('aboutXHours', 2) === 'ongeveer 2 uur')
       })
     })
   })
@@ -102,7 +102,7 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
 
     context('when the count is more than 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xHours', 2) === '2 uren')
+        assert(buildDistanceInWordsLocale().localize('xHours', 2) === '2 uur')
       })
     })
   })
@@ -158,7 +158,7 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
 
     context('when the count is more than 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXYears', 2) === 'ongeveer 2 jaren')
+        assert(buildDistanceInWordsLocale().localize('aboutXYears', 2) === 'ongeveer 2 jaar')
       })
     })
   })
@@ -172,7 +172,7 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
 
     context('when the count is more than 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xYears', 2) === '2 jaren')
+        assert(buildDistanceInWordsLocale().localize('xYears', 2) === '2 jaar')
       })
     })
   })
@@ -180,13 +180,13 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
   describe('overXYears', function () {
     context('when the count equals 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('overXYears', 1) === 'over 1 jaar')
+        assert(buildDistanceInWordsLocale().localize('overXYears', 1) === 'meer dan 1 jaar')
       })
     })
 
     context('when the count is more than 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('overXYears', 2) === 'over 2 jaren')
+        assert(buildDistanceInWordsLocale().localize('overXYears', 2) === 'meer dan 2 jaar')
       })
     })
   })
@@ -200,7 +200,7 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
 
     context('when the count is more than 1', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('almostXYears', 2) === 'bijna 2 jaren')
+        assert(buildDistanceInWordsLocale().localize('almostXYears', 2) === 'bijna 2 jaar')
       })
     })
   })
@@ -221,7 +221,7 @@ describe('nl locale > buildDistanceInWordsLocale', function () {
         addSuffix: true,
         comparison: 1
       })
-      assert(result === 'in halve minuut')
+      assert(result === 'over een halve minuut')
     })
   })
 })


### PR DESCRIPTION
I think that @jtangelder will agree with this fix:

#### `over` confusion
- [x] "over XXX" in English is being translated as "meer dan XXX" (more than)
- [x] "in XXX" in English should be translated as "over XXX"

#### `plural` confusion
- [x] In Dutch it's more common to use "years" as singular, even if it's plural (`over 4 jaar` rather than `over 4 jaren`
- [x] In Dutch it's more common to use "hours" as singular, even if it's plural (`over 4 uur` rather than `over 4 uren`
- [x] "Half a minute" should be translated as "Een halve minuut"