### PR TITLE
Selectable default locale v1

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -21,6 +21,8 @@ There are just a few functions that support I18n:
 - [`distanceInWordsToNow`](https://date-fns.org/docs/distanceInWordsToNow)
 - [`distanceInWordsStrict`](https://date-fns.org/docs/distanceInWordsStrict)
 
+These modules include a default locale, English. For advanced users that want to use another locale without having English in the dependencies, see [Removing English locale from bundle](#removing-english-locale-from-bundle).
+
 To use a locale, you need to require it and then pass
 as an option to a function:
 
@@ -164,3 +166,19 @@ use this quick guide:
 - If you have questions or need guidance, leave a comment in the issue.
 
 Thank you for your support!
+
+## Removing English locale from bundle
+
+**Disclaimer:** *Replacing modules as described below will make the functions `format` etc. return a different result given a specific set of argument values, which in spirit breaks the functional programming principle of [pure functions](https://en.wikipedia.org/wiki/Functional_programming#Pure_functions) and is therefore not advised.*
+
+You can make your bundler alias the default locale in your favorite bundler to another locale.
+
+For example, with webpack you can use the [`NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/)
+
+```js
+// Make the default locale Swedish
+new webpack.NormalModuleReplacementPlugin(
+  /\/locale\/default_locale\/index.js/,
+  require.resolve('date-fns/locale/sv')
+)
+```

--- a/src/distance_in_words/index.js
+++ b/src/distance_in_words/index.js
@@ -2,7 +2,7 @@ var compareDesc = require('../compare_desc/index.js')
 var parse = require('../parse/index.js')
 var differenceInSeconds = require('../difference_in_seconds/index.js')
 var differenceInMonths = require('../difference_in_months/index.js')
-var enLocale = require('../locale/en/index.js')
+var defaultLocale = require('../locale/default_locale/index.js')
 
 var MINUTES_IN_DAY = 1440
 var MINUTES_IN_ALMOST_TWO_DAYS = 2520
@@ -97,7 +97,7 @@ function distanceInWords (dirtyDateToCompare, dirtyDate, dirtyOptions) {
   var comparison = compareDesc(dirtyDateToCompare, dirtyDate)
 
   var locale = options.locale
-  var localize = enLocale.distanceInWords.localize
+  var localize = defaultLocale.distanceInWords.localize
   if (locale && locale.distanceInWords && locale.distanceInWords.localize) {
     localize = locale.distanceInWords.localize
   }

--- a/src/distance_in_words_strict/index.js
+++ b/src/distance_in_words_strict/index.js
@@ -1,7 +1,7 @@
 var compareDesc = require('../compare_desc/index.js')
 var parse = require('../parse/index.js')
 var differenceInSeconds = require('../difference_in_seconds/index.js')
-var enLocale = require('../locale/en/index.js')
+var defaultLocale = require('../locale/default_locale/index.js')
 
 var MINUTES_IN_DAY = 1440
 var MINUTES_IN_MONTH = 43200
@@ -97,7 +97,7 @@ function distanceInWordsStrict (dirtyDateToCompare, dirtyDate, dirtyOptions) {
   var comparison = compareDesc(dirtyDateToCompare, dirtyDate)
 
   var locale = options.locale
-  var localize = enLocale.distanceInWords.localize
+  var localize = defaultLocale.distanceInWords.localize
   if (locale && locale.distanceInWords && locale.distanceInWords.localize) {
     localize = locale.distanceInWords.localize
   }

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -3,7 +3,7 @@ var getISOWeek = require('../get_iso_week/index.js')
 var getISOYear = require('../get_iso_year/index.js')
 var parse = require('../parse/index.js')
 var isValid = require('../is_valid/index.js')
-var enLocale = require('../locale/en/index.js')
+var defaultLocale = require('../locale/default_locale/index.js')
 
 /**
  * @category Common Helpers
@@ -93,8 +93,8 @@ function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   var options = dirtyOptions || {}
 
   var locale = options.locale
-  var localeFormatters = enLocale.format.formatters
-  var formattingTokensRegExp = enLocale.format.formattingTokensRegExp
+  var localeFormatters = defaultLocale.format.formatters
+  var formattingTokensRegExp = defaultLocale.format.formattingTokensRegExp
   if (locale && locale.format && locale.format.formatters) {
     localeFormatters = locale.format.formatters
 

--- a/src/locale/default_locale/index.js
+++ b/src/locale/default_locale/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../en')


### PR DESCRIPTION
# Why?

Users that don't need to format dates with English locale might not want to include the english locale in their javascript bundle to optimize performance towards the end user. The size of the English locale is around 2 KB.

- By hiding English locale behind `date-fns/src/locale/default_locale` the module redirect configuration will make more sense and won't redirect the cases where you want to explicitly user English locale.
- The same technique could be used to select a sensible default locale in a project, although that is probably not recommended.

# How?

- Introduce and use the module `locale/default_locale`
- Add documentation on how to exclude the English locale by showing an example Webpack configuration

