### PR TITLE
Fix es (Español-Spanish) locale

### DIFF
--- a/src/locale/es/_lib/formatLong/index.js
+++ b/src/locale/es/_lib/formatLong/index.js
@@ -1,12 +1,12 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
 var formatLong = buildFormatLongFn({
-  LT: 'h:mm aa',
-  LTS: 'h:mm:ss aa',
-  L: 'MM/DD/YYYY',
-  LL: 'MMMM D YYYY',
-  LLL: 'MMMM D YYYY h:mm aa',
-  LLLL: 'dddd, MMMM D YYYY h:mm aa'
+  LT: 'HH:mm',
+  LTS: 'HH:mm:ss',
+  L: 'DD/MM/YYYY',
+  LL: 'D [de] MMMM [de] YYYY',
+  LLL: 'D [de] MMMM [de] YYYY HH:mm',
+  LLLL: 'dddd, D [de] MMMM [de] YYYY HH:mm'
 })
 
 export default formatLong

--- a/src/locale/es/_lib/formatRelative/index.js
+++ b/src/locale/es/_lib/formatRelative/index.js
@@ -1,12 +1,24 @@
 var formatRelativeLocale = {
-  lastWeek: '[el] dddd [pasado a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
-  yesterday: '[ayer a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
-  today: '[hoy a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
-  tomorrow: '[mañana a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
-  nextWeek: 'dddd [a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
+  lastWeek: '[el] dddd [pasado a la] LT',
+  yesterday: '[ayer a la] LT',
+  today: '[hoy a la] LT',
+  tomorrow: '[mañana a la] LT',
+  nextWeek: 'dddd [a la] LT',
+  other: 'L'
+}
+
+var formatRelativeLocalePlural = {
+  lastWeek: '[el] dddd [pasado a las] LT',
+  yesterday: '[ayer a las] LT',
+  today: '[hoy a las] LT',
+  tomorrow: '[mañana a las] LT',
+  nextWeek: 'dddd [a las] LT',
   other: 'L'
 }
 
 export default function formatRelative (token, date, baseDate, options) {
-  return formatRelativeLocale[token]
+  if(date.getHours() !== 1){
+    return formatRelativeLocalePlural[token];
+  }
+  return formatRelativeLocale[token];
 }

--- a/src/locale/es/_lib/formatRelative/index.js
+++ b/src/locale/es/_lib/formatRelative/index.js
@@ -1,9 +1,9 @@
 var formatRelativeLocale = {
-  lastWeek: '[last] dddd [at] LT',
-  yesterday: '[yesterday at] LT',
-  today: '[today at] LT',
-  tomorrow: '[tomorrow at] LT',
-  nextWeek: 'dddd [at] LT',
+  lastWeek: '[el] dddd [pasado a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
+  yesterday: '[ayer a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
+  today: '[hoy a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
+  tomorrow: '[mañana a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
+  nextWeek: 'dddd [a la' + ((this.hours() !== 1) ? 's' : '') + '] LT',
   other: 'L'
 }
 

