### PR TITLE
fix typo

### DIFF
--- a/src/locale/ar/_lib/localize/index.js
+++ b/src/locale/ar/_lib/localize/index.js
@@ -3,8 +3,8 @@ import buildLocalizeArrayFn from '../../../_lib/buildLocalizeArrayFn/index.js'
 
 var weekdayValues = {
   narrow: ['ح', 'ن', 'ث', 'ر', 'خ', 'ج', 'س'],
-  short: ['أحد', 'إثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت'],
-  long: ['الأحد', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت']
+  short: ['أحد', 'اثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت'],
+  long: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت']
 }
 
 var monthValues = {
@@ -15,7 +15,7 @@ var monthValues = {
 var timeOfDayValues = {
   uppercase: ['صباح', 'مساء'],
   lowercase: ['ص', 'م'],
-  long: ['صباحاً', 'مساءاً']
+  long: ['صباحاً', 'مساءً']
 }
 
 function ordinalNumber (dirtyNumber) {


### PR DESCRIPTION
Monday is from `اثنين` with `hamzat wasl` not `hamzat kataa` (`همزة قطع`). Tanween with Hamza in the end of the word doesn't need Alif (تنوين الهمزة في آخر الكلمة يكون على الهمزة ولا يحتاج ألفا زائدة).