### PR TITLE
Add ability to pass `options.weekStartsOn` to `parse` (closes #419)

### DIFF
--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -84,6 +84,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  * @param {Date|String|Number} baseDate - the date to took the missing higher priority values from
  * @param {Object} [options] - the object with options
  * @param {Locale} [options.locale=enLocale] - the locale object. See [Locale]{@link docs/Locale}
+ * @param {Number} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @returns {Date} the parsed date
  *
  * @example

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -410,6 +410,13 @@ describe('parse', function () {
         var result = parse(dateString, formatString, baseDate)
         assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
       })
+
+      it('allows to specify which day is the first day of the week', function () {
+        var dateString = '0'
+        var formatString = 'd'
+        var result = parse(dateString, formatString, baseDate, {weekStartsOn: 1})
+        assert.deepEqual(result, new Date(1986, 3 /* Apr */, 6))
+      })
     })
 
     describe('day of ISO week', function () {


### PR DESCRIPTION
Ability was (by accident) already there, just not tested and documented