--- a/src/locale/es/_lib/formatRelative/index.js
+++ b/src/locale/es/_lib/formatRelative/index.js
@@ -17,8 +17,8 @@ var formatRelativeLocalePlural = {
 }
 
 export default function formatRelative (token, date, baseDate, options) {
-  if(date.getHours() !== 1){
-    return formatRelativeLocalePlural[token];
+  if (date.getHours() !== 1) {
+    return formatRelativeLocalePlural[token]
   }
-  return formatRelativeLocale[token];
+  return formatRelativeLocale[token]
 }

--- a/src/locale/es/_lib/match/index.js
+++ b/src/locale/es/_lib/match/index.js
@@ -6,22 +6,22 @@ import parseDecimal from '../../../_lib/parseDecimal/index.js'
 var matchOrdinalNumbersPattern = /^(\d+)(th|st|nd|rd)?/i
 
 var matchWeekdaysPatterns = {
-  narrow: /^(su|mo|tu|we|th|fr|sa)/i,
-  short: /^(sun|mon|tue|wed|thu|fri|sat)/i,
-  long: /^(sunday|monday|tuesday|wednesday|thursday|friday|saturday)/i
+  narrow: /^(do|lu|ma|mi|ju|vi|sa)/i,
+  short: /^(dom|lun|mar|mié|jue|vie|sáb)/i,
+  long: /^(domingo|lunes|martes|miércoles|jueves|viernes|sábado)/i
 }
 
 var parseWeekdayPatterns = {
-  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i]
+  any: [/^d/i, /^l/i, /^ma/i, /^mi/i, /^j/i, /^v/i, /^s/i]
 }
 
 var matchMonthsPatterns = {
-  short: /^(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/i,
-  long: /^(january|february|march|april|may|june|july|august|september|october|november|december)/i
+  short: /^(ene|feb|mar|abr|may|jun|jul|ago|sep|oct|nov|dic)/i,
+  long: /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)/i
 }
 
 var parseMonthPatterns = {
-  any: [/^ja/i, /^f/i, /^mar/i, /^ap/i, /^may/i, /^jun/i, /^jul/i, /^au/i, /^s/i, /^o/i, /^n/i, /^d/i]
+  any: [/^e/i, /^f/i, /^mar/i, /^ab/i, /^may/i, /^jun/i, /^jul/i, /^ag/i, /^s/i, /^o/i, /^n/i, /^d/i]
 }
 
 var matchTimesOfDayPatterns = {

--- a/src/locale/es/index.js
+++ b/src/locale/es/index.js
@@ -13,6 +13,7 @@ import match from './_lib/match/index.js'
  * @author Juan Angosto [@juanangosto]{@link https://github.com/juanangosto}
  * @author Guillermo Grau [@guigrpa]{@link https://github.com/guigrpa}
  * @author Fernando Agüero [@fjaguero]{@link https://github.com/fjaguero}
+ * @author Gastón Haro [@harogaston]{@link https://github.com/harogaston}
  */
 var locale = {
   formatDistance: formatDistance,

--- a/src/locale/es/test.js
+++ b/src/locale/es/test.js
@@ -41,53 +41,53 @@ describe.skip('es locale', function () {
 
     describe('months', function () {
       it('Mo', function () {
-        var result = format(date, 'Mo [month]', {locale: locale})
-        assert(result === '4th month')
+        var result = format(date, 'Do [mes]', {locale: locale})
+        assert(result === '4º mes')
       })
 
       it('MMM', function () {
         var result = format(date, 'MMM', {locale: locale})
-        assert(result === 'Apr')
+        assert(result === 'Abr')
       })
 
       it('MMMM', function () {
         var result = format(date, 'MMMM', {locale: locale})
-        assert(result === 'April')
+        assert(result === 'Abril')
       })
     })
 
     describe('quarters', function () {
       it('Qo', function () {
-        var result = format(date, 'Qo [quarter]', {locale: locale})
-        assert(result === '2nd quarter')
+        var result = format(date, 'Qo [cuarto]', {locale: locale})
+        assert(result === '2º cuarto')
       })
     })
 
     describe('days of month', function () {
       it('Do', function () {
         var result = format(date, 'Do MMMM YYYY', {locale: locale})
-        assert(result === '4th April 1986')
+        assert(result === '4º Abril 1986')
       })
     })
 
     describe('days of year', function () {
       it('DDDo', function () {
-        var result = format(new Date(1992, 0 /* Jan */, 1), 'DDDo [day of the year]', {locale: locale})
-        assert(result === '1st day of the year')
+        var result = format(new Date(1992, 0 /* Jan */, 1), 'DDDo [día del año]', {locale: locale})
+        assert(result === '1º día del año')
       })
     })
 
     describe('days of week', function () {
       it('all variants', function () {
-        var result = format(date, 'do [day of the week,] dd ddd dddd', {locale: locale})
-        assert(result === '5th day of the week, Fr Fri Friday')
+        var result = format(date, 'do [día de la semana,] dd ddd dddd', {locale: locale})
+        assert(result === '5º día de la semana, vi vie viernes')
       })
     })
 
     describe('ISO weeks', function () {
       it('Wo', function () {
-        var result = format(date, 'Wo [week]', {locale: locale})
-        assert(result === '14th week')
+        var result = format(date, 'Wo [semana]', {locale: locale})
+        assert(result === '14º semana')
       })
     })
 
@@ -141,22 +141,22 @@ describe.skip('es locale', function () {
 
       it('L', function () {
         var result = format(new Date(2017, 6 /* Jul */, 2), 'L', {locale: locale})
-        assert(result === '07/02/2017')
+        assert(result === '02/07/2017')
       })
 
       it('LL', function () {
         var result = format(date, 'LL', {locale: locale})
-        assert(result === 'April 4 1986')
+        assert(result === '4 de Abril de 1986')
       })
 
       it('LLL', function () {
         var result = format(date, 'LLL', {locale: locale})
-        assert(result === 'April 4 1986 10:32 a.m.')
+        assert(result === '4 de Abril de 1986 10:32')
       })
 
       it('LLLL', function () {
         var result = format(date, 'LLLL', {locale: locale})
-        assert(result === 'Friday, April 4 1986 10:32 a.m.')
+        assert(result === 'viernes, 4 de Abril de 1986 10:32')
       })
     })
   })
@@ -168,7 +168,7 @@ describe.skip('es locale', function () {
         new Date(1986, 3, 4, 10, 32, 0),
         {locale: locale, includeSeconds: true}
       )
-      assert(result === 'half a minute')
+      assert(result === 'medio minuto')
     })
 
     context('when `addSuffix` option is true', function () {
@@ -178,7 +178,7 @@ describe.skip('es locale', function () {
           new Date(1986, 3, 4, 10, 32, 0),
           {locale: locale, includeSeconds: true, addSuffix: true}
         )
-        assert(result === 'in less than 10 seconds')
+        assert(result === 'en menos de 10 segundos')
       })
 
       it('adds a past suffix', function () {
@@ -187,7 +187,7 @@ describe.skip('es locale', function () {
           new Date(1986, 3, 4, 11, 32, 0),
           {locale: locale, addSuffix: true}
         )
-        assert(result === 'about 1 hour ago')
+        assert(result === 'hace alrededor de 1 hora')
       })
     })
   })
@@ -199,7 +199,7 @@ describe.skip('es locale', function () {
         new Date(1986, 3, 4, 12, 32, 0),
         {locale: locale, unit: 'm'}
       )
-      assert(result === '120 minutes')
+      assert(result === '120 minutos')
     })
 
     describe('when `addSuffix` option is true', function () {
@@ -209,7 +209,7 @@ describe.skip('es locale', function () {
           new Date(1986, 3, 4, 10, 32, 0),
           {locale: locale, addSuffix: true}
         )
-        assert(result === 'in 25 seconds')
+        assert(result === 'en 25 segundos')
       })
 
       it('adds a past suffix', function () {
@@ -218,7 +218,7 @@ describe.skip('es locale', function () {
           new Date(1986, 3, 4, 11, 32, 0),
           {locale: locale, addSuffix: true}
         )
-        assert(result === '1 hour ago')
+        assert(result === 'hace 1 hora')
       })
     })
   })
