### PR TITLE
Honor grammatical gender in French ordinals

### DIFF
--- a/src/locale/fr/build_format_locale/index.js
+++ b/src/locale/fr/build_format_locale/index.js
@@ -11,27 +11,27 @@ function buildFormatLocale () {
   var meridiemFull = ['du matin', 'de l’après-midi', 'du soir']
 
   var formatters = {
-    // Month: Jan, Feb, ..., Dec
+    // Month: Jan, Feb, …, Dec
     'MMM': function (date) {
       return months3char[date.getMonth()]
     },
 
-    // Month: January, February, ..., December
+    // Month: January, February, …, December
     'MMMM': function (date) {
       return monthsFull[date.getMonth()]
     },
 
-    // Day of week: Su, Mo, ..., Sa
+    // Day of week: Su, Mo, …, Sa
     'dd': function (date) {
       return weekdays2char[date.getDay()]
     },
 
-    // Day of week: Sun, Mon, ..., Sat
+    // Day of week: Sun, Mon, …, Sat
     'ddd': function (date) {
       return weekdays3char[date.getDay()]
     },
 
-    // Day of week: Sunday, Monday, ..., Saturday
+    // Day of week: Sunday, Monday, …, Saturday
     'dddd': function (date) {
       return weekdaysFull[date.getDay()]
     },
@@ -59,22 +59,21 @@ function buildFormatLocale () {
       }
 
       return meridiemFull[2]
+    },
+
+    // ISO week, ordinal version: 1st, 2nd, …, 53rd
+    // NOTE: Week has feminine grammatical gender in French: semaine
+    'Wo': function (date, formatters) {
+      return feminineOrdinal(formatters.W(date))
     }
   }
 
-  // Generate ordinal version of formatters: M -> Mo, D -> Do, etc.
-  // Words with masculine grammatical gender: mois, jour, trimestre
+  // Generate ordinal version of formatters: M → Mo, D → Do, etc.
+  // NOTE: For words with masculine grammatical gender in French: mois, jour, trimestre
   var ordinalFormatters = ['M', 'D', 'DDD', 'd', 'Q']
   ordinalFormatters.forEach(function (formatterToken) {
     formatters[formatterToken + 'o'] = function (date, formatters) {
-      return ordinal(formatters[formatterToken](date), 0)
-    }
-  })
-  // Words with feminine grammatical gender: semaine
-  ordinalFormatters = ['W']
-  ordinalFormatters.forEach(function (formatterToken) {
-    formatters[formatterToken + 'o'] = function (date, formatters) {
-      return ordinal(formatters[formatterToken](date), 1)
+      return masculineOrdinal(formatters[formatterToken](date))
     }
   })
 
@@ -84,18 +83,17 @@ function buildFormatLocale () {
   }
 }
 
-// Gender:
-// 0 = masculin
-// 1 = féminin
-function ordinal (number, gender) {
+function masculineOrdinal (number) {
   if (number === 1) {
-    switch (gender) {
-      case 0:
-      default:
-        return '1er'
-      case 1:
-        return '1re'
-    }
+    return '1er'
+  }
+
+  return number + 'e'
+}
+
+function feminineOrdinal (number) {
+  if (number === 1) {
+    return '1re'
   }
 
   return number + 'e'

--- a/src/locale/fr/build_format_locale/index.js
+++ b/src/locale/fr/build_format_locale/index.js
@@ -63,10 +63,18 @@ function buildFormatLocale () {
   }
 
   // Generate ordinal version of formatters: M -> Mo, D -> Do, etc.
-  var ordinalFormatters = ['M', 'D', 'DDD', 'd', 'Q', 'W']
+  // Words with masculine grammatical gender: mois, jour, trimestre
+  var ordinalFormatters = ['M', 'D', 'DDD', 'd', 'Q']
   ordinalFormatters.forEach(function (formatterToken) {
     formatters[formatterToken + 'o'] = function (date, formatters) {
-      return ordinal(formatters[formatterToken](date))
+      return ordinal(formatters[formatterToken](date), 0)
+    }
+  })
+  // Words with feminine grammatical gender: semaine
+  ordinalFormatters = ['W']
+  ordinalFormatters.forEach(function (formatterToken) {
+    formatters[formatterToken + 'o'] = function (date, formatters) {
+      return ordinal(formatters[formatterToken](date), 1)
     }
   })
 
@@ -76,9 +84,18 @@ function buildFormatLocale () {
   }
 }
 
-function ordinal (number) {
+// Gender:
+// 0 = masculin
+// 1 = féminin
+function ordinal (number, gender) {
   if (number === 1) {
-    return '1er'
+    switch (gender) {
+      case 0:
+      default:
+        return '1er'
+      case 1:
+        return '1re'
+    }
   }
 
   return number + 'e'

--- a/src/locale/fr/build_format_locale/test.js
+++ b/src/locale/fr/build_format_locale/test.js
@@ -291,7 +291,7 @@ describe('fr locale > buildFormatLocale', function () {
 
     describe('Wo', function () {
       it('returns ordinal result of W formatter', function () {
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 1 }}) === '1er')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 1 }}) === '1re')
         assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 2 }}) === '2e')
       })
     })


### PR DESCRIPTION
Ran `npm run lint` and `npm run test`.