### PR TITLE
Travis CI Chrome test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Environment
 sudo: false
+dist: trusty
 language: node_js
 node_js:
   - 4

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -16,7 +16,7 @@ var config = {
 function getEntryConfig () {
   if (process.env.BUILD_TESTS) {
     return {
-      'tests': './test.js'
+      'tests': './testWithoutLocales.js'
     }
   } else if (process.env.NODE_ENV === 'test') {
     return {}

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -206,12 +206,12 @@ describe('format', function () {
     })
 
     it('12 am', function () {
-      var date = new Date(1986, 3 /* Apr */, 4, 0, 0, 0, 900)
+      var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
       assert(format(date, 'h:mm a') === '12:00 am')
     })
 
     it('12 a.m.', function () {
-      var date = new Date(1986, 3 /* Apr */, 4, 0, 0, 0, 900)
+      var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
       assert(format(date, 'h:mm aa') === '12:00 a.m.')
     })
 
@@ -226,8 +226,8 @@ describe('format', function () {
     })
 
     it('cardinal numbers with leading zeros', function () {
-      var date = new Date(1986, 3 /* Apr */, 4, 1, 0, 0, 900)
-      assert(format(date, 'HH hh') === '01 01')
+      var date = new Date(1986, 3 /* Apr */, 4, 5, 0, 0, 900)
+      assert(format(date, 'HH hh') === '05 05')
     })
 
     it('all hour variants', function () {

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -405,26 +405,26 @@ describe('parse', function () {
 
     describe('day of week', function () {
       it('takes the values of higher priority from baseDate', function () {
-        var dateString = '1'
+        var dateString = '0'
         var formatString = 'd'
         var result = parse(dateString, formatString, baseDate)
-        assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
+        assert.deepEqual(result, new Date(1986, 2 /* Mar */, 30))
       })
 
       it('allows to specify which day is the first day of the week', function () {
-        var dateString = '1'
+        var dateString = '0'
         var formatString = 'd'
-        var result = parse(dateString, formatString, baseDate, {weekStartsOn: 2})
-        assert.deepEqual(result, new Date(1986, 3 /* Apr */, 7))
+        var result = parse(dateString, formatString, baseDate, {weekStartsOn: 1})
+        assert.deepEqual(result, new Date(1986, 3 /* Apr */, 6))
       })
     })
 
     describe('day of ISO week', function () {
       it('takes the values of higher priority from baseDate', function () {
-        var dateString = '6'
+        var dateString = '7'
         var formatString = 'E'
         var result = parse(dateString, formatString, baseDate)
-        assert.deepEqual(result, new Date(1986, 3 /* Apr */, 5))
+        assert.deepEqual(result, new Date(1986, 3 /* Apr */, 6))
       })
     })
 

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -378,10 +378,10 @@ describe('parse', function () {
   context('only one value is provided', function () {
     describe('quarter', function () {
       it('takes the values of higher priority from baseDate', function () {
-        var dateString = '1'
+        var dateString = '2'
         var formatString = 'Q'
         var result = parse(dateString, formatString, baseDate)
-        assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
+        assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
       })
     })
 
@@ -405,10 +405,10 @@ describe('parse', function () {
 
     describe('day of week', function () {
       it('takes the values of higher priority from baseDate', function () {
-        var dateString = '0'
+        var dateString = '1'
         var formatString = 'd'
         var result = parse(dateString, formatString, baseDate)
-        assert.deepEqual(result, new Date(1986, 2 /* Mar */, 30))
+        assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
       })
 
       it('allows to specify which day is the first day of the week', function () {

--- a/src/sub_months/test.js
+++ b/src/sub_months/test.js
@@ -34,10 +34,10 @@ describe('subMonths', function () {
 
   it('handles dates before 100 AD', function () {
     var initialDate = new Date(0)
-    initialDate.setFullYear(0, 2 /* Mar */, 31)
+    initialDate.setFullYear(1, 2 /* Mar */, 31)
     initialDate.setHours(0, 0, 0, 0)
     var expectedResult = new Date(0)
-    expectedResult.setFullYear(0, 1 /* Feb */, 29)
+    expectedResult.setFullYear(1, 1 /* Feb */, 28)
     expectedResult.setHours(0, 0, 0, 0)
     var result = subMonths(initialDate, 1)
     assert.deepEqual(result, expectedResult)

--- a/testWithoutLocales.js
+++ b/testWithoutLocales.js
@@ -1,0 +1,7 @@
+var testsContext = require.context('./src/', true, /\/test\.js$/)
+testsContext
+  .keys()
+  .filter(function (test) {
+    return !test.match(/\.\/locale\//)
+  })
+  .forEach(testsContext)


### PR DESCRIPTION
Some dates don't exist in some timezones, for example:

```
$ env TZ="America/New_York" node
> new Date(2017, 2 /* March */, 12, 2).toString()
'Sun Mar 12 2017 03:00:00 GMT-0400 (EDT)'
> new Date(2017, 2 /* March */, 12, 3).toString()
'Sun Mar 12 2017 03:00:00 GMT-0400 (EDT)'
```

In `America/New_York` timezone and node environment the date `2017-03-12T02:00:00` doesn't exist because of DST.

So, when there's a test like this:
```javascript
it('subtracts a day', function () {
  var date = new Date(2017, 2 /* March */, 12, 2)
  var result = subDays(date, 1)
  assert.deepEqual(result, new Date(2017, 2 /* March */, 11, 2)
})
```
it fails in `America/New_York` even when there's nothing wrong with function `subDays`. We run our tests through a number of timezones: https://github.com/date-fns/date-fns/blob/master/scripts/test_tz_extended.sh#L8-L344
Some tests will fail. Right now, we have no other solution but to modify tests to exclude all dates that don't exist in any timezone. Before, we also had to deal with `phantomjs` which has a lot of timezone related bugs (basically, in `phantomjs` you can create impossible dates by manipulating them via `Date` methods, even if you can't create these dates using `Date` constructor). That's why we had to do PRs #422 and #427. Recently, we moved our automatic tests to Chromium.

This PR:
- undoes #427 and test changes of #422
- updates Travis CI to the `trusty` environment that includes one of the latest versions of Chromium (Chromium 53.0.2785 at the moment)
- excludes locale tests when testing through timezones (locales are supposed to be timezone-independent) to speed up the Travis CI tests. Makes the difference between [passed test](https://travis-ci.org/date-fns/date-fns/builds/200302803) and [failed due to the time restriction](https://travis-ci.org/date-fns/date-fns/builds/200263583). Linked tests were made on this PR before rebasing.
- fixes tests for Chromium