### PR TITLE
No longer return -0 when days are the same (closes #544)

### DIFF
--- a/src/differenceInDays/index.js
+++ b/src/differenceInDays/index.js
@@ -44,6 +44,10 @@ export default function differenceInDays (dirtyDateLeft, dirtyDateRight, dirtyOp
 
   var sign = compareAsc(dateLeft, dateRight, dirtyOptions)
   var difference = Math.abs(differenceInCalendarDays(dateLeft, dateRight, dirtyOptions))
+
+  // exit early if the days are the same
+  if (difference === 0) return 0
+
   dateLeft.setDate(dateLeft.getDate() - sign * difference)
 
   // Math.abs(diff in full days - diff in calendar days) === 1 if last calendar day is not full

--- a/src/differenceInDays/test.js
+++ b/src/differenceInDays/test.js
@@ -69,6 +69,21 @@ describe('differenceInDays', function () {
       )
       assert(result === 0)
     })
+
+    it('does not return -0 when given dates are the same', () => {
+      // thank you Chris West! @ChrisWestBlog, http://cwestblog.com/2014/02/25/javascript-testing-for-negative-zero/
+      function isNegative (n) {
+        return ((n = +n) || 1 / n) < 0
+      }
+
+      var result = differenceInDays(
+        new Date(2014, 8 /* Sep */, 5, 0, 0),
+        new Date(2014, 8 /* Sep */, 5, 0, 0)
+      )
+
+      var resultIsNegative = isNegative(result)
+      assert(resultIsNegative === false)
+    })
   })
 
   it('returns NaN if the first date is `Invalid Date`', function () {


### PR DESCRIPTION
This pull request addresses issue #544 

When the `difference === 0` exit early with a return of `0`. This was an interesting issue to look into as I was unfamiliar with `-0` appearing in JS. Additionally, JS treats `0` and `-0` the same in equality checks which made testing for this tricky. See Image:

![image](https://user-images.githubusercontent.com/5889417/32669086-ff09eca6-c604-11e7-8a48-976e7698e8f0.png)

Please let me know if I should make additional updates to this PR. I did not see this issue addressed in the PR's that are open and thought I could help out by taking care of an open issue.

