### PR TITLE
Adding isFirstWeekInMonth helper

### DIFF
--- a/src/isFirstDayOfMonth/test.js
+++ b/src/isFirstDayOfMonth/test.js
@@ -5,12 +5,12 @@ import assert from 'power-assert'
 import isFirstDayOfMonth from '.'
 
 describe('isFirstDayOfMonth', function () {
-  it('returns true if the given date is in the last day of month', function () {
+  it('returns true if the given date is in the first day of month', function () {
     var result = isFirstDayOfMonth(new Date(2014, 9 /* Oct */, 1))
     assert(result === true)
   })
 
-  it('returns false if the given date is not in the last day of month', function () {
+  it('returns false if the given date is not in the first day of month', function () {
     var result = isFirstDayOfMonth(new Date(2014, 9 /* Oct */, 2))
     assert(result === false)
   })

--- a/src/isFirstWeekInMonth/benchmark.js
+++ b/src/isFirstWeekInMonth/benchmark.js
@@ -1,0 +1,15 @@
+// @flow
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import isFirstWeekOfMonth from '.'
+
+suite('isFirstWeekOfMonth', function () {
+  benchmark('date-fns', function () {
+    return isFirstWeekOfMonth(this.date)
+  })
+}, {
+  setup: function () {
+    this.date = new Date()
+  }
+})

--- a/src/isFirstWeekInMonth/index.js
+++ b/src/isFirstWeekInMonth/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+import startOfWeek from '../startOfWeek/index.js'
+import addDays from '../addDays/index.js'
+
+/**
+ * @name isFirstWeekInMonth
+ * @category Week Helpers
+ * @summary Is the given date the first week of a month?
+ *
+ * @description
+ * Is the given date the first week of a month?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is the first week of a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 1 September 2017 the first week of a month?
+ * var result = isFirstWeekInMonth(new Date(2017, 8, 1))
+ * //=> true
+ */
+export default function isFirstWeekInMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  const date = toDate(dirtyDate, dirtyOptions)
+  return addDays(startOfWeek(date), 6).getDate() <= 7
+}

--- a/src/isFirstWeekInMonth/test.js
+++ b/src/isFirstWeekInMonth/test.js
@@ -1,0 +1,49 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isFirstWeekOfMonth from '.'
+
+describe('isFirstWeekOfMonth', function () {
+  it('returns true if the given date is in the first week of month - 1', function () {
+    var result = isFirstWeekOfMonth(new Date(2017, 10 /* Nov */, 1))
+    assert(result === true)
+  })
+
+  it('returns true if the given date is in the first week of month - 2', function () {
+    var result = isFirstWeekOfMonth(new Date(2017, 9 /* Oct */, 30))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not in the first week of month', function () {
+    var result = isFirstWeekOfMonth(new Date(2017, 10 /* Nov */, 6))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(2017, 9 /* Oct */, 30).toISOString()
+    var result = isFirstWeekOfMonth(date)
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = new Date(2017, 9 /* Oct */, 30).getTime()
+    var result = isFirstWeekOfMonth(date)
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isFirstWeekOfMonth(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isFirstWeekOfMonth.bind(null, new Date(2017, 9 /* Oct */, 30), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isFirstWeekOfMonth.bind(null), TypeError)
+  })
+})


### PR DESCRIPTION
Use-case: diagram gantt or another timescale in week-scale, when first week-item in month needs special style or logic.