### PR TITLE
Change Indonesian translation for Friday

### DIFF
--- a/src/locale/id/build_format_locale/index.js
+++ b/src/locale/id/build_format_locale/index.js
@@ -9,7 +9,7 @@ function buildFormatLocale () {
   var monthsFull = ['Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni', 'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember']
   var weekdays2char = ['Mi', 'Sn', 'Sl', 'Ra', 'Ka', 'Ju', 'Sa']
   var weekdays3char = ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab']
-  var weekdaysFull = ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', "Jum'at", 'Sabtu']
+  var weekdaysFull = ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', "Jumat", 'Sabtu']
   var meridiemUppercase = ['AM', 'PM']
   var meridiemLowercase = ['am', 'pm']
   var meridiemFull = ['a.m.', 'p.m.']


### PR DESCRIPTION
The correct word is "Jumat" instead of "Jum'at".
References: http://kbbi.web.id/Jumat
@rbudiharso