### PR TITLE
Fix meridiem time for zh_cn locale

### DIFF
--- a/src/locale/zh_cn/build_format_locale/index.js
+++ b/src/locale/zh_cn/build_format_locale/index.js
@@ -6,8 +6,6 @@ function buildFormatLocale () {
   var weekdays2char = ['日', '一', '二', '三', '四', '五', '六']
   var weekdays3char = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
   var weekdaysFull = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六']
-  var meridiemUppercase = ['上午', '下午']
-  var meridiemLowercase = ['上午', '下午']
   var meridiemFull = ['上午', '下午']
 
   var formatters = {
@@ -38,12 +36,12 @@ function buildFormatLocale () {
 
     // AM, PM
     'A': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemUppercase[1] : meridiemUppercase[0]
+      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
     },
 
     // am, pm
     'a': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemLowercase[1] : meridiemLowercase[0]
+      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
     },
 
     // a.m., p.m.

--- a/src/locale/zh_cn/build_format_locale/index.js
+++ b/src/locale/zh_cn/build_format_locale/index.js
@@ -6,8 +6,8 @@ function buildFormatLocale () {
   var weekdays2char = ['日', '一', '二', '三', '四', '五', '六']
   var weekdays3char = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
   var weekdaysFull = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六']
-  var meridiemUppercase = ['AM', 'PM']
-  var meridiemLowercase = ['am', 'pm']
+  var meridiemUppercase = ['上午', '下午']
+  var meridiemLowercase = ['上午', '下午']
   var meridiemFull = ['上午', '下午']
 
   var formatters = {

--- a/src/locale/zh_cn/build_format_locale/index.js
+++ b/src/locale/zh_cn/build_format_locale/index.js
@@ -32,7 +32,7 @@ function buildFormatLocale () {
     // Day of week: Sunday, Monday, ..., Saturday
     'dddd': function (date) {
       return weekdaysFull[date.getDay()]
-    },
+    }
   }
 
   // AM, PM / am, pm / a.m., p.m. all translates to 上午, 下午

--- a/src/locale/zh_cn/build_format_locale/index.js
+++ b/src/locale/zh_cn/build_format_locale/index.js
@@ -33,21 +33,11 @@ function buildFormatLocale () {
     'dddd': function (date) {
       return weekdaysFull[date.getDay()]
     },
+  }
 
-    // AM, PM
-    'A': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
-    },
-
-    // am, pm
-    'a': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
-    },
-
-    // a.m., p.m.
-    'aa': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
-    }
+  // AM, PM / am, pm / a.m., p.m. all translates to 上午, 下午
+  formatters.a = formatters.aa = formatters.A = function (date) {
+    return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
   }
 
   // Generate ordinal version of formatters: M -> Mo, D -> Do, etc.

--- a/src/locale/zh_cn/build_format_locale/test.js
+++ b/src/locale/zh_cn/build_format_locale/test.js
@@ -206,37 +206,37 @@ describe('zh_CN locale > buildFormatLocale', function () {
 
     describe('A', function () {
       it('returns the correct string for 1-11 a.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 1)) === 'AM')
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 1)) === '上午')
       })
 
       it('returns the correct string for 12 a.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 0)) === 'AM')
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 0)) === '上午')
       })
 
       it('returns the correct string for 1-11 p.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 13)) === 'PM')
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 13)) === '下午')
       })
 
       it('returns the correct string for 12 p.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 12)) === 'PM')
+        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 12)) === '下午')
       })
     })
 
     describe('a', function () {
       it('returns the correct string for 1-11 a.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 1)) === 'am')
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 1)) === '上午')
       })
 
       it('returns the correct string for 12 a.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 0)) === 'am')
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 0)) === '上午')
       })
 
       it('returns the correct string for 1-11 p.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 13)) === 'pm')
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 13)) === '下午')
       })
 
       it('returns the correct string for 12 p.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 12)) === 'pm')
+        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 12)) === '下午')
       })
     })
 


### PR DESCRIPTION
Under no circumstances should `am/pm` be shown on `zh_cn`(Chinese) interfaces, so `meridiemUppercase` and `meridiemLowercase` should be translated into `['上午', '下午']` too.  There's no difference of upper/lower case in Chinese.

Previous behavior:
`hh:mm a` => `12:30 am`
`hh:mm A` => `12:30 AM`
`hh:mm aa` => `12:30 上午`

Corrected behavoir: 
`hh:mm a` => `12:30 上午`
`hh:mm A` => `12:30 上午`
`hh:mm aa` => `12:30 上午`