### PR TITLE
Simplify ESM usage example in docs

### DIFF
--- a/scripts/build/docs.js
+++ b/scripts/build/docs.js
@@ -275,15 +275,8 @@ function generateUsage (name, isFPFn) {
 
     esm: {
       title: 'ESM',
-      code: `import {${name}} from 'date-fns/esm${submodule}'`,
+      code: `import { ${name} } from 'date-fns${submodule && `/esm/${submodule}`}'`,
       text: 'See [ECMAScript Modules guide](https://date-fns.org/docs/ECMAScript-Modules) for more information'
-    }
-  }
-
-  if (!isFPFn) {
-    usage.umd = {
-      title: 'UMD',
-      code: `var ${name} = dateFns.${name}`
     }
   }
 


### PR DESCRIPTION
- Don’t add `/esm` in examples if unless it’s a submodule.
- Remove UMD from examples.
- Fix the code style of ESM usage example.