### PR TITLE
Allow getDay to accept weekStartsOn option

### DIFF
--- a/src/end_of_week/index.js
+++ b/src/end_of_week/index.js
@@ -1,3 +1,4 @@
+var getDay = require('../get_day/index.js')
 var parse = require('../parse/index.js')
 
 /**
@@ -24,11 +25,9 @@ var parse = require('../parse/index.js')
  * //=> Sun Sep 07 2014 23:59:59.999
  */
 function endOfWeek (dirtyDate, dirtyOptions) {
-  var weekStartsOn = dirtyOptions ? (Number(dirtyOptions.weekStartsOn) || 0) : 0
-
   var date = parse(dirtyDate)
-  var day = date.getDay()
-  var diff = (day < weekStartsOn ? -7 : 0) + 6 - (day - weekStartsOn)
+  var day = getDay(date, dirtyOptions)
+  var diff = 6 - day
 
   date.setDate(date.getDate() + diff)
   date.setHours(23, 59, 59, 999)

--- a/src/get_day/index.js
+++ b/src/get_day/index.js
@@ -8,6 +8,8 @@ var parse = require('../parse/index.js')
  * Get the day of the week of the given date.
  *
  * @param {Date|String|Number} date - the given date
+ * @param {Object} [options] - the object with options
+ * @param {Number} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @returns {Number} the day of week
  *
  * @example
@@ -15,9 +17,13 @@ var parse = require('../parse/index.js')
  * var result = getDay(new Date(2012, 1, 29))
  * //=> 3
  */
-function getDay (dirtyDate) {
+function getDay (dirtyDate, dirtyOptions) {
+  var weekStartsOn = dirtyOptions ? (Number(dirtyOptions.weekStartsOn) || 0) : 0
+
   var date = parse(dirtyDate)
-  var day = date.getDay()
+  var rawDay = date.getDay()
+  var day = (rawDay + (7 - weekStartsOn)) % 7
+
   return day
 }
 

--- a/src/get_day/index.js.flow
+++ b/src/get_day/index.js.flow
@@ -1,5 +1,8 @@
 // @flow
 
 declare module.exports: (
-  date: Date | string | number
+  date: Date | string | number,
+  options?: {
+    weekStartsOn?: number
+  }
 ) => number

--- a/src/get_day/test.js
+++ b/src/get_day/test.js
@@ -19,4 +19,17 @@ describe('getDay', function () {
     var result = getDay(new Date(2014, 5 /* Jun */, 1).getTime())
     assert(result === 0)
   })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = getDay(date, {weekStartsOn: 1})
+    assert(result === 1)
+  })
+
+  it('implicitly converts options', function () {
+    var date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0)
+    // $ExpectedMistake
+    var result = getDay(date, {weekStartsOn: '1'})
+    assert(result === 1)
+  })
 })

--- a/src/start_of_week/index.js
+++ b/src/start_of_week/index.js
@@ -1,4 +1,5 @@
 var parse = require('../parse/index.js')
+var getDay = require('../get_day/index.js')
 
 /**
  * @category Week Helpers
@@ -24,13 +25,10 @@ var parse = require('../parse/index.js')
  * //=> Mon Sep 01 2014 00:00:00
  */
 function startOfWeek (dirtyDate, dirtyOptions) {
-  var weekStartsOn = dirtyOptions ? (Number(dirtyOptions.weekStartsOn) || 0) : 0
-
   var date = parse(dirtyDate)
-  var day = date.getDay()
-  var diff = (day < weekStartsOn ? 7 : 0) + day - weekStartsOn
+  var day = getDay(date, dirtyOptions)
 
-  date.setDate(date.getDate() - diff)
+  date.setDate(date.getDate() - day)
   date.setHours(0, 0, 0, 0)
   return date
 }


### PR DESCRIPTION
Adds an options parameter with weekStartsOn to getDay

For example

```javascript
// A Friday with standard options
getDay(new Date(2017, 3, 7)) // 5

// A Friday with the week beginning on a Monday
getDay(new Date(2017, 3, 7), { weekStartsOn: 1 }) // 4
```

Also updates other functions using weekStartsOn to rely on getDay, removing duplicated logic

NB: In working on this PR I discovered issue #472.