@@ -228,32 +228,32 @@ describe.skip('es locale', function () {
 
     it('last week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 1), baseDate, {locale: locale})
-      assert(result === 'last Tuesday at 12:00 a.m.')
+      assert(result === 'el martes pasado a las 12:00')
     })
 
     it('yesterday', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 3, 22, 22), baseDate, {locale: locale})
-      assert(result === 'yesterday at 10:22 p.m.')
+      assert(result === 'ayer a las 22:22')
     })
 
     it('today', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 4, 16, 50), baseDate, {locale: locale})
-      assert(result === 'today at 4:50 p.m.')
+      assert(result === 'hoy a las 16:50')
     })
 
     it('tomorrow', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 5, 7, 30), baseDate, {locale: locale})
-      assert(result === 'tomorrow at 7:30 a.m.')
+      assert(result === 'mañana a las 7:30')
     })
 
     it('next week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 6, 12, 0), baseDate, {locale: locale})
-      assert(result === 'Sunday at 12:00 p.m.')
+      assert(result === 'domingo a las 12:00')
     })
 
     it('after the next week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 11, 16, 50), baseDate, {locale: locale})
-      assert(result === '04/11/1986')
+      assert(result === '11/04/1986')
     })
   })
 
@@ -286,67 +286,67 @@ describe.skip('es locale', function () {
 
     describe('quarters', function () {
       it('Qo', function () {
-        var result = parse('2000 2nd', 'YYYY Qo', baseDate, {locale: locale})
+        var result = parse('2000 2º', 'YYYY Qo', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2000, 3 /* Apr */, 1))
       })
     })
 
     describe('months', function () {
       it('Mo', function () {
-        var result = parse('2014 12th', 'YYYY Mo', baseDate, {locale: locale})
+        var result = parse('2014 12º', 'YYYY Mo', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2014, 11 /* Dec */, 1))
       })
 
       it('MMM', function () {
-        var result = parse('2016 Nov', 'YYYY MMM', baseDate, {locale: locale})
+        var result = parse('2016 nov', 'YYYY MMM', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 10 /* Nov */, 1))
       })
 
       it('MMMM', function () {
-        var result = parse('2016 December', 'YYYY MMMM', baseDate, {locale: locale})
+        var result = parse('2016 diciembre', 'YYYY MMMM', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 11 /* Dec */, 1))
       })
     })
 
     describe('ISO weeks', function () {
       it('Wo', function () {
-        var result = parse('2016 3rd', 'GGGG Wo', baseDate, {locale: locale})
+        var result = parse('2016 3º', 'GGGG Wo', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 0 /* Jan */, 18))
       })
     })
 
     describe('days of a week', function () {
       it('do', function () {
-        var result = parse('2016 4 0th', 'GGGG W do', baseDate, {locale: locale})
+        var result = parse('2016 4 0º', 'GGGG W do', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 0 /* Jan */, 24))
       })
 
       it('dd', function () {
-        var result = parse('2016 4 Mo', 'GGGG W dd', baseDate, {locale: locale})
+        var result = parse('2016 4 lu', 'GGGG W dd', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 0 /* Jan */, 25))
       })
 
       it('ddd', function () {
-        var result = parse('2016 4 Wed', 'GGGG W ddd', baseDate, {locale: locale})
+        var result = parse('2016 4 mié', 'GGGG W ddd', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 0 /* Jan */, 27))
       })
 
       it('dddd', function () {
-        var result = parse('2016 4 Friday', 'GGGG W dddd', baseDate, {locale: locale})
+        var result = parse('2016 4 viernes', 'GGGG W dddd', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 0 /* Jan */, 29))
       })
     })
 
     describe('days of a month', function () {
       it('Do', function () {
-        var result = parse('2016 11 15th', 'YYYY MM Do', baseDate, {locale: locale})
+        var result = parse('2016 11 15º', 'YYYY MM Do', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 10 /* Nov */, 15))
       })
     })
 
     describe('days of a year', function () {
       it('DDDo', function () {
-        var result = parse('2016 100th', 'YYYY DDDo', baseDate, {locale: locale})
+        var result = parse('2016 100º', 'YYYY DDDo', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(2016, 3 /* Apr */, 9))
       })
     })
@@ -385,7 +385,7 @@ describe.skip('es locale', function () {
 
     describe('long formats', function () {
       it('unfolds long formats', function () {
-        var result = parse('April 6 1987 11:32 a.m.', 'LLL', baseDate, {locale: locale})
+        var result = parse('6 de Abril de 1987 11:32', 'LLL', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(1987, 3 /* Apr */, 6, 11, 32))
       })
     })


### PR DESCRIPTION
It was using default (English) values for:
- formatLong
- formatRelative

Also fixed tests.