### PR TITLE
UTC functions

### DIFF
--- a/src/utc/addDays/index.js
+++ b/src/utc/addDays/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name addDays
+ * @category Day Helpers
+ * @summary Add the specified number of days to the given date.
+ *
+ * @description
+ * Add the specified number of days to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of days to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the days added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 10 days to 1 September 2014:
+ * var result = addDays(new Date(Date.UTC(2014, 8, 1)), 10)
+ * //=> Thu Sep 11 2014 00:00:00
+ */
+export default function addDays (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var amount = Number(dirtyAmount)
+  date.setUTCDate(date.getUTCDate() + amount)
+  return date
+}

--- a/src/utc/addDays/test.js
+++ b/src/utc/addDays/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addDays from '.'
+
+describe('utc/addDays', function () {
+  it('adds the given number of days', function () {
+    var result = addDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 10)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 11)))
+  })
+
+  it('accepts a string', function () {
+    var result = addDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 10)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 11)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addDays(Date.UTC(2014, 8 /* Sep */, 1), 10)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 11)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '10')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 11)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    addDays(date, 11)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addDays(new Date(NaN), 10)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addDays.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 10, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addDays.bind(null), TypeError)
+    assert.throws(addDays.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addHours/index.js
+++ b/src/utc/addHours/index.js
@@ -1,0 +1,33 @@
+import addMilliseconds from '../addMilliseconds/index.js'
+
+var MILLISECONDS_IN_HOUR = 3600000
+
+/**
+ * @name addHours
+ * @category Hour Helpers
+ * @summary Add the specified number of hours to the given date.
+ *
+ * @description
+ * Add the specified number of hours to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of hours to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the hours added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 2 hours to 10 July 2014 23:00:00:
+ * var result = addHours(new Date(Date.UTC(2014, 6, 10, 23, 0)), 2)
+ * //=> Fri Jul 11 2014 01:00:00
+ */
+export default function addHours (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMilliseconds(dirtyDate, amount * MILLISECONDS_IN_HOUR, dirtyOptions)
+}

--- a/src/utc/addHours/test.js
+++ b/src/utc/addHours/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addHours from '.'
+
+describe('utc/addHours', function () {
+  it('adds the given numbers of hours', function () {
+    var result = addHours(new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)), 2)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 11, 1, 0)))
+  })
+
+  it('accepts a string', function () {
+    var result = addHours(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)).toISOString(), 26
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 12, 1, 0)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addHours(
+      Date.UTC(2014, 6 /* Jul */, 10, 23, 0), 26
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 12, 1, 0)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addHours(new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)), '2')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 11, 1, 0)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0))
+    addHours(date, 10)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addHours(new Date(NaN), 2)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addHours(new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addHours.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)), 2, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addHours.bind(null), TypeError)
+    assert.throws(addHours.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addISOWeekYears/index.js
+++ b/src/utc/addISOWeekYears/index.js
@@ -1,0 +1,34 @@
+import getISOWeekYear from '../getISOWeekYear/index.js'
+import setISOWeekYear from '../setISOWeekYear/index.js'
+
+/**
+ * @name addISOWeekYears
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Add the specified number of ISO week-numbering years to the given date.
+ *
+ * @description
+ * Add the specified number of ISO week-numbering years to the given date.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of ISO week-numbering years to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the ISO week-numbering years added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 5 ISO week-numbering years to 2 July 2010:
+ * var result = addISOWeekYears(new Date(Date.UTC(2010, 6, 2)), 5)
+ * //=> Fri Jun 26 2015 00:00:00
+ */
+export default function addISOWeekYears (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return setISOWeekYear(dirtyDate, getISOWeekYear(dirtyDate, dirtyOptions) + amount, dirtyOptions)
+}

--- a/src/utc/addISOWeekYears/test.js
+++ b/src/utc/addISOWeekYears/test.js
@@ -1,0 +1,66 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addISOWeekYears from '.'
+
+describe('utc/addISOWeekYears', function () {
+  it('adds the given number of ISO week-numbering years', function () {
+    var result = addISOWeekYears(new Date(Date.UTC(2010, 6 /* Jul */, 2)), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 5 /* Jun */, 26)))
+  })
+
+  it('accepts a string', function () {
+    var result = addISOWeekYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2026, 7 /* Aug */, 31)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addISOWeekYears(Date.UTC(2014, 8 /* Sep */, 1), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2026, 7 /* Aug */, 31)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addISOWeekYears(new Date(Date.UTC(2010, 6 /* Jul */, 2)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2015, 5 /* Jun */, 26)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    addISOWeekYears(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(10, 6 /* Jul */, 2)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(15, 5 /* Jun */, 26)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = addISOWeekYears(initialDate, 5)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addISOWeekYears(new Date(NaN), 5)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addISOWeekYears(new Date(Date.UTC(2010, 6 /* Jul */, 2)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addISOWeekYears.bind(null, new Date(Date.UTC(2010, 6 /* Jul */, 2)), 5, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addISOWeekYears.bind(null), TypeError)
+    assert.throws(addISOWeekYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addMilliseconds/index.js
+++ b/src/utc/addMilliseconds/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name addMilliseconds
+ * @category Millisecond Helpers
+ * @summary Add the specified number of milliseconds to the given date.
+ *
+ * @description
+ * Add the specified number of milliseconds to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of milliseconds to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the milliseconds added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 750 milliseconds to 10 July 2014 12:45:30.000:
+ * var result = addMilliseconds(new Date(Date.UTC(2014, 6, 10, 12, 45, 30, 0)), 750)
+ * //=> Thu Jul 10 2014 12:45:30.750
+ */
+export default function addMilliseconds (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var timestamp = toDate(dirtyDate, dirtyOptions).getTime()
+  var amount = Number(dirtyAmount)
+  return new Date(timestamp + amount)
+}

--- a/src/utc/addMilliseconds/test.js
+++ b/src/utc/addMilliseconds/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addMilliseconds from '.'
+
+describe('utc/addMilliseconds', function () {
+  it('adds the given number of milliseconds', function () {
+    var result = addMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), 750)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 750)))
+  })
+
+  it('accepts a string', function () {
+    var result = addMilliseconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)).toISOString(), 500
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 500)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addMilliseconds(
+      Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 500
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 500)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 5)), '750')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 755)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0))
+    addMilliseconds(date, 250)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addMilliseconds(new Date(NaN), 750)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addMilliseconds.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), 750, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addMilliseconds.bind(null), TypeError)
+    assert.throws(addMilliseconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addMinutes/index.js
+++ b/src/utc/addMinutes/index.js
@@ -1,0 +1,33 @@
+import addMilliseconds from '../addMilliseconds/index.js'
+
+var MILLISECONDS_IN_MINUTE = 60000
+
+/**
+ * @name addMinutes
+ * @category Minute Helpers
+ * @summary Add the specified number of minutes to the given date.
+ *
+ * @description
+ * Add the specified number of minutes to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of minutes to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the minutes added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 30 minutes to 10 July 2014 12:00:00:
+ * var result = addMinutes(new Date(Date.UTC(2014, 6, 10, 12, 0)), 30)
+ * //=> Thu Jul 10 2014 12:30:00
+ */
+export default function addMinutes (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMilliseconds(dirtyDate, amount * MILLISECONDS_IN_MINUTE, dirtyOptions)
+}

--- a/src/utc/addMinutes/test.js
+++ b/src/utc/addMinutes/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addMinutes from '.'
+
+describe('utc/addMinutes', function () {
+  it('adds the given number of minutes', function () {
+    var result = addMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), 30)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 30)))
+  })
+
+  it('accepts a string', function () {
+    var result = addMinutes(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)).toISOString(), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 20)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addMinutes(
+      Date.UTC(2014, 6 /* Jul */, 10, 12, 0), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 20)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 5)), '30')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 35)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0))
+    addMinutes(date, 25)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addMinutes(new Date(NaN), 30)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addMinutes.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), 30, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addMinutes.bind(null), TypeError)
+    assert.throws(addMinutes.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addMonths/index.js
+++ b/src/utc/addMonths/index.js
@@ -1,0 +1,41 @@
+import toDate from '../toDate/index.js'
+import getDaysInMonth from '../getDaysInMonth/index.js'
+
+/**
+ * @name addMonths
+ * @category Month Helpers
+ * @summary Add the specified number of months to the given date.
+ *
+ * @description
+ * Add the specified number of months to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of months to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the months added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 5 months to 1 September 2014:
+ * var result = addMonths(new Date(Date.UTC(2014, 8, 1)), 5)
+ * //=> Sun Feb 01 2015 00:00:00
+ */
+export default function addMonths (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var amount = Number(dirtyAmount)
+  var desiredMonth = date.getUTCMonth() + amount
+  var dateWithDesiredMonth = new Date(0)
+  dateWithDesiredMonth.setUTCFullYear(date.getUTCFullYear(), desiredMonth, 1)
+  dateWithDesiredMonth.setUTCHours(0, 0, 0, 0)
+  var daysInMonth = getDaysInMonth(dateWithDesiredMonth, dirtyOptions)
+  // Set the last day of the new month
+  // if the original date was the last day of the longer month
+  date.setUTCMonth(desiredMonth, Math.min(daysInMonth, date.getUTCDate()))
+  return date
+}

--- a/src/utc/addMonths/test.js
+++ b/src/utc/addMonths/test.js
@@ -1,0 +1,72 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addMonths from '.'
+
+describe('utc/addMonths', function () {
+  it('adds the given number of months', function () {
+    var result = addMonths(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 1 /* Feb */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = addMonths(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addMonths(Date.UTC(2014, 8 /* Sep */, 1), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addMonths(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2015, 1 /* Feb */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    addMonths(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('works well if the desired month has fewer days and the provided date is in the last day of a month', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    var result = addMonths(date, 2)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 1 /* Feb */, 28)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 0 /* Jan */, 31)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(0, 1 /* Feb */, 29)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = addMonths(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addMonths(new Date(NaN), 5)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addMonths(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addMonths.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addMonths.bind(null), TypeError)
+    assert.throws(addMonths.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addQuarters/index.js
+++ b/src/utc/addQuarters/index.js
@@ -1,0 +1,32 @@
+import addMonths from '../addMonths/index.js'
+
+/**
+ * @name addQuarters
+ * @category Quarter Helpers
+ * @summary Add the specified number of year quarters to the given date.
+ *
+ * @description
+ * Add the specified number of year quarters to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of quarters to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the quarters added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 1 quarter to 1 September 2014:
+ * var result = addQuarters(new Date(Date.UTC(2014, 8, 1)), 1)
+ * //=> Mon Dec 01 2014 00:00:00
+ */
+export default function addQuarters (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  var months = amount * 3
+  return addMonths(dirtyDate, months, dirtyOptions)
+}

--- a/src/utc/addQuarters/test.js
+++ b/src/utc/addQuarters/test.js
@@ -1,0 +1,72 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addQuarters from '.'
+
+describe('utc/addQuarters', function () {
+  it('adds the given number of quarters', function () {
+    var result = addQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = addQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addQuarters(Date.UTC(2014, 8 /* Sep */, 1), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '1')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    addQuarters(date, 4)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('works well if the desired month has fewer days and the provided date is in the last day of a month', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    var result = addQuarters(date, 3)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 8 /* Sep */, 30)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(-1, 10 /* Nov */, 30)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(0, 1 /* Feb */, 29)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = addQuarters(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addQuarters(new Date(NaN), 1)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addQuarters.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 1, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addQuarters.bind(null), TypeError)
+    assert.throws(addQuarters.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addSeconds/index.js
+++ b/src/utc/addSeconds/index.js
@@ -1,0 +1,31 @@
+import addMilliseconds from '../addMilliseconds/index.js'
+
+/**
+ * @name addSeconds
+ * @category Second Helpers
+ * @summary Add the specified number of seconds to the given date.
+ *
+ * @description
+ * Add the specified number of seconds to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of seconds to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the seconds added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 30 seconds to 10 July 2014 12:45:00:
+ * var result = addSeconds(new Date(Date.UTC(2014, 6, 10, 12, 45, 0)), 30)
+ * //=> Thu Jul 10 2014 12:45:30
+ */
+export default function addSeconds (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMilliseconds(dirtyDate, amount * 1000, dirtyOptions)
+}

--- a/src/utc/addSeconds/test.js
+++ b/src/utc/addSeconds/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addSeconds from '.'
+
+describe('utc/addSeconds', function () {
+  it('adds the given number of seconds', function () {
+    var result = addSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), 30)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30)))
+  })
+
+  it('accepts a string', function () {
+    var result = addSeconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)).toISOString(), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 20)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addSeconds(
+      Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 20)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 5)), '30')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 35)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0))
+    addSeconds(date, 15)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addSeconds(new Date(NaN), 30)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addSeconds.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), 30, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addSeconds.bind(null), TypeError)
+    assert.throws(addSeconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addWeeks/index.js
+++ b/src/utc/addWeeks/index.js
@@ -1,0 +1,32 @@
+import addDays from '../addDays/index.js'
+
+/**
+ * @name addWeeks
+ * @category Week Helpers
+ * @summary Add the specified number of weeks to the given date.
+ *
+ * @description
+ * Add the specified number of week to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of weeks to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the weeks added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 4 weeks to 1 September 2014:
+ * var result = addWeeks(new Date(Date.UTC(2014, 8, 1)), 4)
+ * //=> Mon Sep 29 2014 00:00:00
+ */
+export default function addWeeks (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  var days = amount * 7
+  return addDays(dirtyDate, days, dirtyOptions)
+}

--- a/src/utc/addWeeks/test.js
+++ b/src/utc/addWeeks/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addWeeks from '.'
+
+describe('utc/addWeeks', function () {
+  it('adds the given number of weeks', function () {
+    var result = addWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 29)))
+  })
+
+  it('accepts a string', function () {
+    var result = addWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 2)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 15)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addWeeks(Date.UTC(2014, 8 /* Sep */, 1), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 8)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '4')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 29)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    addWeeks(date, 2)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addWeeks(new Date(NaN), 4)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addWeeks.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 4, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addWeeks.bind(null), TypeError)
+    assert.throws(addWeeks.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/addYears/index.js
+++ b/src/utc/addYears/index.js
@@ -1,0 +1,31 @@
+import addMonths from '../addMonths/index.js'
+
+/**
+ * @name addYears
+ * @category Year Helpers
+ * @summary Add the specified number of years to the given date.
+ *
+ * @description
+ * Add the specified number of years to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of years to be added
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the years added
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Add 5 years to 1 September 2014:
+ * var result = addYears(new Date(Date.UTC(2014, 8, 1)), 5)
+ * //=> Sun Sep 01 2019 00:00:00
+ */
+export default function addYears (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMonths(dirtyDate, amount * 12, dirtyOptions)
+}

--- a/src/utc/addYears/test.js
+++ b/src/utc/addYears/test.js
@@ -1,0 +1,71 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import addYears from '.'
+
+describe('utc/addYears', function () {
+  it('adds the given number of years', function () {
+    var result = addYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2019, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = addYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2026, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = addYears(Date.UTC(2014, 8 /* Sep */, 1), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2026, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = addYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2019, 8 /* Sep */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    addYears(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('handles the leap years properly', function () {
+    var result = addYears(new Date(Date.UTC(2016, 1 /* Feb */, 29)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2017, 1 /* Feb */, 28)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 1 /* Feb */, 29)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(1, 1 /* Feb */, 28)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = addYears(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = addYears(new Date(NaN), 5)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = addYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = addYears.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(addYears.bind(null), TypeError)
+    assert.throws(addYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/areIntervalsOverlapping/index.js
+++ b/src/utc/areIntervalsOverlapping/index.js
@@ -1,0 +1,54 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name areIntervalsOverlapping
+ * @category Interval Helpers
+ * @summary Is the given time interval overlapping with another time interval?
+ *
+ * @description
+ * Is the given time interval overlapping with another time interval?
+ *
+ * @param {Interval} intervalLeft - the first interval to compare. See [Interval]{@link docs/types/Interval}
+ * @param {Interval} intervalRight - the second interval to compare. See [Interval]{@link docs/types/Interval}
+ * @param {Options} [options] - the object with options. See [Options]{@link docs/types/Options}
+ * @returns {Boolean} whether the time intervals are overlapping
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} The start of an interval cannot be after its end
+ * @throws {RangeError} Date in interval cannot be `Invalid Date`
+ *
+ * @example
+ * // For overlapping time intervals:
+ * areIntervalsOverlapping(
+ *   {start: new Date(Date.UTC(2014, 0, 10)), end: new Date(Date.UTC(2014, 0, 20))},
+ *   {start: new Date(Date.UTC(2014, 0, 17)), end: new Date(Date.UTC(2014, 0, 21))}
+ * )
+ * //=> true
+ *
+ * @example
+ * // For non-overlapping time intervals:
+ * areIntervalsOverlapping(
+ *   {start: new Date(Date.UTC(2014, 0, 10)), end: new Date(Date.UTC(2014, 0, 20))},
+ *   {start: new Date(Date.UTC(2014, 0, 21)), end: new Date(Date.UTC(2014, 0, 22))}
+ * )
+ * //=> false
+ */
+export default function areIntervalsOverlapping (dirtyIntervalLeft, dirtyIntervalRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var intervalLeft = dirtyIntervalLeft || {}
+  var intervalRight = dirtyIntervalRight || {}
+  var leftStartTime = toDate(intervalLeft.start, dirtyOptions).getTime()
+  var leftEndTime = toDate(intervalLeft.end, dirtyOptions).getTime()
+  var rightStartTime = toDate(intervalRight.start, dirtyOptions).getTime()
+  var rightEndTime = toDate(intervalRight.end, dirtyOptions).getTime()
+
+  // Throw an exception if start date is after end date or if any date is `Invalid Date`
+  if (!(leftStartTime <= leftEndTime && rightStartTime <= rightEndTime)) {
+    throw new RangeError('Invalid interval')
+  }
+
+  return leftStartTime < rightEndTime && rightStartTime < leftEndTime
+}

--- a/src/utc/areIntervalsOverlapping/test.js
+++ b/src/utc/areIntervalsOverlapping/test.js
@@ -1,0 +1,248 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import areIntervalsOverlapping from '.'
+
+describe('utc/areIntervalsOverlapping', function () {
+  var initialIntervalStart = new Date(Date.UTC(2016, 10, 10, 13, 0, 0))
+  var initialIntervalEnd = new Date(Date.UTC(2016, 11, 3, 15, 0, 0))
+
+  context('when the time intervals don\'t overlap', function () {
+    it('returns false for a valid non overlapping interval before another interval', function () {
+      var earlierIntervalStart = new Date(Date.UTC(2016, 9, 25))
+      var earlierIntervalEnd = new Date(Date.UTC(2016, 10, 9))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: earlierIntervalStart, end: earlierIntervalEnd}
+      )
+      assert(isOverlapping === false)
+    })
+
+    it('returns false for a valid non overlapping interval after another interval', function () {
+      var laterIntervalStart = new Date(Date.UTC(2016, 11, 4))
+      var laterIntervalEnd = new Date(Date.UTC(2016, 11, 9))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: laterIntervalStart, end: laterIntervalEnd}
+      )
+      assert(isOverlapping === false)
+    })
+
+    it('returns false for a non overlapping same-day interval', function () {
+      var sameDayIntervalStart = new Date(Date.UTC(2016, 11, 4, 9, 0, 0))
+      var sameDayIntervalEnd = new Date(Date.UTC(2016, 11, 4, 18, 0, 0))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: sameDayIntervalStart, end: sameDayIntervalEnd}
+      )
+      assert(isOverlapping === false)
+    })
+
+    it('returns false for an interval differing by a few hours', function () {
+      var oneDayOverlappingIntervalStart = new Date(Date.UTC(2016, 11, 3, 18, 0, 0))
+      var oneDayOverlappingIntervalEnd = new Date(Date.UTC(2016, 11, 14, 13, 0, 0))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: oneDayOverlappingIntervalStart, end: oneDayOverlappingIntervalEnd}
+      )
+      assert(isOverlapping === false)
+    })
+
+    it('returns false for an interval with the same startDateTime as the initial time intervals\'s endDateTime', function () {
+      var oneDayOverlapIntervalStart = new Date(Date.UTC(2016, 11, 3, 15, 0, 0))
+      var oneDayOverlapIntervalEnd = new Date(Date.UTC(2016, 11, 14, 13, 0, 0))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: oneDayOverlapIntervalStart, end: oneDayOverlapIntervalEnd}
+      )
+      assert(isOverlapping === false)
+    })
+
+    it('returns false for an interval with the same endDateTime as the initial time interval\'s startDateTime', function () {
+      var oneDayOverlapIntervalStart = new Date(Date.UTC(2016, 10, 3, 15, 0, 0))
+      var oneDayOverlapIntervalEnd = new Date(Date.UTC(2016, 10, 10, 13, 0, 0))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: oneDayOverlapIntervalStart, end: oneDayOverlapIntervalEnd}
+      )
+      assert(isOverlapping === false)
+    })
+  })
+
+  context('when the time intervals overlap', function () {
+    it('returns true for an interval included within another interval', function () {
+      var includedIntervalStart = new Date(Date.UTC(2016, 10, 14))
+      var includedIntervalEnd = new Date(Date.UTC(2016, 10, 14))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: includedIntervalStart, end: includedIntervalEnd}
+      )
+      assert(isOverlapping === true)
+    })
+
+    it('returns true for an interval overlapping at the end', function () {
+      var endOverlappingIntervalStart = new Date(Date.UTC(2016, 10, 5))
+      var endOverlappingIntervalEnd = new Date(Date.UTC(2016, 10, 14))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: endOverlappingIntervalStart, end: endOverlappingIntervalEnd}
+      )
+      assert(isOverlapping === true)
+    })
+
+    it('returns true for an interval overlapping at the beginning', function () {
+      var startOverlappingIntervalStart = new Date(Date.UTC(2016, 10, 20))
+      var startOverlappingIntervalEnd = new Date(Date.UTC(2016, 11, 14))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: startOverlappingIntervalStart, end: startOverlappingIntervalEnd}
+      )
+      assert(isOverlapping === true)
+    })
+
+    it('returns true for an interval including another interval', function () {
+      var includingIntervalStart = new Date(Date.UTC(2016, 10, 5))
+      var includingIntervalEnd = new Date(Date.UTC(2016, 11, 15))
+
+      var isOverlapping = areIntervalsOverlapping(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: includingIntervalStart, end: includingIntervalEnd}
+      )
+      assert(isOverlapping === true)
+    })
+  })
+
+  it('accepts strings', function () {
+    var initialIntervalStart = new Date(Date.UTC(2016, 10, 10, 13, 0, 0)).toISOString()
+    var initialIntervalEnd = new Date(Date.UTC(2016, 11, 3, 15, 0, 0)).toISOString()
+
+    var endOverlappingIntervalStart = new Date(Date.UTC(2016, 10, 5)).toISOString()
+    var endOverlappingIntervalEnd = new Date(Date.UTC(2016, 10, 14)).toISOString()
+
+    var isOverlapping = areIntervalsOverlapping(
+      {start: initialIntervalStart, end: initialIntervalEnd},
+      {start: endOverlappingIntervalStart, end: endOverlappingIntervalEnd}
+    )
+    assert(isOverlapping === true)
+  })
+
+  it('accepts timestamp', function () {
+    var initialIntervalStart = Date.UTC(2016, 10, 10, 13, 0, 0)
+    var initialIntervalEnd = Date.UTC(2016, 11, 3, 15, 0, 0)
+
+    var endOverlappingIntervalStart = Date.UTC(2016, 10, 5)
+    var endOverlappingIntervalEnd = Date.UTC(2016, 10, 14)
+
+    var isOverlapping = areIntervalsOverlapping(
+      {start: initialIntervalStart, end: initialIntervalEnd},
+      {start: endOverlappingIntervalStart, end: endOverlappingIntervalEnd}
+    )
+    assert(isOverlapping === true)
+  })
+
+  it('throws an exception if the start date of the initial time interval is after the end date', function () {
+    var block = areIntervalsOverlapping.bind(
+      null,
+      {start: new Date(Date.UTC(2016, 10, 7)), end: new Date(Date.UTC(2016, 10, 3))},
+      {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the start date of the compared time interval is after the end date', function () {
+    var block = areIntervalsOverlapping.bind(
+      null,
+      {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+      {start: new Date(Date.UTC(2016, 10, 15)), end: new Date(Date.UTC(2016, 10, 5))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the initial interval is undefined', function () {
+    var block = areIntervalsOverlapping.bind(
+      null,
+      // $ExpectedMistake
+      undefined,
+      {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the compared interval is undefined', function () {
+    var block = areIntervalsOverlapping.bind(
+      null,
+      {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+      // $ExpectedMistake
+      undefined
+    )
+    assert.throws(block, RangeError)
+  })
+
+  context('one of the dates is `Invalid Date`', function () {
+    it('throws an exception if the start date of the initial time interval is `Invalid Date`', function () {
+      var block = areIntervalsOverlapping.bind(
+        null,
+        {start: new Date(NaN), end: new Date(Date.UTC(2016, 10, 3))},
+        {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+      )
+      assert.throws(block, RangeError)
+    })
+
+    it('throws an exception if the end date of the initial time interval is `Invalid Date`', function () {
+      var block = areIntervalsOverlapping.bind(
+        null,
+        {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(NaN)},
+        {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+      )
+      assert.throws(block, RangeError)
+    })
+
+    it('throws an exception if the start date of the compared time interval is `Invalid Date`', function () {
+      var block = areIntervalsOverlapping.bind(
+        null,
+        {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+        {start: new Date(NaN), end: new Date(Date.UTC(2016, 10, 5))}
+      )
+      assert.throws(block, RangeError)
+    })
+
+    it('throws an exception if the end date of the compared time interval is `Invalid Date`', function () {
+      var block = areIntervalsOverlapping.bind(
+        null,
+        {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+        {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(NaN)}
+      )
+      assert.throws(block, RangeError)
+    })
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var earlierIntervalStart = new Date(Date.UTC(2016, 9, 25))
+    var earlierIntervalEnd = new Date(Date.UTC(2016, 10, 9))
+
+    var block = areIntervalsOverlapping.bind(
+      null,
+      {start: initialIntervalStart, end: initialIntervalEnd},
+      {start: earlierIntervalStart, end: earlierIntervalEnd},
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(areIntervalsOverlapping.bind(null), TypeError)
+    // $ExpectedMistake
+    assert.throws(areIntervalsOverlapping.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/closestIndexTo/index.js
+++ b/src/utc/closestIndexTo/index.js
@@ -1,0 +1,76 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name closestIndexTo
+ * @category Common Helpers
+ * @summary Return an index of the closest date from the array comparing to the given date.
+ *
+ * @description
+ * Return an index of the closest date from the array comparing to the given date.
+ *
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {Date[]|String[]|Number[]} datesArray - the array to search
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} an index of the date closest to the given date
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which date is closer to 6 September 2015?
+ * var dateToCompare = new Date(Date.UTC(2015, 8, 6))
+ * var datesArray = [
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   new Date(Date.UTC(2016, 0, 1)),
+ *   new Date(Date.UTC(2017, 0, 1))
+ * ]
+ * var result = closestIndexTo(dateToCompare, datesArray)
+ * //=> 1
+ */
+export default function closestIndexTo (dirtyDateToCompare, dirtyDatesArray, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateToCompare = toDate(dirtyDateToCompare, dirtyOptions)
+
+  if (isNaN(dateToCompare)) {
+    return NaN
+  }
+
+  var timeToCompare = dateToCompare.getTime()
+
+  var datesArray
+  // `dirtyDatesArray` is undefined or null
+  if (dirtyDatesArray == null) {
+    datesArray = []
+
+  // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method
+  } else if (typeof dirtyDatesArray.forEach === 'function') {
+    datesArray = dirtyDatesArray
+
+  // If `dirtyDatesArray` is Array-like Object, convert to Array. Otherwise, make it empty Array
+  } else {
+    datesArray = Array.prototype.slice.call(dirtyDatesArray)
+  }
+
+  var result
+  var minDistance
+  datesArray.forEach(function (dirtyDate, index) {
+    var currentDate = toDate(dirtyDate, dirtyOptions)
+
+    if (isNaN(currentDate)) {
+      result = NaN
+      minDistance = NaN
+      return
+    }
+
+    var distance = Math.abs(timeToCompare - currentDate.getTime())
+    if (result === undefined || distance < minDistance) {
+      result = index
+      minDistance = distance
+    }
+  })
+
+  return result
+}

--- a/src/utc/closestIndexTo/test.js
+++ b/src/utc/closestIndexTo/test.js
@@ -1,0 +1,121 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import closestIndexTo from '.'
+
+describe('utc/closestIndexTo', function () {
+  it('returns the date index from the given array closest to the given date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestIndexTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert.equal(result, 0)
+  })
+
+  it('works if the closest date from the given array is before the given date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 4, 500))
+    var result = closestIndexTo(date, [
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 5, 900)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 3, 900)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 10))
+    ])
+    assert.equal(result, 1)
+  })
+
+  it('accepts strings', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    var result = closestIndexTo(date, [
+      new Date(Date.UTC(2012, 6 /* Jul */, 2)).toISOString(),
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)).toISOString()
+    ])
+    assert.equal(result, 1)
+  })
+
+  it('accepts timestamps', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    var result = closestIndexTo(date, [
+      Date.UTC(2015, 7 /* Aug */, 31),
+      Date.UTC(2012, 6 /* Jul */, 2)
+    ])
+    assert.equal(result, 0)
+  })
+
+  it('returns undefined if the given array is empty', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    var result = closestIndexTo(date, [])
+    assert(result === undefined)
+  })
+
+  it('returns NaN if the given date is `Invalid Date`', function () {
+    var date = new Date(NaN)
+    var result = closestIndexTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if any date in the given array is `Invalid Date`', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestIndexTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(NaN),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if any value in the given array is undefined', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestIndexTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      // $ExpectedMistake
+      undefined,
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(isNaN(result))
+  })
+
+  it('converts Array-like objects into Array', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var object = {
+      '0': new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      '1': new Date(Date.UTC(2012, 6 /* Jul */, 2)),
+      length: 2
+    }
+    // $ExpectedMistake
+    var result = closestIndexTo(date, object)
+    assert.equal(result, 0)
+  })
+
+  it('converts undefined into empty array', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    // $ExpectedMistake
+    var result = closestIndexTo(date, undefined)
+    assert(result === undefined)
+  })
+
+  it('converts null into empty array', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    // $ExpectedMistake
+    var result = closestIndexTo(date, null)
+    assert(result === undefined)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var block = closestIndexTo.bind(null, date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    // $ExpectedMistake
+    ], {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(closestIndexTo.bind(null), TypeError)
+    assert.throws(closestIndexTo.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/closestTo/index.js
+++ b/src/utc/closestTo/index.js
@@ -1,0 +1,74 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name closestTo
+ * @category Common Helpers
+ * @summary Return a date from the array closest to the given date.
+ *
+ * @description
+ * Return a date from the array closest to the given date.
+ *
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {Date[]|String[]|Number[]} datesArray - the array to search
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the date from the array closest to the given date
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which date is closer to 6 September 2015: 1 January 2000 or 1 January 2030?
+ * var dateToCompare = new Date(Date.UTC(2015, 8, 6))
+ * var result = closestTo(dateToCompare, [
+ *   new Date(Date.UTC(2000, 0, 1)),
+ *   new Date(Date.UTC(2030, 0, 1))
+ * ])
+ * //=> Tue Jan 01 2030 00:00:00
+ */
+export default function closestTo (dirtyDateToCompare, dirtyDatesArray, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateToCompare = toDate(dirtyDateToCompare, dirtyOptions)
+
+  if (isNaN(dateToCompare)) {
+    return new Date(NaN)
+  }
+
+  var timeToCompare = dateToCompare.getTime()
+
+  var datesArray
+  // `dirtyDatesArray` is undefined or null
+  if (dirtyDatesArray == null) {
+    datesArray = []
+
+  // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method
+  } else if (typeof dirtyDatesArray.forEach === 'function') {
+    datesArray = dirtyDatesArray
+
+  // If `dirtyDatesArray` is Array-like Object, convert to Array. Otherwise, make it empty Array
+  } else {
+    datesArray = Array.prototype.slice.call(dirtyDatesArray)
+  }
+
+  var result
+  var minDistance
+  datesArray.forEach(function (dirtyDate) {
+    var currentDate = toDate(dirtyDate, dirtyOptions)
+
+    if (isNaN(currentDate)) {
+      result = new Date(NaN)
+      minDistance = NaN
+      return
+    }
+
+    var distance = Math.abs(timeToCompare - currentDate.getTime())
+    if (result === undefined || distance < minDistance) {
+      result = currentDate
+      minDistance = distance
+    }
+  })
+
+  return result
+}

--- a/src/utc/closestTo/test.js
+++ b/src/utc/closestTo/test.js
@@ -1,0 +1,131 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import closestTo from '.'
+
+describe('utc/closestTo', function () {
+  it('returns the date from the given array closest to the given date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert.deepEqual(result, new Date(Date.UTC(2015, 7 /* Aug */, 31)))
+  })
+
+  it('works if the closest date from the given array is before the given date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 4, 500))
+    var result = closestTo(date, [
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 5, 900)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 3, 900)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 10))
+    ])
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 30, 3, 900)))
+  })
+
+  it('accepts strings', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    var result = closestTo(date, [
+      new Date(Date.UTC(2012, 6 /* Jul */, 2)).toISOString(),
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)).toISOString()
+    ])
+    assert.deepEqual(result, new Date(Date.UTC(2015, 7 /* Aug */, 31)))
+  })
+
+  it('accepts timestamps', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    var result = closestTo(date, [
+      Date.UTC(2015, 7 /* Aug */, 31),
+      Date.UTC(2012, 6 /* Jul */, 2)
+    ])
+    assert.deepEqual(result, new Date(Date.UTC(2015, 7 /* Aug */, 31)))
+  })
+
+  it('returns undefined if the given array is empty', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    var result = closestTo(date, [])
+    assert(result === undefined)
+  })
+
+  it('returns `Invalid Date` if the given date is `Invalid Date`', function () {
+    var date = new Date(NaN)
+    var result = closestTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if any date in the given array is `Invalid Date`', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(NaN),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if any date in the given array is `Invalid Date`', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(NaN),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if any value in the given array is undefined', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var result = closestTo(date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      // $ExpectedMistake
+      undefined,
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('converts Array-like objects into Array', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var object = {
+      '0': new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      '1': new Date(Date.UTC(2012, 6 /* Jul */, 2)),
+      length: 2
+    }
+    // $ExpectedMistake
+    var result = closestTo(date, object)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 7 /* Aug */, 31)))
+  })
+
+  it('converts undefined into empty array', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    // $ExpectedMistake
+    var result = closestTo(date, undefined)
+    assert(result === undefined)
+  })
+
+  it('converts null into empty array', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    // $ExpectedMistake
+    var result = closestTo(date, null)
+    assert(result === undefined)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    var block = closestTo.bind(null, date, [
+      new Date(Date.UTC(2015, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2))
+    // $ExpectedMistake
+    ], {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(closestTo.bind(null), TypeError)
+    assert.throws(closestTo.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/compareAsc/index.js
+++ b/src/utc/compareAsc/index.js
@@ -1,0 +1,59 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name compareAsc
+ * @category Common Helpers
+ * @summary Compare the two dates and return -1, 0 or 1.
+ *
+ * @description
+ * Compare the two dates and return 1 if the first date is after the second,
+ * -1 if the first date is before the second or 0 if dates are equal.
+ *
+ * @param {Date|String|Number} dateLeft - the first date to compare
+ * @param {Date|String|Number} dateRight - the second date to compare
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the result of the comparison
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Compare 11 February 1987 and 10 July 1989:
+ * var result = compareAsc(
+ *   new Date(Date.UTC(1987, 1, 11)),
+ *   new Date(Date.UTC(1989, 6, 10))
+ * )
+ * //=> -1
+ *
+ * @example
+ * // Sort the array of dates:
+ * var result = [
+ *   new Date(Date.UTC(1995, 6, 2)),
+ *   new Date(Date.UTC(1987, 1, 11)),
+ *   new Date(Date.UTC(1989, 6, 10))
+ * ].sort(compareAsc)
+ * //=> [
+ * //   Wed Feb 11 1987 00:00:00,
+ * //   Mon Jul 10 1989 00:00:00,
+ * //   Sun Jul 02 1995 00:00:00
+ * // ]
+ */
+export default function compareAsc (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var diff = dateLeft.getTime() - dateRight.getTime()
+
+  if (diff < 0) {
+    return -1
+  } else if (diff > 0) {
+    return 1
+  // Return 0 if diff is 0; return NaN if diff is NaN
+  } else {
+    return diff
+  }
+}

--- a/src/utc/compareAsc/test.js
+++ b/src/utc/compareAsc/test.js
@@ -1,0 +1,105 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import compareAsc from '.'
+
+describe('utc/compareAsc', function () {
+  it('returns 0 if the given dates are equal', function () {
+    var result = compareAsc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === 0)
+  })
+
+  it('returns -1 if the first date is before the second one', function () {
+    var result = compareAsc(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === -1)
+  })
+
+  it('returns 1 if the first date is after the second one', function () {
+    var result = compareAsc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    )
+    assert(result === 1)
+  })
+
+  it('sorts the dates array in the chronological order when function is passed as the argument to Array.prototype.sort()', function () {
+    var unsortedArray = [
+      new Date(Date.UTC(1995, 6 /* Jul */, 2)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    ]
+
+    var sortedArray = [
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1995, 6 /* Jul */, 2))
+    ]
+
+    var result = unsortedArray.sort(compareAsc)
+
+    assert.deepEqual(result, sortedArray)
+  })
+
+  it('accepts strings', function () {
+    var result = compareAsc(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString(),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)).toISOString()
+    )
+    assert(result === -1)
+  })
+
+  it('accepts timestamps', function () {
+    var result = compareAsc(
+      Date.UTC(1987, 1 /* Feb */, 11),
+      Date.UTC(1989, 6 /* Jul */, 10)
+    )
+    assert(result === -1)
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = compareAsc(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = compareAsc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = compareAsc(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = compareAsc.bind(
+      null,
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(compareAsc.bind(null), TypeError)
+    assert.throws(compareAsc.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/compareDesc/index.js
+++ b/src/utc/compareDesc/index.js
@@ -1,0 +1,59 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name compareDesc
+ * @category Common Helpers
+ * @summary Compare the two dates reverse chronologically and return -1, 0 or 1.
+ *
+ * @description
+ * Compare the two dates and return -1 if the first date is after the second,
+ * 1 if the first date is before the second or 0 if dates are equal.
+ *
+ * @param {Date|String|Number} dateLeft - the first date to compare
+ * @param {Date|String|Number} dateRight - the second date to compare
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the result of the comparison
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Compare 11 February 1987 and 10 July 1989 reverse chronologically:
+ * var result = compareDesc(
+ *   new Date(Date.UTC(1987, 1, 11)),
+ *   new Date(Date.UTC(1989, 6, 10))
+ * )
+ * //=> 1
+ *
+ * @example
+ * // Sort the array of dates in reverse chronological order:
+ * var result = [
+ *   new Date(Date.UTC(1995, 6, 2)),
+ *   new Date(Date.UTC(1987, 1, 11)),
+ *   new Date(Date.UTC(1989, 6, 10))
+ * ].sort(compareDesc)
+ * //=> [
+ * //   Sun Jul 02 1995 00:00:00,
+ * //   Mon Jul 10 1989 00:00:00,
+ * //   Wed Feb 11 1987 00:00:00
+ * // ]
+ */
+export default function compareDesc (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var diff = dateLeft.getTime() - dateRight.getTime()
+
+  if (diff > 0) {
+    return -1
+  } else if (diff < 0) {
+    return 1
+  // Return 0 if diff is 0; return NaN if diff is NaN
+  } else {
+    return diff
+  }
+}

--- a/src/utc/compareDesc/test.js
+++ b/src/utc/compareDesc/test.js
@@ -1,0 +1,105 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import compareDesc from '.'
+
+describe('utc/compareDesc', function () {
+  it('returns 0 if the given dates are equal', function () {
+    var result = compareDesc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === 0)
+  })
+
+  it('returns 1 if the first date is before the second one', function () {
+    var result = compareDesc(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === 1)
+  })
+
+  it('returns -1 if the first date is after the second one', function () {
+    var result = compareDesc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    )
+    assert(result === -1)
+  })
+
+  it('sorts the dates array in the reverse chronological order when function is passed as the argument to Array.prototype.sort()', function () {
+    var unsortedArray = [
+      new Date(Date.UTC(1995, 6 /* Jul */, 2)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    ]
+
+    var sortedArray = [
+      new Date(Date.UTC(1995, 6 /* Jul */, 2)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    ]
+
+    var result = unsortedArray.sort(compareDesc)
+
+    assert.deepEqual(result, sortedArray)
+  })
+
+  it('accepts strings', function () {
+    var result = compareDesc(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString(),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)).toISOString()
+    )
+    assert(result === 1)
+  })
+
+  it('accepts timestamps', function () {
+    var result = compareDesc(
+      Date.UTC(1987, 1 /* Feb */, 11),
+      Date.UTC(1989, 6 /* Jul */, 10)
+    )
+    assert(result === 1)
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = compareDesc(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = compareDesc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = compareDesc(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = compareDesc.bind(
+      null,
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(compareDesc.bind(null), TypeError)
+    assert.throws(compareDesc.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarDays/index.js
+++ b/src/utc/differenceInCalendarDays/index.js
@@ -1,0 +1,56 @@
+import startOfDay from '../startOfDay/index.js'
+
+var MILLISECONDS_IN_MINUTE = 60000
+var MILLISECONDS_IN_DAY = 86400000
+
+/**
+ * @name differenceInCalendarDays
+ * @category Day Helpers
+ * @summary Get the number of calendar days between the given dates.
+ *
+ * @description
+ * Get the number of calendar days between the given dates. This means that the times are removed
+ * from the dates and then the difference in days is calculated.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of calendar days
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many calendar days are between
+ * // 2 July 2011 23:00:00 and 2 July 2012 00:00:00?
+ * var result = differenceInCalendarDays(
+ *   new Date(Date.UTC(2012, 6, 2, 0, 0)),
+ *   new Date(Date.UTC(2011, 6, 2, 23, 0))
+ * )
+ * //=> 366
+ * // How many calendar days are between
+ * // 2 July 2011 23:59:00 and 3 July 2011 00:01:00?
+ * var result = differenceInCalendarDays(
+ *   new Date(Date.UTC(2011, 6, 2, 0, 1)),
+ *   new Date(Date.UTC(2011, 6, 2, 23, 59))
+ * )
+ * //=> 1
+ */
+export default function differenceInCalendarDays (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var startOfDayLeft = startOfDay(dirtyDateLeft, dirtyOptions)
+  var startOfDayRight = startOfDay(dirtyDateRight, dirtyOptions)
+
+  var timestampLeft = startOfDayLeft.getTime() -
+    startOfDayLeft.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+  var timestampRight = startOfDayRight.getTime() -
+    startOfDayRight.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+
+  // Round the number of days to the nearest integer
+  // because the number of milliseconds in a day is not constant
+  // (e.g. it's different in the day of the daylight saving time clock shift)
+  return Math.round((timestampLeft - timestampRight) / MILLISECONDS_IN_DAY)
+}

--- a/src/utc/differenceInCalendarDays/test.js
+++ b/src/utc/differenceInCalendarDays/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarDays from '.'
+
+describe('utc/differenceInCalendarDays', function () {
+  it('returns the number of calendar days between the given dates', function () {
+    var result = differenceInCalendarDays(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 366)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarDays(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -366)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarDays(
+      new Date(Date.UTC(2014, 6 /* Jul */, 1, 23, 59, 59, 999)).toISOString(),
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 181)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarDays(
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 0),
+      Date.UTC(2014, 8 /* Sep */, 4, 6, 0)
+    )
+    assert(result === 1)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a day, but the given dates are in different calendar days', function () {
+      var result = differenceInCalendarDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 4, 23, 59))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 4, 23, 59)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === -1)
+    })
+
+    it('the time values of the given the given dates are the same', function () {
+      var result = differenceInCalendarDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 6, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 1)
+    })
+
+    it('the given the given dates are the same', function () {
+      var result = differenceInCalendarDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarDays(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarDays(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarDays(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarDays.bind(
+      null,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarDays.bind(null), TypeError)
+    assert.throws(differenceInCalendarDays.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarISOWeekYears/index.js
+++ b/src/utc/differenceInCalendarISOWeekYears/index.js
@@ -1,0 +1,35 @@
+import getISOWeekYear from '../getISOWeekYear/index.js'
+
+/**
+ * @name differenceInCalendarISOWeekYears
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Get the number of calendar ISO week-numbering years between the given dates.
+ *
+ * @description
+ * Get the number of calendar ISO week-numbering years between the given dates.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of calendar ISO week-numbering years
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many calendar ISO week-numbering years are 1 January 2010 and 1 January 2012?
+ * var result = differenceInCalendarISOWeekYears(
+ *   new Date(Date.UTC(2012, 0, 1)),
+ *   new Date(Date.UTC(2010, 0, 1))
+ * )
+ * //=> 2
+ */
+export default function differenceInCalendarISOWeekYears (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  return getISOWeekYear(dirtyDateLeft, dirtyOptions) - getISOWeekYear(dirtyDateRight, dirtyOptions)
+}

--- a/src/utc/differenceInCalendarISOWeekYears/test.js
+++ b/src/utc/differenceInCalendarISOWeekYears/test.js
@@ -1,0 +1,124 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarISOWeekYears from '.'
+
+describe('utc/differenceInCalendarISOWeekYears', function () {
+  it('returns the number of calendar ISO week-numbering years between the given dates', function () {
+    var result = differenceInCalendarISOWeekYears(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 1)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarISOWeekYears(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -1)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarISOWeekYears(
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 15)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarISOWeekYears(
+      Date.UTC(2014, 6 /* Jul */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 4)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var firstDate = new Date(0)
+    firstDate.setUTCFullYear(14, 0 /* Jan */, 1)
+    firstDate.setUTCHours(0, 0, 0, 0)
+    var secondDate = new Date(0)
+    secondDate.setUTCFullYear(0, 0 /* Jan */, 1)
+    secondDate.setUTCHours(0, 0, 0, 0)
+    var result = differenceInCalendarISOWeekYears(firstDate, secondDate)
+    assert(result === 15)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than an ISO year, but the given dates are in different calendar ISO years', function () {
+      var result = differenceInCalendarISOWeekYears(
+        new Date(Date.UTC(2012, 0 /* Jan */, 2)),
+        new Date(Date.UTC(2012, 0 /* Jan */, 1))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarISOWeekYears(
+        new Date(Date.UTC(2012, 0 /* Jan */, 1)),
+        new Date(Date.UTC(2012, 0 /* Jan */, 2))
+      )
+      assert(result === -1)
+    })
+
+    it('the ISO weeks and weekdays of the given dates are the same', function () {
+      var result = differenceInCalendarISOWeekYears(
+        new Date(Date.UTC(2013, 11 /* Dec */, 30)),
+        new Date(Date.UTC(2012, 0 /* Jan */, 2))
+      )
+      assert(result === 2)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInCalendarISOWeekYears(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarISOWeekYears(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarISOWeekYears(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarISOWeekYears(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarISOWeekYears.bind(
+      null,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarISOWeekYears.bind(null), TypeError)
+    assert.throws(differenceInCalendarISOWeekYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarISOWeeks/index.js
+++ b/src/utc/differenceInCalendarISOWeeks/index.js
@@ -1,0 +1,49 @@
+import startOfISOWeek from '../startOfISOWeek/index.js'
+
+var MILLISECONDS_IN_MINUTE = 60000
+var MILLISECONDS_IN_WEEK = 604800000
+
+/**
+ * @name differenceInCalendarISOWeeks
+ * @category ISO Week Helpers
+ * @summary Get the number of calendar ISO weeks between the given dates.
+ *
+ * @description
+ * Get the number of calendar ISO weeks between the given dates.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of calendar ISO weeks
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many calendar ISO weeks are between 6 July 2014 and 21 July 2014?
+ * var result = differenceInCalendarISOWeeks(
+ *   new Date(Date.UTC(2014, 6, 21)),
+ *   new Date(Date.UTC(2014, 6, 6))
+ * )
+ * //=> 3
+ */
+export default function differenceInCalendarISOWeeks (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var startOfISOWeekLeft = startOfISOWeek(dirtyDateLeft, dirtyOptions)
+  var startOfISOWeekRight = startOfISOWeek(dirtyDateRight, dirtyOptions)
+
+  var timestampLeft = startOfISOWeekLeft.getTime() -
+    startOfISOWeekLeft.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+  var timestampRight = startOfISOWeekRight.getTime() -
+    startOfISOWeekRight.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+
+  // Round the number of days to the nearest integer
+  // because the number of milliseconds in a week is not constant
+  // (e.g. it's different in the week of the daylight saving time clock shift)
+  return Math.round((timestampLeft - timestampRight) / MILLISECONDS_IN_WEEK)
+}

--- a/src/utc/differenceInCalendarISOWeeks/test.js
+++ b/src/utc/differenceInCalendarISOWeeks/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarISOWeeks from '.'
+
+describe('utc/differenceInCalendarISOWeeks', function () {
+  it('returns the number of calendar ISO weeks between the given dates', function () {
+    var result = differenceInCalendarISOWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0))
+    )
+    assert(result === 2)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarISOWeeks(
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0))
+    )
+    assert(result === -2)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarISOWeeks(
+      new Date(Date.UTC(2014, 7 /* Aug */, 8)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    )
+    assert(result === 5)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarISOWeeks(
+      Date.UTC(2014, 6 /* Jul */, 12),
+      Date.UTC(2014, 6 /* Jul */, 2)
+    )
+    assert(result === 1)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than an ISO week, but the given dates are in different calendar ISO weeks', function () {
+      var result = differenceInCalendarISOWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 7)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 6))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarISOWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 6)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 7))
+      )
+      assert(result === -1)
+    })
+
+    it('the days of weeks of the given dates are the same', function () {
+      var result = differenceInCalendarISOWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 9)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 2))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInCalendarISOWeeks(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarISOWeeks(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarISOWeeks(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarISOWeeks(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarISOWeeks.bind(
+      null,
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarISOWeeks.bind(null), TypeError)
+    assert.throws(differenceInCalendarISOWeeks.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarMonths/index.js
+++ b/src/utc/differenceInCalendarMonths/index.js
@@ -1,0 +1,39 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name differenceInCalendarMonths
+ * @category Month Helpers
+ * @summary Get the number of calendar months between the given dates.
+ *
+ * @description
+ * Get the number of calendar months between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of calendar months
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many calendar months are between 31 January 2014 and 1 September 2014?
+ * var result = differenceInCalendarMonths(
+ *   new Date(Date.UTC(2014, 8, 1)),
+ *   new Date(Date.UTC(2014, 0, 31))
+ * )
+ * //=> 8
+ */
+export default function differenceInCalendarMonths (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var yearDiff = dateLeft.getUTCFullYear() - dateRight.getUTCFullYear()
+  var monthDiff = dateLeft.getUTCMonth() - dateRight.getUTCMonth()
+
+  return yearDiff * 12 + monthDiff
+}

--- a/src/utc/differenceInCalendarMonths/test.js
+++ b/src/utc/differenceInCalendarMonths/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarMonths from '.'
+
+describe('utc/differenceInCalendarMonths', function () {
+  it('returns the number of calendar months between the given dates', function () {
+    var result = differenceInCalendarMonths(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 12)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarMonths(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -12)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarMonths(
+      new Date(Date.UTC(2000, 3 /* Apr */, 2)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 3)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarMonths(
+      Date.UTC(2014, 7 /* Aug */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 49)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a month, but the given dates are in different calendar months', function () {
+      var result = differenceInCalendarMonths(
+        new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+        new Date(Date.UTC(2014, 7 /* Aug */, 31))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarMonths(
+        new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 1))
+      )
+      assert(result === -1)
+    })
+
+    it('the days of months of the given dates are the same', function () {
+      var result = differenceInCalendarMonths(
+        new Date(Date.UTC(2014, 8 /* Sep */, 6)),
+        new Date(Date.UTC(2014, 7 /* Aug */, 6))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInCalendarMonths(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarMonths(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarMonths(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarMonths(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarMonths.bind(
+      null,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarMonths.bind(null), TypeError)
+    assert.throws(differenceInCalendarMonths.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarQuarters/index.js
+++ b/src/utc/differenceInCalendarQuarters/index.js
@@ -1,0 +1,40 @@
+import getQuarter from '../getQuarter/index.js'
+import toDate from '../toDate/index.js'
+
+/**
+ * @name differenceInCalendarQuarters
+ * @category Quarter Helpers
+ * @summary Get the number of calendar quarters between the given dates.
+ *
+ * @description
+ * Get the number of calendar quarters between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of calendar quarters
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many calendar quarters are between 31 December 2013 and 2 July 2014?
+ * var result = differenceInCalendarQuarters(
+ *   new Date(Date.UTC(2014, 6, 2)),
+ *   new Date(Date.UTC(2013, 11, 31))
+ * )
+ * //=> 3
+ */
+export default function differenceInCalendarQuarters (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var yearDiff = dateLeft.getUTCFullYear() - dateRight.getUTCFullYear()
+  var quarterDiff = getQuarter(dateLeft, dirtyOptions) - getQuarter(dateRight, dirtyOptions)
+
+  return yearDiff * 4 + quarterDiff
+}

--- a/src/utc/differenceInCalendarQuarters/test.js
+++ b/src/utc/differenceInCalendarQuarters/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarQuarters from '.'
+
+describe('utc/differenceInCalendarQuarters', function () {
+  it('returns the number of calendar quarters between the given dates', function () {
+    var result = differenceInCalendarQuarters(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 4)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarQuarters(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -4)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarQuarters(
+      new Date(Date.UTC(2000, 11 /* Dec */, 31)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 3)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarQuarters(
+      Date.UTC(2014, 9 /* Oct */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 17)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a quarter, but the given dates are in different calendar quarters', function () {
+      var result = differenceInCalendarQuarters(
+        new Date(Date.UTC(2014, 6 /* Jul */, 1)),
+        new Date(Date.UTC(2014, 5 /* Jun */, 30))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarQuarters(
+        new Date(Date.UTC(2014, 5 /* Jun */, 30)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 1))
+      )
+      assert(result === -1)
+    })
+
+    it('the days of months of the given dates are the same', function () {
+      var result = differenceInCalendarQuarters(
+        new Date(Date.UTC(2014, 3 /* Apr */, 6)),
+        new Date(Date.UTC(2014, 0 /* Jan */, 6))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInCalendarQuarters(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarQuarters(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarQuarters(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarQuarters(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarQuarters.bind(
+      null,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarQuarters.bind(null), TypeError)
+    assert.throws(differenceInCalendarQuarters.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarWeeks/index.js
+++ b/src/utc/differenceInCalendarWeeks/index.js
@@ -1,0 +1,60 @@
+import startOfWeek from '../startOfWeek/index.js'
+
+var MILLISECONDS_IN_MINUTE = 60000
+var MILLISECONDS_IN_WEEK = 604800000
+
+/**
+ * @name differenceInCalendarWeeks
+ * @category Week Helpers
+ * @summary Get the number of calendar weeks between the given dates.
+ *
+ * @description
+ * Get the number of calendar weeks between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Number} the number of calendar weeks
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // How many calendar weeks are between 5 July 2014 and 20 July 2014?
+ * var result = differenceInCalendarWeeks(
+ *   new Date(Date.UTC(2014, 6, 20)),
+ *   new Date(Date.UTC(2014, 6, 5))
+ * )
+ * //=> 3
+ *
+ * @example
+ * // If the week starts on Monday,
+ * // how many calendar weeks are between 5 July 2014 and 20 July 2014?
+ * var result = differenceInCalendarWeeks(
+ *   new Date(Date.UTC(2014, 6, 20)),
+ *   new Date(Date.UTC(2014, 6, 5)),
+ *   {weekStartsOn: 1}
+ * )
+ * //=> 2
+ */
+export default function differenceInCalendarWeeks (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var startOfWeekLeft = startOfWeek(dirtyDateLeft, dirtyOptions)
+  var startOfWeekRight = startOfWeek(dirtyDateRight, dirtyOptions)
+
+  var timestampLeft = startOfWeekLeft.getTime() -
+    startOfWeekLeft.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+  var timestampRight = startOfWeekRight.getTime() -
+    startOfWeekRight.getTimezoneOffset() * MILLISECONDS_IN_MINUTE
+
+  // Round the number of days to the nearest integer
+  // because the number of milliseconds in a week is not constant
+  // (e.g. it's different in the week of the daylight saving time clock shift)
+  return Math.round((timestampLeft - timestampRight) / MILLISECONDS_IN_WEEK)
+}

--- a/src/utc/differenceInCalendarWeeks/test.js
+++ b/src/utc/differenceInCalendarWeeks/test.js
@@ -1,0 +1,172 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarWeeks from '.'
+
+describe('utc/differenceInCalendarWeeks', function () {
+  it('returns the number of calendar weeks between the given dates', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0))
+    )
+    assert(result === 1)
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      {weekStartsOn: 1}
+    )
+    assert(result === 2)
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert(result === 2)
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert(result === 2)
+  })
+
+  it('returns a positive number if the time value of the second date is smaller', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      // $ExpectedMistake
+      {weekStartsOn: '1'}
+    )
+    assert(result === 2)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0))
+    )
+    assert(result === -1)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2014, 7 /* Aug */, 8)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    )
+    assert(result === 5)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarWeeks(
+      Date.UTC(2014, 6 /* Jul */, 12),
+      Date.UTC(2014, 6 /* Jul */, 2)
+    )
+    assert(result === 1)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a week, but the given dates are in different calendar weeks', function () {
+      var result = differenceInCalendarWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 6)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 5))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 5)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 6))
+      )
+      assert(result === -1)
+    })
+
+    it('the days of weeks of the given dates are the same', function () {
+      var result = differenceInCalendarWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 9)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 2))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInCalendarWeeks(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarWeeks(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    var block = differenceInCalendarWeeks.bind(
+      null,
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      // $ExpectedMistake
+      {weekStartsOn: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarWeeks.bind(
+      null,
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarWeeks.bind(null), TypeError)
+    assert.throws(differenceInCalendarWeeks.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInCalendarYears/index.js
+++ b/src/utc/differenceInCalendarYears/index.js
@@ -1,0 +1,36 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name differenceInCalendarYears
+ * @category Year Helpers
+ * @summary Get the number of calendar years between the given dates.
+ *
+ * @description
+ * Get the number of calendar years between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of calendar years
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many calendar years are between 31 December 2013 and 11 February 2015?
+ * var result = differenceInCalendarYears(
+ *   new Date(Date.UTC(2015, 1, 11)),
+ *   new Date(Date.UTC(2013, 11, 31))
+ * )
+ * //=> 2
+ */
+export default function differenceInCalendarYears (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  return dateLeft.getUTCFullYear() - dateRight.getUTCFullYear()
+}

--- a/src/utc/differenceInCalendarYears/test.js
+++ b/src/utc/differenceInCalendarYears/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInCalendarYears from '.'
+
+describe('utc/differenceInCalendarYears', function () {
+  it('returns the number of calendar years between the given dates', function () {
+    var result = differenceInCalendarYears(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 1)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInCalendarYears(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -1)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInCalendarYears(
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 14)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInCalendarYears(
+      Date.UTC(2014, 6 /* Jul */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 4)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a year, but the given dates are in different calendar years', function () {
+      var result = differenceInCalendarYears(
+        new Date(Date.UTC(2015, 0 /* Jan */, 1)),
+        new Date(Date.UTC(2014, 11 /* Dec */, 31))
+      )
+      assert(result === 1)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInCalendarYears(
+        new Date(Date.UTC(2014, 11 /* Dec */, 31)),
+        new Date(Date.UTC(2015, 0 /* Jan */, 1))
+      )
+      assert(result === -1)
+    })
+
+    it('the days and months of the given dates are the same', function () {
+      var result = differenceInCalendarYears(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5)),
+        new Date(Date.UTC(2012, 8 /* Sep */, 5))
+      )
+      assert(result === 2)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInCalendarYears(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInCalendarYears(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInCalendarYears(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInCalendarYears(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInCalendarYears.bind(
+      null,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInCalendarYears.bind(null), TypeError)
+    assert.throws(differenceInCalendarYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInDays/index.js
+++ b/src/utc/differenceInDays/index.js
@@ -1,0 +1,57 @@
+import toDate from '../toDate/index.js'
+import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+import compareAsc from '../compareAsc/index.js'
+
+/**
+ * @name differenceInDays
+ * @category Day Helpers
+ * @summary Get the number of full days between the given dates.
+ *
+ * @description
+ * Get the number of full day periods between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of full days
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many full days are between
+ * // 2 July 2011 23:00:00 and 2 July 2012 00:00:00?
+ * var result = differenceInDays(
+ *   new Date(Date.UTC(2012, 6, 2, 0, 0)),
+ *   new Date(Date.UTC(2011, 6, 2, 23, 0))
+ * )
+ * //=> 365
+ * // How many days are between
+ * // 2 July 2011 23:59:00 and 3 July 2011 00:01:00?
+ * var result = differenceInDays(
+ *   new Date(Date.UTC(2011, 6, 2, 0, 1)),
+ *   new Date(Date.UTC(2011, 6, 2, 23, 59))
+ * )
+ * //=> 0
+*/
+export default function differenceInDays (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var sign = compareAsc(dateLeft, dateRight, dirtyOptions)
+  var difference = Math.abs(differenceInCalendarDays(dateLeft, dateRight, dirtyOptions))
+
+  // exit early if the days are the same
+  if (difference === 0) return 0
+
+  dateLeft.setUTCDate(dateLeft.getUTCDate() - sign * difference)
+
+  // Math.abs(diff in full days - diff in calendar days) === 1 if last calendar day is not full
+  // If so, result must be decreased by 1 in absolute value
+  var isLastDayNotFull = compareAsc(dateLeft, dateRight, dirtyOptions) === -sign
+  return sign * (difference - isLastDayNotFull)
+}

--- a/src/utc/differenceInDays/test.js
+++ b/src/utc/differenceInDays/test.js
@@ -1,0 +1,128 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInDays from '.'
+
+describe('utc/differenceInDays', function () {
+  it('returns the number of full days between the given dates', function () {
+    var result = differenceInDays(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 366)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInDays(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -366)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInDays(
+      new Date(Date.UTC(2014, 6 /* Jul */, 1, 23, 59, 59, 999)).toISOString(),
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 181)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInDays(
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 0),
+      Date.UTC(2014, 8 /* Sep */, 4, 6, 0)
+    )
+    assert(result === 1)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a day, but the given dates are in different calendar days', function () {
+      var result = differenceInDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 4, 23, 59))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 4, 23, 59)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+
+    it('the time values of the given dates are the same', function () {
+      var result = differenceInDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 6, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+
+    it('does not return -0 when given dates are the same', () => {
+      // thank you Chris West! @ChrisWestBlog, http://cwestblog.com/2014/02/25/javascript-testing-for-negative-zero/
+      function isNegative (n) {
+        return ((n = +n) || 1 / n) < 0
+      }
+
+      var result = differenceInDays(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+
+      var resultIsNegative = isNegative(result)
+      assert(resultIsNegative === false)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInDays(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInDays(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInDays(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInDays.bind(
+      this,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInDays.bind(null), TypeError)
+    assert.throws(differenceInDays.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInHours/index.js
+++ b/src/utc/differenceInHours/index.js
@@ -1,0 +1,36 @@
+import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
+
+var MILLISECONDS_IN_HOUR = 3600000
+
+/**
+ * @name differenceInHours
+ * @category Hour Helpers
+ * @summary Get the number of hours between the given dates.
+ *
+ * @description
+ * Get the number of hours between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of hours
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many hours are between 2 July 2014 06:50:00 and 2 July 2014 19:00:00?
+ * var result = differenceInHours(
+ *   new Date(Date.UTC(2014, 6, 2, 19, 0)),
+ *   new Date(Date.UTC(2014, 6, 2, 6, 50))
+ * )
+ * //=> 12
+ */
+export default function differenceInHours (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var diff = differenceInMilliseconds(dirtyDateLeft, dirtyDateRight, dirtyOptions) / MILLISECONDS_IN_HOUR
+  return diff > 0 ? Math.floor(diff) : Math.ceil(diff)
+}

--- a/src/utc/differenceInHours/test.js
+++ b/src/utc/differenceInHours/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInHours from '.'
+
+describe('utc/differenceInHours', function () {
+  it('returns the number of hours between the given dates', function () {
+    var result = differenceInHours(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 20, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 14)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInHours(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 20, 0))
+    )
+    assert(result === -14)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInHours(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23, 59, 59, 999)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 13)).toISOString()
+    )
+    assert(result === 10)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInHours(
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 0),
+      Date.UTC(2014, 8 /* Sep */, 5, 6, 0)
+    )
+    assert(result === 12)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than an hour, but the given dates are in different calendar hours', function () {
+      var result = differenceInHours(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 11, 59))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInHours(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 11, 59)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12))
+      )
+      assert(result === 0)
+    })
+
+    it('the difference is an integral number of hours', function () {
+      var result = differenceInHours(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 13, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 0))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInHours(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInHours(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInHours(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInHours(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInHours.bind(
+      this,
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 20, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInHours.bind(null), TypeError)
+    assert.throws(differenceInHours.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInISOWeekYears/index.js
+++ b/src/utc/differenceInISOWeekYears/index.js
@@ -1,0 +1,49 @@
+import toDate from '../toDate/index.js'
+import differenceInCalendarISOWeekYears from '../differenceInCalendarISOWeekYears/index.js'
+import compareAsc from '../compareAsc/index.js'
+import subISOWeekYears from '../subISOWeekYears/index.js'
+
+/**
+ * @name differenceInISOWeekYears
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Get the number of full ISO week-numbering years between the given dates.
+ *
+ * @description
+ * Get the number of full ISO week-numbering years between the given dates.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of full ISO week-numbering years
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many full ISO week-numbering years are between 1 January 2010 and 1 January 2012?
+ * var result = differenceInISOWeekYears(
+ *   new Date(Date.UTC(2012, 0, 1)),
+ *   new Date(Date.UTC(2010, 0, 1))
+ * )
+ * //=> 1
+ */
+export default function differenceInISOWeekYears (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var sign = compareAsc(dateLeft, dateRight, dirtyOptions)
+  var difference = Math.abs(differenceInCalendarISOWeekYears(dateLeft, dateRight, dirtyOptions))
+  dateLeft = subISOWeekYears(dateLeft, sign * difference, dirtyOptions)
+
+  // Math.abs(diff in full ISO years - diff in calendar ISO years) === 1
+  // if last calendar ISO year is not full
+  // If so, result must be decreased by 1 in absolute value
+  var isLastISOWeekYearNotFull = compareAsc(dateLeft, dateRight, dirtyOptions) === -sign
+  return sign * (difference - isLastISOWeekYearNotFull)
+}

--- a/src/utc/differenceInISOWeekYears/test.js
+++ b/src/utc/differenceInISOWeekYears/test.js
@@ -1,0 +1,124 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInISOWeekYears from '.'
+
+describe('utc/differenceInISOWeekYears', function () {
+  it('returns the number of full ISO week-numbering years between the given dates', function () {
+    var result = differenceInISOWeekYears(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 1)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInISOWeekYears(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -1)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInISOWeekYears(
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 14)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInISOWeekYears(
+      Date.UTC(2014, 6 /* Jul */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 4)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var firstDate = new Date(0)
+    firstDate.setUTCFullYear(14, 0 /* Jan */, 1)
+    firstDate.setUTCHours(0, 0, 0, 0)
+    var secondDate = new Date(0)
+    secondDate.setUTCFullYear(0, 0 /* Jan */, 1)
+    secondDate.setUTCHours(0, 0, 0, 0)
+    var result = differenceInISOWeekYears(firstDate, secondDate)
+    assert(result === 14)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than an ISO year, but the given dates are in different calendar years', function () {
+      var result = differenceInISOWeekYears(
+        new Date(Date.UTC(2012, 0 /* Jan */, 2)),
+        new Date(Date.UTC(2012, 0 /* Jan */, 1))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInISOWeekYears(
+        new Date(Date.UTC(2012, 0 /* Jan */, 1)),
+        new Date(Date.UTC(2012, 0 /* Jan */, 2))
+      )
+      assert(result === 0)
+    })
+
+    it('the ISO weeks and weekdays of the given dates are the same', function () {
+      var result = differenceInISOWeekYears(
+        new Date(Date.UTC(2013, 11 /* Dec */, 30)),
+        new Date(Date.UTC(2012, 0 /* Jan */, 2))
+      )
+      assert(result === 2)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInISOWeekYears(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInISOWeekYears(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInISOWeekYears(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInISOWeekYears(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInISOWeekYears.bind(
+      this,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInISOWeekYears.bind(null), TypeError)
+    assert.throws(differenceInISOWeekYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInMilliseconds/index.js
+++ b/src/utc/differenceInMilliseconds/index.js
@@ -1,0 +1,36 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name differenceInMilliseconds
+ * @category Millisecond Helpers
+ * @summary Get the number of milliseconds between the given dates.
+ *
+ * @description
+ * Get the number of milliseconds between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of milliseconds
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many milliseconds are between
+ * // 2 July 2014 12:30:20.600 and 2 July 2014 12:30:21.700?
+ * var result = differenceInMilliseconds(
+ *   new Date(Date.UTC(2014, 6, 2, 12, 30, 21, 700)),
+ *   new Date(Date.UTC(2014, 6, 2, 12, 30, 20, 600))
+ * )
+ * //=> 1100
+ */
+export default function differenceInMilliseconds (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+  return dateLeft.getTime() - dateRight.getTime()
+}

--- a/src/utc/differenceInMilliseconds/test.js
+++ b/src/utc/differenceInMilliseconds/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInMilliseconds from '.'
+
+describe('utc/differenceInMilliseconds', function () {
+  it('returns the number of milliseconds between the given dates', function () {
+    var result = differenceInMilliseconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20, 700)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20, 600))
+    )
+    assert(result === 100)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInMilliseconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20, 600)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20, 700))
+    )
+    assert(result === -100)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInMilliseconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23, 59, 59, 999)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23, 59, 58, 999)).toISOString()
+    )
+    assert(result === 1000)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInMilliseconds(
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 30, 45, 500),
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 30, 45, 500)
+    )
+    assert(result === 0)
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInMilliseconds(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInMilliseconds(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInMilliseconds(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInMilliseconds.bind(
+      this,
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20, 600)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20, 700)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInMilliseconds.bind(null), TypeError)
+    assert.throws(differenceInMilliseconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInMinutes/index.js
+++ b/src/utc/differenceInMinutes/index.js
@@ -1,0 +1,36 @@
+import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
+
+var MILLISECONDS_IN_MINUTE = 60000
+
+/**
+ * @name differenceInMinutes
+ * @category Minute Helpers
+ * @summary Get the number of minutes between the given dates.
+ *
+ * @description
+ * Get the number of minutes between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of minutes
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many minutes are between 2 July 2014 12:07:59 and 2 July 2014 12:20:00?
+ * var result = differenceInMinutes(
+ *   new Date(Date.UTC(2014, 6, 2, 12, 20, 0)),
+ *   new Date(Date.UTC(2014, 6, 2, 12, 7, 59))
+ * )
+ * //=> 12
+ */
+export default function differenceInMinutes (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var diff = differenceInMilliseconds(dirtyDateLeft, dirtyDateRight, dirtyOptions) / MILLISECONDS_IN_MINUTE
+  return diff > 0 ? Math.floor(diff) : Math.ceil(diff)
+}

--- a/src/utc/differenceInMinutes/test.js
+++ b/src/utc/differenceInMinutes/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInMinutes from '.'
+
+describe('utc/differenceInMinutes', function () {
+  it('returns the number of minutes between the given dates', function () {
+    var result = differenceInMinutes(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 20)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 6))
+    )
+    assert(result === 14)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInMinutes(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 6)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 20))
+    )
+    assert(result === -14)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInMinutes(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23, 59, 59, 999)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23)).toISOString()
+    )
+    assert(result === 59)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInMinutes(
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 45),
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 15)
+    )
+    assert(result === 30)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a minute, but the given dates are in different calendar minutes', function () {
+      var result = differenceInMinutes(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 12)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 11, 59))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInMinutes(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 11, 59)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 12))
+      )
+      assert(result === 0)
+    })
+
+    it('the difference is an integral number of minutes', function () {
+      var result = differenceInMinutes(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 25)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 15))
+      )
+      assert(result === 10)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInMinutes(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInMinutes(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInMinutes(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInMinutes(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInMinutes.bind(
+      this,
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 6)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 20)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInMinutes.bind(null), TypeError)
+    assert.throws(differenceInMinutes.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInMonths/index.js
+++ b/src/utc/differenceInMonths/index.js
@@ -1,0 +1,45 @@
+import toDate from '../toDate/index.js'
+import differenceInCalendarMonths from '../differenceInCalendarMonths/index.js'
+import compareAsc from '../compareAsc/index.js'
+
+/**
+ * @name differenceInMonths
+ * @category Month Helpers
+ * @summary Get the number of full months between the given dates.
+ *
+ * @description
+ * Get the number of full months between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of full months
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many full months are between 31 January 2014 and 1 September 2014?
+ * var result = differenceInMonths(
+ *   new Date(Date.UTC(2014, 8, 1)),
+ *   new Date(Date.UTC(2014, 0, 31))
+ * )
+ * //=> 7
+ */
+export default function differenceInMonths (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var sign = compareAsc(dateLeft, dateRight, dirtyOptions)
+  var difference = Math.abs(differenceInCalendarMonths(dateLeft, dateRight, dirtyOptions))
+  dateLeft.setUTCMonth(dateLeft.getUTCMonth() - sign * difference)
+
+  // Math.abs(diff in full months - diff in calendar months) === 1 if last calendar month is not full
+  // If so, result must be decreased by 1 in absolute value
+  var isLastMonthNotFull = compareAsc(dateLeft, dateRight, dirtyOptions) === -sign
+  return sign * (difference - isLastMonthNotFull)
+}

--- a/src/utc/differenceInMonths/test.js
+++ b/src/utc/differenceInMonths/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInMonths from '.'
+
+describe('utc/differenceInMonths', function () {
+  it('returns the number of full months between the given dates', function () {
+    var result = differenceInMonths(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 12)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInMonths(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -12)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInMonths(
+      new Date(Date.UTC(2000, 3 /* Apr */, 2)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 3)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInMonths(
+      Date.UTC(2014, 7 /* Aug */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 49)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a month, but the given dates are in different calendar months', function () {
+      var result = differenceInMonths(
+        new Date(Date.UTC(2014, 7 /* Aug */, 1)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 31))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInMonths(
+        new Date(Date.UTC(2014, 6 /* Jul */, 31)),
+        new Date(Date.UTC(2014, 7 /* Aug */, 1))
+      )
+      assert(result === 0)
+    })
+
+    it('the days of months of the given dates are the same', function () {
+      var result = differenceInMonths(
+        new Date(Date.UTC(2014, 8 /* Sep */, 6)),
+        new Date(Date.UTC(2014, 7 /* Aug */, 6))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInMonths(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInMonths(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInMonths(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInMonths(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInMonths.bind(
+      this,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInMonths.bind(null), TypeError)
+    assert.throws(differenceInMonths.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInQuarters/index.js
+++ b/src/utc/differenceInQuarters/index.js
@@ -1,0 +1,34 @@
+import differenceInMonths from '../differenceInMonths/index.js'
+
+/**
+ * @name differenceInQuarters
+ * @category Quarter Helpers
+ * @summary Get the number of full quarters between the given dates.
+ *
+ * @description
+ * Get the number of full quarters between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of full quarters
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many full quarters are between 31 December 2013 and 2 July 2014?
+ * var result = differenceInQuarters(
+ *   new Date(Date.UTC(2014, 6, 2)),
+ *   new Date(Date.UTC(2013, 11, 31))
+ * )
+ * //=> 2
+ */
+export default function differenceInQuarters (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var diff = differenceInMonths(dirtyDateLeft, dirtyDateRight, dirtyOptions) / 3
+  return diff > 0 ? Math.floor(diff) : Math.ceil(diff)
+}

--- a/src/utc/differenceInQuarters/test.js
+++ b/src/utc/differenceInQuarters/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInQuarters from '.'
+
+describe('utc/differenceInQuarters', function () {
+  it('returns the number of full quarters between the given dates', function () {
+    var result = differenceInQuarters(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 4)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInQuarters(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -4)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInQuarters(
+      new Date(Date.UTC(2000, 11 /* Dec */, 31)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 3)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInQuarters(
+      Date.UTC(2014, 9 /* Oct */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 17)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a quarter, but the given dates are in different calendar quarters', function () {
+      var result = differenceInQuarters(
+        new Date(Date.UTC(2014, 6 /* Jul */, 1)),
+        new Date(Date.UTC(2014, 5 /* Jun */, 30))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInQuarters(
+        new Date(Date.UTC(2014, 5 /* Jun */, 30)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 1))
+      )
+      assert(result === 0)
+    })
+
+    it('the days of months of the given dates are the same', function () {
+      var result = differenceInQuarters(
+        new Date(Date.UTC(2014, 3 /* Apr */, 6)),
+        new Date(Date.UTC(2014, 0 /* Jan */, 6))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInQuarters(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInQuarters(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInQuarters(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInQuarters(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInQuarters.bind(
+      this,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInQuarters.bind(null), TypeError)
+    assert.throws(differenceInQuarters.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInSeconds/index.js
+++ b/src/utc/differenceInSeconds/index.js
@@ -1,0 +1,35 @@
+import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
+
+/**
+ * @name differenceInSeconds
+ * @category Second Helpers
+ * @summary Get the number of seconds between the given dates.
+ *
+ * @description
+ * Get the number of seconds between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of seconds
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many seconds are between
+ * // 2 July 2014 12:30:07.999 and 2 July 2014 12:30:20.000?
+ * var result = differenceInSeconds(
+ *   new Date(Date.UTC(2014, 6, 2, 12, 30, 20, 0)),
+ *   new Date(Date.UTC(2014, 6, 2, 12, 30, 7, 999))
+ * )
+ * //=> 12
+ */
+export default function differenceInSeconds (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var diff = differenceInMilliseconds(dirtyDateLeft, dirtyDateRight, dirtyOptions) / 1000
+  return diff > 0 ? Math.floor(diff) : Math.ceil(diff)
+}

--- a/src/utc/differenceInSeconds/test.js
+++ b/src/utc/differenceInSeconds/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInSeconds from '.'
+
+describe('utc/differenceInSeconds', function () {
+  it('returns the number of seconds between the given dates', function () {
+    var result = differenceInSeconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 6))
+    )
+    assert(result === 14)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInSeconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 6)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20))
+    )
+    assert(result === -14)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInSeconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23, 59, 59, 999)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 23, 59)).toISOString()
+    )
+    assert(result === 59)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInSeconds(
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 30, 45),
+      Date.UTC(2014, 8 /* Sep */, 5, 18, 30, 15)
+    )
+    assert(result === 30)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a second, but the given dates are in different calendar seconds', function () {
+      var result = differenceInSeconds(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 30, 12)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 30, 11, 999))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInSeconds(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 30, 11, 999)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 30, 12))
+      )
+      assert(result === 0)
+    })
+
+    it('the difference is an integral number of seconds', function () {
+      var result = differenceInSeconds(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 30, 25)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 12, 30, 15))
+      )
+      assert(result === 10)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInSeconds(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInSeconds(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInSeconds(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInSeconds(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInSeconds.bind(
+      this,
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 6)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2, 12, 30, 20)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInSeconds.bind(null), TypeError)
+    assert.throws(differenceInSeconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInWeeks/index.js
+++ b/src/utc/differenceInWeeks/index.js
@@ -1,0 +1,34 @@
+import differenceInDays from '../differenceInDays/index.js'
+
+/**
+ * @name differenceInWeeks
+ * @category Week Helpers
+ * @summary Get the number of full weeks between the given dates.
+ *
+ * @description
+ * Get the number of full weeks between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of full weeks
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many full weeks are between 5 July 2014 and 20 July 2014?
+ * var result = differenceInWeeks(
+ *   new Date(Date.UTC(2014, 6, 20)),
+ *   new Date(Date.UTC(2014, 6, 5))
+ * )
+ * //=> 2
+ */
+export default function differenceInWeeks (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var diff = differenceInDays(dirtyDateLeft, dirtyDateRight, dirtyOptions) / 7
+  return diff > 0 ? Math.floor(diff) : Math.ceil(diff)
+}

--- a/src/utc/differenceInWeeks/test.js
+++ b/src/utc/differenceInWeeks/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInWeeks from '.'
+
+describe('utc/differenceInWeeks', function () {
+  it('returns the number of full weeks between the given dates', function () {
+    var result = differenceInWeeks(
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0))
+    )
+    assert(result === 1)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInWeeks(
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0))
+    )
+    assert(result === -1)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInWeeks(
+      new Date(Date.UTC(2014, 7 /* Aug */, 8)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    )
+    assert(result === 5)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInWeeks(
+      Date.UTC(2014, 6 /* Jul */, 12),
+      Date.UTC(2014, 6 /* Jul */, 2)
+    )
+    assert(result === 1)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a week, but the given dates are in different calendar weeks', function () {
+      var result = differenceInWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 6)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 5))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 5)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 6))
+      )
+      assert(result === 0)
+    })
+
+    it('days of weeks of the given dates are the same', function () {
+      var result = differenceInWeeks(
+        new Date(Date.UTC(2014, 6 /* Jul */, 9)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 2))
+      )
+      assert(result === 1)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInWeeks(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInWeeks(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInWeeks(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInWeeks(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInWeeks.bind(
+      this,
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInWeeks.bind(null), TypeError)
+    assert.throws(differenceInWeeks.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/differenceInYears/index.js
+++ b/src/utc/differenceInYears/index.js
@@ -1,0 +1,45 @@
+import toDate from '../toDate/index.js'
+import differenceInCalendarYears from '../differenceInCalendarYears/index.js'
+import compareAsc from '../compareAsc/index.js'
+
+/**
+ * @name differenceInYears
+ * @category Year Helpers
+ * @summary Get the number of full years between the given dates.
+ *
+ * @description
+ * Get the number of full years between the given dates.
+ *
+ * @param {Date|String|Number} dateLeft - the later date
+ * @param {Date|String|Number} dateRight - the earlier date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of full years
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many full years are between 31 December 2013 and 11 February 2015?
+ * var result = differenceInYears(
+ *   new Date(Date.UTC(2015, 1, 11)),
+ *   new Date(Date.UTC(2013, 11, 31))
+ * )
+ * //=> 1
+ */
+export default function differenceInYears (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+
+  var sign = compareAsc(dateLeft, dateRight, dirtyOptions)
+  var difference = Math.abs(differenceInCalendarYears(dateLeft, dateRight, dirtyOptions))
+  dateLeft.setUTCFullYear(dateLeft.getUTCFullYear() - sign * difference)
+
+  // Math.abs(diff in full years - diff in calendar years) === 1 if last calendar year is not full
+  // If so, result must be decreased by 1 in absolute value
+  var isLastYearNotFull = compareAsc(dateLeft, dateRight, dirtyOptions) === -sign
+  return sign * (difference - isLastYearNotFull)
+}

--- a/src/utc/differenceInYears/test.js
+++ b/src/utc/differenceInYears/test.js
@@ -1,0 +1,113 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import differenceInYears from '.'
+
+describe('utc/differenceInYears', function () {
+  it('returns the number of full years between the given dates', function () {
+    var result = differenceInYears(
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0))
+    )
+    assert(result === 1)
+  })
+
+  it('returns a negative number if the time value of the first date is smaller', function () {
+    var result = differenceInYears(
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0))
+    )
+    assert(result === -1)
+  })
+
+  it('accepts strings', function () {
+    var result = differenceInYears(
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)).toISOString(),
+      new Date(Date.UTC(2000, 0 /* Jan */, 1)).toISOString()
+    )
+    assert(result === 14)
+  })
+
+  it('accepts timestamps', function () {
+    var result = differenceInYears(
+      Date.UTC(2014, 6 /* Jul */, 2),
+      Date.UTC(2010, 6 /* Jul */, 2)
+    )
+    assert(result === 4)
+  })
+
+  describe('edge cases', function () {
+    it('the difference is less than a year, but the given dates are in different calendar years', function () {
+      var result = differenceInYears(
+        new Date(Date.UTC(2015, 0 /* Jan */, 1)),
+        new Date(Date.UTC(2014, 11 /* Dec */, 31))
+      )
+      assert(result === 0)
+    })
+
+    it('the same for the swapped dates', function () {
+      var result = differenceInYears(
+        new Date(Date.UTC(2014, 11 /* Dec */, 31)),
+        new Date(Date.UTC(2015, 0 /* Jan */, 1))
+      )
+      assert(result === 0)
+    })
+
+    it('the days and months of the given dates are the same', function () {
+      var result = differenceInYears(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5)),
+        new Date(Date.UTC(2012, 8 /* Sep */, 5))
+      )
+      assert(result === 2)
+    })
+
+    it('the given dates are the same', function () {
+      var result = differenceInYears(
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0)),
+        new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+      )
+      assert(result === 0)
+    })
+  })
+
+  it('returns NaN if the first date is `Invalid Date`', function () {
+    var result = differenceInYears(
+      new Date(NaN),
+      new Date(Date.UTC(2017, 0 /* Jan */, 1))
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the second date is `Invalid Date`', function () {
+    var result = differenceInYears(
+      new Date(Date.UTC(2017, 0 /* Jan */, 1)),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('returns NaN if the both dates are `Invalid Date`', function () {
+    var result = differenceInYears(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = differenceInYears.bind(
+      this,
+      new Date(Date.UTC(2011, 6 /* Jul */, 2, 6, 0)),
+      new Date(Date.UTC(2012, 6 /* Jul */, 2, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(differenceInYears.bind(null), TypeError)
+    assert.throws(differenceInYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/eachDayOfInterval/index.js
+++ b/src/utc/eachDayOfInterval/index.js
@@ -1,0 +1,61 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name eachDayOfInterval
+ * @category Interval Helpers
+ * @summary Return the array of dates within the specified time interval.
+ *
+ * @description
+ * Return the array of dates within the specified time interval.
+ *
+ * @param {Interval} interval - the interval. See [Interval]{@link docs/types/Interval}
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date[]} the array with starts of days from the day of the interval start to the day of the interval end
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} The start of an interval cannot be after its end
+ * @throws {RangeError} Date in interval cannot be `Invalid Date`
+ *
+ * @example
+ * // Each day between 6 October 2014 and 10 October 2014:
+ * var result = eachDayOfInterval({
+ *   start: new Date(Date.UTC(2014, 9, 6)),
+ *   end: new Date(Date.UTC(2014, 9, 10))
+ * })
+ * //=> [
+ * //   Mon Oct 06 2014 00:00:00,
+ * //   Tue Oct 07 2014 00:00:00,
+ * //   Wed Oct 08 2014 00:00:00,
+ * //   Thu Oct 09 2014 00:00:00,
+ * //   Fri Oct 10 2014 00:00:00
+ * // ]
+ */
+export default function eachDayOfInterval (dirtyInterval, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var interval = dirtyInterval || {}
+  var startDate = toDate(interval.start, dirtyOptions)
+  var endDate = toDate(interval.end, dirtyOptions)
+
+  var endTime = endDate.getTime()
+
+  // Throw an exception if start date is after end date or if any date is `Invalid Date`
+  if (!(startDate.getTime() <= endTime)) {
+    throw new RangeError('Invalid interval')
+  }
+
+  var dates = []
+
+  var currentDate = startDate
+  currentDate.setUTCHours(0, 0, 0, 0)
+
+  while (currentDate.getTime() <= endTime) {
+    dates.push(toDate(currentDate, dirtyOptions))
+    currentDate.setUTCDate(currentDate.getUTCDate() + 1)
+  }
+
+  return dates
+}

--- a/src/utc/eachDayOfInterval/test.js
+++ b/src/utc/eachDayOfInterval/test.js
@@ -1,0 +1,146 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import eachDayOfInterval from '.'
+
+describe('utc/eachDayOfInterval', function () {
+  it('returns an array with starts of days from the day of the start date to the day of the end date', function () {
+    var result = eachDayOfInterval({
+      start: new Date(Date.UTC(2014, 9 /* Oct */, 6)),
+      end: new Date(Date.UTC(2014, 9 /* Oct */, 12))
+    })
+    assert.deepEqual(result, [
+      new Date(Date.UTC(2014, 9 /* Oct */, 6)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 7)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 8)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 9)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 10)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 11)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 12))
+    ])
+  })
+
+  it('accepts strings', function () {
+    var result = eachDayOfInterval({
+      start: new Date(Date.UTC(2014, 9 /* Oct */, 6)).toISOString(),
+      end: new Date(Date.UTC(2014, 9 /* Oct */, 12)).toISOString()
+    })
+    assert.deepEqual(result, [
+      new Date(Date.UTC(2014, 9 /* Oct */, 6)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 7)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 8)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 9)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 10)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 11)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 12))
+    ])
+  })
+
+  it('accepts timestamps', function () {
+    var result = eachDayOfInterval({
+      start: Date.UTC(2014, 9 /* Oct */, 6),
+      end: Date.UTC(2014, 9 /* Oct */, 12)
+    })
+    assert.deepEqual(result, [
+      new Date(Date.UTC(2014, 9 /* Oct */, 6)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 7)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 8)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 9)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 10)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 11)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 12))
+    ])
+  })
+
+  it('handles the dates that are not starts of days', function () {
+    var result = eachDayOfInterval({
+      start: new Date(Date.UTC(2014, 9 /* Oct */, 6, 6, 35)),
+      end: new Date(Date.UTC(2014, 9 /* Oct */, 12, 22, 15))
+    })
+    assert.deepEqual(result, [
+      new Date(Date.UTC(2014, 9 /* Oct */, 6)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 7)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 8)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 9)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 10)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 11)),
+      new Date(Date.UTC(2014, 9 /* Oct */, 12))
+    ])
+  })
+
+  it('returns one day if the both arguments are on the same day', function () {
+    var result = eachDayOfInterval({
+      start: new Date(Date.UTC(2014, 9 /* Oct */, 6, 14)),
+      end: new Date(Date.UTC(2014, 9 /* Oct */, 6, 15))
+    })
+    assert.deepEqual(result, [
+      new Date(Date.UTC(2014, 9 /* Oct */, 6))
+    ])
+  })
+
+  it('returns one day if the both arguments are the same', function () {
+    var result = eachDayOfInterval({
+      start: new Date(Date.UTC(2014, 9 /* Oct */, 6, 14)),
+      end: new Date(Date.UTC(2014, 9 /* Oct */, 6, 14))
+    })
+    assert.deepEqual(result, [
+      new Date(Date.UTC(2014, 9 /* Oct */, 6))
+    ])
+  })
+
+  it('throws an exception if the start date is after the end date', function () {
+    var block = eachDayOfInterval.bind(
+      null,
+      {
+        start: new Date(Date.UTC(2014, 9 /* Oct */, 12)),
+        end: new Date(Date.UTC(2014, 9 /* Oct */, 6))
+      }
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the start date is `Invalid Date`', function () {
+    var block = eachDayOfInterval.bind(
+      null,
+      {
+        start: new Date(NaN),
+        end: new Date(Date.UTC(2014, 9 /* Oct */, 6))
+      }
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the end date is `Invalid Date`', function () {
+    var block = eachDayOfInterval.bind(
+      null,
+      {
+        start: new Date(Date.UTC(2014, 9 /* Oct */, 12)),
+        end: new Date(NaN)
+      }
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the interval is undefined', function () {
+    var block = eachDayOfInterval.bind(
+      null,
+      // $ExpectedMistake
+      undefined
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = eachDayOfInterval.bind(null, {
+      start: new Date(Date.UTC(2014, 9 /* Oct */, 6)),
+      end: new Date(Date.UTC(2014, 9 /* Oct */, 12))
+    // $ExpectedMistake
+    }, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(eachDayOfInterval.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfDay/index.js
+++ b/src/utc/endOfDay/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfDay
+ * @category Day Helpers
+ * @summary Return the end of a day for the given date.
+ *
+ * @description
+ * Return the end of a day for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of a day
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of a day for 2 September 2014 11:55:00:
+ * var result = endOfDay(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Sep 02 2014 23:59:59.999
+ */
+export default function endOfDay (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCHours(23, 59, 59, 999)
+  return date
+}

--- a/src/utc/endOfDay/test.js
+++ b/src/utc/endOfDay/test.js
@@ -1,0 +1,53 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfDay from '.'
+
+describe('utc/endOfDay', function () {
+  it('returns the date with the time setted to 23:59:59.999', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfDay(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = endOfDay(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = endOfDay(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2, 23, 59, 59, 999))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    endOfDay(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfDay(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = endOfDay.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfDay.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfHour/index.js
+++ b/src/utc/endOfHour/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfHour
+ * @category Hour Helpers
+ * @summary Return the end of an hour for the given date.
+ *
+ * @description
+ * Return the end of an hour for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of an hour
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of an hour for 2 September 2014 11:55:00:
+ * var result = endOfHour(new Date(Date.UTC(2014, 8, 2, 11, 55)))
+ * //=> Tue Sep 02 2014 11:59:59.999
+ */
+export default function endOfHour (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCMinutes(59, 59, 999)
+  return date
+}

--- a/src/utc/endOfHour/test.js
+++ b/src/utc/endOfHour/test.js
@@ -1,0 +1,46 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfHour from '.'
+
+describe('utc/endOfHour', function () {
+  it('returns the date with the time setted to the last millisecond before an hour ends', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15))
+    var result = endOfHour(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 22, 59, 59, 999)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 13)).toISOString()
+    var result = endOfHour(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 13, 59, 59, 999)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = endOfHour(Date.UTC(2014, 11, 1, 22, 15))
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 22, 59, 59, 999)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15))
+    endOfHour(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 11, 1, 22, 15)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfHour(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15))
+    // $ExpectedMistake
+    var block = endOfHour.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfHour.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfISOWeek/index.js
+++ b/src/utc/endOfISOWeek/index.js
@@ -1,0 +1,35 @@
+import endOfWeek from '../endOfWeek/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+
+/**
+ * @name endOfISOWeek
+ * @category ISO Week Helpers
+ * @summary Return the end of an ISO week for the given date.
+ *
+ * @description
+ * Return the end of an ISO week for the given date.
+ * The result will be in the local timezone.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of an ISO week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of an ISO week for 2 September 2014 11:55:00:
+ * var result = endOfISOWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Sun Sep 07 2014 23:59:59.999
+ */
+export default function endOfISOWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var endOfWeekOptions = cloneObject(dirtyOptions)
+  endOfWeekOptions.weekStartsOn = 1
+  return endOfWeek(dirtyDate, endOfWeekOptions)
+}

--- a/src/utc/endOfISOWeek/test.js
+++ b/src/utc/endOfISOWeek/test.js
@@ -1,0 +1,53 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfISOWeek from '.'
+
+describe('utc/endOfISOWeek', function () {
+  it('returns the date with the time setted to 23:59:59:999 and the date setted to the last day of an ISO week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfISOWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2, 11, 55, 0)).toISOString()
+    var result = endOfISOWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 6 /* Jul */, 6, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 1 /* Feb */, 11, 11, 55, 0)
+    var result = endOfISOWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 1 /* Feb */, 16, 23, 59, 59, 999))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    endOfISOWeek(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfISOWeek(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = endOfISOWeek.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfISOWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfISOWeekYear/index.js
+++ b/src/utc/endOfISOWeekYear/index.js
@@ -1,0 +1,40 @@
+import getISOWeekYear from '../getISOWeekYear/index.js'
+import startOfISOWeek from '../startOfISOWeek/index.js'
+
+/**
+ * @name endOfISOWeekYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Return the end of an ISO week-numbering year for the given date.
+ *
+ * @description
+ * Return the end of an ISO week-numbering year,
+ * which always starts 3 days before the year's first Thursday.
+ * The result will be in the local timezone.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of an ISO week-numbering year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of an ISO week-numbering year for 2 July 2005:
+ * var result = endOfISOWeekYear(new Date(Date.UTC(2005, 6, 2)))
+ * //=> Sun Jan 01 2006 23:59:59.999
+ */
+export default function endOfISOWeekYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var year = getISOWeekYear(dirtyDate, dirtyOptions)
+  var fourthOfJanuaryOfNextYear = new Date(0)
+  fourthOfJanuaryOfNextYear.setUTCFullYear(year + 1, 0, 4)
+  fourthOfJanuaryOfNextYear.setUTCHours(0, 0, 0, 0)
+  var date = startOfISOWeek(fourthOfJanuaryOfNextYear, dirtyOptions)
+  date.setUTCMilliseconds(date.getUTCMilliseconds() - 1)
+  return date
+}

--- a/src/utc/endOfISOWeekYear/test.js
+++ b/src/utc/endOfISOWeekYear/test.js
@@ -1,0 +1,54 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfISOWeekYear from '.'
+
+describe('utc/endOfISOWeekYear', function () {
+  it('returns the date with the time setted to 23:59:59.999 and the date setted to the last day of an ISO year', function () {
+    var result = endOfISOWeekYear(new Date(Date.UTC(2009, 0 /* Jan */, 1, 16, 0)))
+    assert.deepEqual(result, new Date(Date.UTC(2010, 0 /* Jan */, 3, 23, 59, 59, 999)))
+  })
+
+  it('accepts a string', function () {
+    var result = endOfISOWeekYear(new Date(Date.UTC(2005, 0 /* Jan */, 1, 6, 0)).toISOString())
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 2, 23, 59, 59, 999)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = endOfISOWeekYear(Date.UTC(2005, 0 /* Jan */, 1, 6, 0))
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 2, 23, 59, 59, 999)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    endOfISOWeekYear(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(5, 0 /* Jan */, 4)
+    initialDate.setUTCHours(16, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(6, 0 /* Jan */, 1)
+    expectedResult.setUTCHours(23, 59, 59, 999)
+    var result = endOfISOWeekYear(initialDate)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfISOWeekYear(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = endOfISOWeekYear.bind(null, new Date(Date.UTC(2009, 0 /* Jan */, 1, 16, 0)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfISOWeekYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfMinute/index.js
+++ b/src/utc/endOfMinute/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfMinute
+ * @category Minute Helpers
+ * @summary Return the end of a minute for the given date.
+ *
+ * @description
+ * Return the end of a minute for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of a minute
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of a minute for 1 December 2014 22:15:45.400:
+ * var result = endOfMinute(new Date(Date.UTC(2014, 11, 1, 22, 15, 45, 400)))
+ * //=> Mon Dec 01 2014 22:15:59.999
+ */
+export default function endOfMinute (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCSeconds(59, 999)
+  return date
+}

--- a/src/utc/endOfMinute/test.js
+++ b/src/utc/endOfMinute/test.js
@@ -1,0 +1,45 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfMinute from '.'
+
+describe('utc/endOfMinute', function () {
+  it('returns the date with the time setted to the last millisecond before a minute ends', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15))
+    var result = endOfMinute(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 22, 15, 59, 999)))
+  })
+
+  it('accepts a string', function () {
+    var result = endOfMinute('2014-12-01T13:00:00.000Z')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 13, 0, 59, 999)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = endOfMinute(Date.UTC(2014, 11, 1, 22, 15))
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 22, 15, 59, 999)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15))
+    endOfMinute(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 11, 1, 22, 15)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfMinute(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15))
+    // $ExpectedMistake
+    var block = endOfMinute.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfMinute.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfMonth/index.js
+++ b/src/utc/endOfMonth/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfMonth
+ * @category Month Helpers
+ * @summary Return the end of a month for the given date.
+ *
+ * @description
+ * Return the end of a month for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of a month for 2 September 2014 11:55:00:
+ * var result = endOfMonth(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Sep 30 2014 23:59:59.999
+ */
+export default function endOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var month = date.getUTCMonth()
+  date.setUTCFullYear(date.getUTCFullYear(), month + 1, 0)
+  date.setUTCHours(23, 59, 59, 999)
+  return date
+}

--- a/src/utc/endOfMonth/test.js
+++ b/src/utc/endOfMonth/test.js
@@ -1,0 +1,71 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfMonth from '.'
+
+describe('utc/endOfMonth', function () {
+  it('returns the date with the time setted to 23:59:59.999 and the date setted to the last day of a month', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfMonth(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 30, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = endOfMonth(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 30, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = endOfMonth(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 30, 23, 59, 59, 999))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    endOfMonth(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  describe('edge cases', function () {
+    it('works for last month in year', function () {
+      var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 0, 0, 0))
+      var result = endOfMonth(date)
+      assert.deepEqual(result,
+        new Date(Date.UTC(2014, 11 /* Dec */, 31, 23, 59, 59, 999))
+      )
+    })
+
+    it('works for last day of month', function () {
+      var date = new Date(Date.UTC(2014, 9 /* Oct */, 31))
+      var result = endOfMonth(date)
+      assert.deepEqual(result,
+        new Date(Date.UTC(2014, 9 /* Oct */, 31, 23, 59, 59, 999))
+      )
+    })
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfMonth(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = endOfMonth.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfQuarter/index.js
+++ b/src/utc/endOfQuarter/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfQuarter
+ * @category Quarter Helpers
+ * @summary Return the end of a year quarter for the given date.
+ *
+ * @description
+ * Return the end of a year quarter for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of a quarter
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of a quarter for 2 September 2014 11:55:00:
+ * var result = endOfQuarter(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Sep 30 2014 23:59:59.999
+ */
+export default function endOfQuarter (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var currentMonth = date.getUTCMonth()
+  var month = currentMonth - currentMonth % 3 + 3
+  date.setUTCMonth(month, 0)
+  date.setUTCHours(23, 59, 59, 999)
+  return date
+}

--- a/src/utc/endOfQuarter/test.js
+++ b/src/utc/endOfQuarter/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfQuarter from '.'
+
+describe('utc/endOfQuarter', function () {
+  it('returns the date with the time setted to 23:59:59.999 and the date setted to the last day of a quarter', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30, 23, 59, 59, 999)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 0 /* Jan */, 1, 11, 55, 0)).toISOString()
+    var result = endOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 2 /* Mar */, 31, 23, 59, 59, 999)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = endOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30, 23, 59, 59, 999)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    endOfQuarter(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfQuarter(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = endOfQuarter.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfQuarter.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfSecond/index.js
+++ b/src/utc/endOfSecond/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfSecond
+ * @category Second Helpers
+ * @summary Return the end of a second for the given date.
+ *
+ * @description
+ * Return the end of a second for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of a second
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of a second for 1 December 2014 22:15:45.400:
+ * var result = endOfSecond(new Date(Date.UTC(2014, 11, 1, 22, 15, 45, 400)))
+ * //=> Mon Dec 01 2014 22:15:45.999
+ */
+export default function endOfSecond (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCMilliseconds(999)
+  return date
+}

--- a/src/utc/endOfSecond/test.js
+++ b/src/utc/endOfSecond/test.js
@@ -1,0 +1,45 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfSecond from '.'
+
+describe('utc/endOfSecond', function () {
+  it('returns the date with the time setted to the last millisecond before a second ends', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15, 30))
+    var result = endOfSecond(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 22, 15, 30, 999)))
+  })
+
+  it('accepts a string', function () {
+    var result = endOfSecond('2014-12-01T13:00:00.000Z')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 13, 0, 0, 999)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = endOfSecond(Date.UTC(2014, 11, 1, 22, 15, 45))
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 22, 15, 45, 999)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15, 15, 300))
+    endOfSecond(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 11, 1, 22, 15, 15, 300)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfSecond(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 11, 1, 22, 15, 30))
+    // $ExpectedMistake
+    var block = endOfSecond.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfSecond.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfWeek/index.js
+++ b/src/utc/endOfWeek/index.js
@@ -1,0 +1,56 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfWeek
+ * @category Week Helpers
+ * @summary Return the end of a week for the given date.
+ *
+ * @description
+ * Return the end of a week for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Date} the end of a week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // The end of a week for 2 September 2014 11:55:00:
+ * var result = endOfWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Sat Sep 06 2014 23:59:59.999
+ *
+ * @example
+ * // If the week starts on Monday, the end of the week for 2 September 2014 11:55:00:
+ * var result = endOfWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)), {weekStartsOn: 1})
+ * //=> Sun Sep 07 2014 23:59:59.999
+ */
+export default function endOfWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var date = toDate(dirtyDate, options)
+  var day = date.getUTCDay()
+  var diff = (day < weekStartsOn ? -7 : 0) + 6 - (day - weekStartsOn)
+
+  date.setUTCDate(date.getUTCDate() + diff)
+  date.setUTCHours(23, 59, 59, 999)
+  return date
+}

--- a/src/utc/endOfWeek/test.js
+++ b/src/utc/endOfWeek/test.js
@@ -1,0 +1,141 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfWeek from '.'
+
+describe('utc/endOfWeek', function () {
+  it('returns the date with the time setted to 23:59:59:999 and the date setted to the last day of a week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 6, 23, 59, 59, 999))
+    )
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfWeek(date, {weekStartsOn: 1})
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7, 23, 59, 59, 999))
+    )
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfWeek(
+      date,
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7, 23, 59, 59, 999))
+    )
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfWeek(
+      date,
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7, 23, 59, 59, 999))
+    )
+  })
+
+  it('implicitly converts options', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var result = endOfWeek(date, {weekStartsOn: '1'})
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = endOfWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 6, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = endOfWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 6, 23, 59, 59, 999))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    endOfWeek(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  describe('edge cases', function () {
+    context('when the given day is before the start of a week', function () {
+      it('it returns the end of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 6))
+        var result = endOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 7, 23, 59, 59, 999)))
+      })
+    })
+
+    context('when the given day is the start of a week', function () {
+      it('it returns the end of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 8))
+        var result = endOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 14, 23, 59, 59, 999)))
+      })
+    })
+
+    context('when the given day is after the start of a week', function () {
+      it('it returns the end of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 10))
+        var result = endOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 14, 23, 59, 59, 999)))
+      })
+    })
+
+    it('handles the week at the end of a year', function () {
+      var date = new Date(Date.UTC(2014, 11 /* Dec */, 29))
+      var result = endOfWeek(date, {weekStartsOn: 5})
+      assert.deepEqual(result, new Date(Date.UTC(2015, 0 /* Jan */, 1, 23, 59, 59, 999)))
+    })
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfWeek(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // $ExpectedMistake
+    var block = endOfWeek.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)), {weekStartsOn: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = endOfWeek.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/endOfYear/index.js
+++ b/src/utc/endOfYear/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name endOfYear
+ * @category Year Helpers
+ * @summary Return the end of a year for the given date.
+ *
+ * @description
+ * Return the end of a year for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of a year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The end of a year for 2 September 2014 11:55:00:
+ * var result = endOfYear(new Date(Date.UTC(2014, 8, 2, 11, 55, 00)))
+ * //=> Wed Dec 31 2014 23:59:59.999
+ */
+export default function endOfYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = date.getUTCFullYear()
+  date.setUTCFullYear(year + 1, 0, 0)
+  date.setUTCHours(23, 59, 59, 999)
+  return date
+}

--- a/src/utc/endOfYear/test.js
+++ b/src/utc/endOfYear/test.js
@@ -1,0 +1,53 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import endOfYear from '.'
+
+describe('utc/endOfYear', function () {
+  it('returns the date with the time setted to 23:59:59.999 and the date setted to the last day of a year', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = endOfYear(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = endOfYear(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31, 23, 59, 59, 999))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = endOfYear(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31, 23, 59, 59, 999))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    endOfYear(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = endOfYear(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = endOfYear.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(endOfYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/format/_lib/formatters/index.js
+++ b/src/utc/format/_lib/formatters/index.js
@@ -1,0 +1,257 @@
+import getDayOfYear from '../../../getDayOfYear/index.js'
+import getISOWeek from '../../../getISOWeek/index.js'
+import getISOWeekYear from '../../../getISOWeekYear/index.js'
+
+var formatters = {
+  // Month: 1, 2, ..., 12
+  'M': function (date) {
+    return date.getUTCMonth() + 1
+  },
+
+  // Month: 1st, 2nd, ..., 12th
+  'Mo': function (date, options) {
+    var month = date.getUTCMonth() + 1
+    return options.locale.localize.ordinalNumber(month, {unit: 'month'})
+  },
+
+  // Month: 01, 02, ..., 12
+  'MM': function (date) {
+    return addLeadingZeros(date.getUTCMonth() + 1, 2)
+  },
+
+  // Month: Jan, Feb, ..., Dec
+  'MMM': function (date, options) {
+    return options.locale.localize.month(date.getUTCMonth(), {type: 'short'})
+  },
+
+  // Month: January, February, ..., December
+  'MMMM': function (date, options) {
+    return options.locale.localize.month(date.getUTCMonth(), {type: 'long'})
+  },
+
+  // Quarter: 1, 2, 3, 4
+  'Q': function (date) {
+    return Math.ceil((date.getUTCMonth() + 1) / 3)
+  },
+
+  // Quarter: 1st, 2nd, 3rd, 4th
+  'Qo': function (date, options) {
+    var quarter = Math.ceil((date.getUTCMonth() + 1) / 3)
+    return options.locale.localize.ordinalNumber(quarter, {unit: 'quarter'})
+  },
+
+  // Day of month: 1, 2, ..., 31
+  'D': function (date) {
+    return date.getUTCDate()
+  },
+
+  // Day of month: 1st, 2nd, ..., 31st
+  'Do': function (date, options) {
+    return options.locale.localize.ordinalNumber(date.getUTCDate(), {unit: 'dayOfMonth'})
+  },
+
+  // Day of month: 01, 02, ..., 31
+  'DD': function (date) {
+    return addLeadingZeros(date.getUTCDate(), 2)
+  },
+
+  // Day of year: 1, 2, ..., 366
+  'DDD': function (date) {
+    return getDayOfYear(date)
+  },
+
+  // Day of year: 1st, 2nd, ..., 366th
+  'DDDo': function (date, options) {
+    return options.locale.localize.ordinalNumber(getDayOfYear(date), {unit: 'dayOfYear'})
+  },
+
+  // Day of year: 001, 002, ..., 366
+  'DDDD': function (date) {
+    return addLeadingZeros(getDayOfYear(date), 3)
+  },
+
+  // Day of week: Su, Mo, ..., Sa
+  'dd': function (date, options) {
+    return options.locale.localize.weekday(date.getUTCDay(), {type: 'narrow'})
+  },
+
+  // Day of week: Sun, Mon, ..., Sat
+  'ddd': function (date, options) {
+    return options.locale.localize.weekday(date.getUTCDay(), {type: 'short'})
+  },
+
+  // Day of week: Sunday, Monday, ..., Saturday
+  'dddd': function (date, options) {
+    return options.locale.localize.weekday(date.getUTCDay(), {type: 'long'})
+  },
+
+  // Day of week: 0, 1, ..., 6
+  'd': function (date) {
+    return date.getUTCDay()
+  },
+
+  // Day of week: 0th, 1st, 2nd, ..., 6th
+  'do': function (date, options) {
+    return options.locale.localize.ordinalNumber(date.getUTCDay(), {unit: 'dayOfWeek'})
+  },
+
+  // Day of ISO week: 1, 2, ..., 7
+  'E': function (date) {
+    return date.getUTCDay() || 7
+  },
+
+  // ISO week: 1, 2, ..., 53
+  'W': function (date) {
+    return getISOWeek(date)
+  },
+
+  // ISO week: 1st, 2nd, ..., 53th
+  'Wo': function (date, options) {
+    return options.locale.localize.ordinalNumber(getISOWeek(date), {unit: 'isoWeek'})
+  },
+
+  // ISO week: 01, 02, ..., 53
+  'WW': function (date) {
+    return addLeadingZeros(getISOWeek(date), 2)
+  },
+
+  // Year: 00, 01, ..., 99
+  'YY': function (date) {
+    return addLeadingZeros(date.getUTCFullYear(), 4).substr(2)
+  },
+
+  // Year: 1900, 1901, ..., 2099
+  'YYYY': function (date) {
+    return addLeadingZeros(date.getUTCFullYear(), 4)
+  },
+
+  // ISO week-numbering year: 00, 01, ..., 99
+  'GG': function (date) {
+    return String(getISOWeekYear(date)).substr(2)
+  },
+
+  // ISO week-numbering year: 1900, 1901, ..., 2099
+  'GGGG': function (date) {
+    return getISOWeekYear(date)
+  },
+
+  // Hour: 0, 1, ... 23
+  'H': function (date) {
+    return date.getUTCHours()
+  },
+
+  // Hour: 00, 01, ..., 23
+  'HH': function (date) {
+    return addLeadingZeros(date.getUTCHours(), 2)
+  },
+
+  // Hour: 1, 2, ..., 12
+  'h': function (date) {
+    var hours = date.getUTCHours()
+    if (hours === 0) {
+      return 12
+    } else if (hours > 12) {
+      return hours % 12
+    } else {
+      return hours
+    }
+  },
+
+  // Hour: 01, 02, ..., 12
+  'hh': function (date) {
+    return addLeadingZeros(formatters['h'](date), 2)
+  },
+
+  // Minute: 0, 1, ..., 59
+  'm': function (date) {
+    return date.getUTCMinutes()
+  },
+
+  // Minute: 00, 01, ..., 59
+  'mm': function (date) {
+    return addLeadingZeros(date.getUTCMinutes(), 2)
+  },
+
+  // Second: 0, 1, ..., 59
+  's': function (date) {
+    return date.getUTCSeconds()
+  },
+
+  // Second: 00, 01, ..., 59
+  'ss': function (date) {
+    return addLeadingZeros(date.getUTCSeconds(), 2)
+  },
+
+  // 1/10 of second: 0, 1, ..., 9
+  'S': function (date) {
+    return Math.floor(date.getUTCMilliseconds() / 100)
+  },
+
+  // 1/100 of second: 00, 01, ..., 99
+  'SS': function (date) {
+    return addLeadingZeros(Math.floor(date.getUTCMilliseconds() / 10), 2)
+  },
+
+  // Millisecond: 000, 001, ..., 999
+  'SSS': function (date) {
+    return addLeadingZeros(date.getUTCMilliseconds(), 3)
+  },
+
+  // Timezone: -01:00, +00:00, ... +12:00
+  'Z': function (date, options) {
+    var originalDate = options._originalDate || date
+    return formatTimezone(originalDate.getTimezoneOffset(), ':')
+  },
+
+  // Timezone: -0100, +0000, ... +1200
+  'ZZ': function (date, options) {
+    var originalDate = options._originalDate || date
+    return formatTimezone(originalDate.getTimezoneOffset())
+  },
+
+  // Seconds timestamp: 512969520
+  'X': function (date, options) {
+    var originalDate = options._originalDate || date
+    return Math.floor(originalDate.getTime() / 1000)
+  },
+
+  // Milliseconds timestamp: 512969520900
+  'x': function (date, options) {
+    var originalDate = options._originalDate || date
+    return originalDate.getTime()
+  },
+
+  // AM, PM
+  'A': function (date, options) {
+    return options.locale.localize.timeOfDay(date.getUTCHours(), {type: 'uppercase'})
+  },
+
+  // am, pm
+  'a': function (date, options) {
+    return options.locale.localize.timeOfDay(date.getUTCHours(), {type: 'lowercase'})
+  },
+
+  // a.m., p.m.
+  'aa': function (date, options) {
+    return options.locale.localize.timeOfDay(date.getUTCHours(), {type: 'long'})
+  }
+}
+
+function formatTimezone (offset, delimeter) {
+  delimeter = delimeter || ''
+  var sign = offset > 0 ? '-' : '+'
+  var absOffset = Math.abs(offset)
+  var hours = Math.floor(absOffset / 60)
+  var minutes = absOffset % 60
+  return sign + addLeadingZeros(hours, 2) + delimeter + addLeadingZeros(minutes, 2)
+}
+
+function addLeadingZeros (number, targetLength) {
+  var output = Math.abs(number).toString()
+  while (output.length < targetLength) {
+    output = '0' + output
+  }
+  return output
+}
+
+export default formatters

--- a/src/utc/format/index.js
+++ b/src/utc/format/index.js
@@ -3,7 +3,6 @@ import isValid from '../isValid/index.js'
 import defaultLocale from '../../locale/en-US/index.js'
 import formatters from './_lib/formatters/index.js'
 import cloneObject from '../../_lib/cloneObject/index.js'
-import addMinutes from '../addMinutes/index.js'
 
 var longFormattingTokensRegExp = /(\[[^[]*])|(\\)?(LTS|LT|LLLL|LLL|LL|L|llll|lll|ll|l)/g
 var defaultFormattingTokensRegExp = /(\[[^[]*])|(\\)?(x|ss|s|mm|m|hh|h|do|dddd|ddd|dd|d|aa|a|ZZ|Z|YYYY|YY|X|Wo|WW|W|SSS|SS|S|Qo|Q|Mo|MMMM|MMM|MM|M|HH|H|GGGG|GG|E|Do|DDDo|DDDD|DDD|DD|D|A|.)/g
@@ -129,17 +128,11 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   var formattingTokensRegExp = locale.formattingTokensRegExp || defaultFormattingTokensRegExp
   var formatLong = locale.formatLong
 
-  var originalDate = toDate(dirtyDate, options)
+  var date = toDate(dirtyDate, options)
 
-  if (!isValid(originalDate, options)) {
+  if (!isValid(date, options)) {
     return 'Invalid Date'
   }
-
-  // Convert the date in system timezone to the same date in UTC+00:00 timezone.
-  // This ensures that when UTC functions will be implemented, locales will be compatible with them.
-  // See an issue about UTC functions: https://github.com/date-fns/date-fns/issues/376
-  var timezoneOffset = originalDate.getTimezoneOffset()
-  var utcDate = addMinutes(originalDate, -timezoneOffset, options)
 
   var formatterOptions = cloneObject(options)
   formatterOptions.locale = locale
@@ -148,7 +141,7 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   // When UTC functions will be implemented, options._originalDate will likely be a part of public API.
   // Right now, please don't use it in locales. If you have to use an original date,
   // please restore it from `date`, adding a timezone offset to it.
-  formatterOptions._originalDate = originalDate
+  formatterOptions._originalDate = date
 
   var result = formatStr
     .replace(longFormattingTokensRegExp, function (substring) {
@@ -166,7 +159,7 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
       var formatter = localeFormatters[substring] || formatters[substring]
 
       if (formatter) {
-        return formatter(utcDate, formatterOptions)
+        return formatter(date, formatterOptions)
       } else {
         return cleanEscapedString(substring)
       }

--- a/src/utc/format/index.js
+++ b/src/utc/format/index.js
@@ -1,0 +1,183 @@
+import toDate from '../toDate/index.js'
+import isValid from '../isValid/index.js'
+import defaultLocale from '../../locale/en-US/index.js'
+import formatters from './_lib/formatters/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+import addMinutes from '../addMinutes/index.js'
+
+var longFormattingTokensRegExp = /(\[[^[]*])|(\\)?(LTS|LT|LLLL|LLL|LL|L|llll|lll|ll|l)/g
+var defaultFormattingTokensRegExp = /(\[[^[]*])|(\\)?(x|ss|s|mm|m|hh|h|do|dddd|ddd|dd|d|aa|a|ZZ|Z|YYYY|YY|X|Wo|WW|W|SSS|SS|S|Qo|Q|Mo|MMMM|MMM|MM|M|HH|H|GGGG|GG|E|Do|DDDo|DDDD|DDD|DD|D|A|.)/g
+
+/**
+ * @name format
+ * @category Common Helpers
+ * @summary Format the date.
+ *
+ * @description
+ * Return the formatted date string in the given format.
+ *
+ * Accepted tokens:
+ * | Unit                    | Token | Result examples                  |
+ * |-------------------------|-------|----------------------------------|
+ * | Month                   | M     | 1, 2, ..., 12                    |
+ * |                         | Mo    | 1st, 2nd, ..., 12th              |
+ * |                         | MM    | 01, 02, ..., 12                  |
+ * |                         | MMM   | Jan, Feb, ..., Dec               |
+ * |                         | MMMM  | January, February, ..., December |
+ * | Quarter                 | Q     | 1, 2, 3, 4                       |
+ * |                         | Qo    | 1st, 2nd, 3rd, 4th               |
+ * | Day of month            | D     | 1, 2, ..., 31                    |
+ * |                         | Do    | 1st, 2nd, ..., 31st              |
+ * |                         | DD    | 01, 02, ..., 31                  |
+ * | Day of year             | DDD   | 1, 2, ..., 366                   |
+ * |                         | DDDo  | 1st, 2nd, ..., 366th             |
+ * |                         | DDDD  | 001, 002, ..., 366               |
+ * | Day of week             | d     | 0, 1, ..., 6                     |
+ * |                         | do    | 0th, 1st, ..., 6th               |
+ * |                         | dd    | Su, Mo, ..., Sa                  |
+ * |                         | ddd   | Sun, Mon, ..., Sat               |
+ * |                         | dddd  | Sunday, Monday, ..., Saturday    |
+ * | Day of ISO week         | E     | 1, 2, ..., 7                     |
+ * | ISO week                | W     | 1, 2, ..., 53                    |
+ * |                         | Wo    | 1st, 2nd, ..., 53rd              |
+ * |                         | WW    | 01, 02, ..., 53                  |
+ * | Year                    | YY    | 00, 01, ..., 99                  |
+ * |                         | YYYY  | 1900, 1901, ..., 2099            |
+ * | ISO week-numbering year | GG    | 00, 01, ..., 99                  |
+ * |                         | GGGG  | 1900, 1901, ..., 2099            |
+ * | AM/PM                   | A     | AM, PM                           |
+ * |                         | a     | am, pm                           |
+ * |                         | aa    | a.m., p.m.                       |
+ * | Hour                    | H     | 0, 1, ... 23                     |
+ * |                         | HH    | 00, 01, ... 23                   |
+ * |                         | h     | 1, 2, ..., 12                    |
+ * |                         | hh    | 01, 02, ..., 12                  |
+ * | Minute                  | m     | 0, 1, ..., 59                    |
+ * |                         | mm    | 00, 01, ..., 59                  |
+ * | Second                  | s     | 0, 1, ..., 59                    |
+ * |                         | ss    | 00, 01, ..., 59                  |
+ * | 1/10 of second          | S     | 0, 1, ..., 9                     |
+ * | 1/100 of second         | SS    | 00, 01, ..., 99                  |
+ * | Millisecond             | SSS   | 000, 001, ..., 999               |
+ * | Timezone                | Z     | -01:00, +00:00, ... +12:00       |
+ * |                         | ZZ    | -0100, +0000, ..., +1200         |
+ * | Seconds timestamp       | X     | 512969520                        |
+ * | Milliseconds timestamp  | x     | 512969520900                     |
+ * | Long format             | LT    | 05:30 a.m.                       |
+ * |                         | LTS   | 05:30:15 a.m.                    |
+ * |                         | L     | 07/02/1995                       |
+ * |                         | l     | 7/2/1995                         |
+ * |                         | LL    | July 2 1995                      |
+ * |                         | ll    | Jul 2 1995                       |
+ * |                         | LLL   | July 2 1995 05:30 a.m.           |
+ * |                         | lll   | Jul 2 1995 05:30 a.m.            |
+ * |                         | LLLL  | Sunday, July 2 1995 05:30 a.m.   |
+ * |                         | llll  | Sun, Jul 2 1995 05:30 a.m.       |
+ *
+ * The characters wrapped in square brackets are escaped.
+ *
+ * The result may vary by locale.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {String} format - the string of tokens
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {String} the formatted date string
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.locale` must contain `localize` property
+ * @throws {RangeError} `options.locale` must contain `formatLong` property
+ *
+ * @example
+ * // Represent 11 February 2014 in middle-endian format:
+ * var result = format(
+ *   new Date(Date.UTC(2014, 1, 11)),
+ *   'MM/DD/YYYY'
+ * )
+ * //=> '02/11/2014'
+ *
+ * @example
+ * // Represent 2 July 2014 in Esperanto:
+ * import { eoLocale } from 'date-fns/locale/eo'
+ * var result = format(
+ *   new Date(Date.UTC(2014, 6, 2)),
+ *   'Do [de] MMMM YYYY',
+ *   {locale: eoLocale}
+ * )
+ * //=> '2-a de julio 2014'
+ */
+export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var formatStr = String(dirtyFormatStr)
+  var options = dirtyOptions || {}
+
+  var locale = options.locale || defaultLocale
+
+  if (!locale.localize) {
+    throw new RangeError('locale must contain localize property')
+  }
+
+  if (!locale.formatLong) {
+    throw new RangeError('locale must contain formatLong property')
+  }
+
+  var localeFormatters = locale.formatters || {}
+  var formattingTokensRegExp = locale.formattingTokensRegExp || defaultFormattingTokensRegExp
+  var formatLong = locale.formatLong
+
+  var originalDate = toDate(dirtyDate, options)
+
+  if (!isValid(originalDate, options)) {
+    return 'Invalid Date'
+  }
+
+  // Convert the date in system timezone to the same date in UTC+00:00 timezone.
+  // This ensures that when UTC functions will be implemented, locales will be compatible with them.
+  // See an issue about UTC functions: https://github.com/date-fns/date-fns/issues/376
+  var timezoneOffset = originalDate.getTimezoneOffset()
+  var utcDate = addMinutes(originalDate, -timezoneOffset, options)
+
+  var formatterOptions = cloneObject(options)
+  formatterOptions.locale = locale
+  formatterOptions.formatters = formatters
+
+  // When UTC functions will be implemented, options._originalDate will likely be a part of public API.
+  // Right now, please don't use it in locales. If you have to use an original date,
+  // please restore it from `date`, adding a timezone offset to it.
+  formatterOptions._originalDate = originalDate
+
+  var result = formatStr
+    .replace(longFormattingTokensRegExp, function (substring) {
+      if (substring[0] === '[') {
+        return substring
+      }
+
+      if (substring[0] === '\\') {
+        return cleanEscapedString(substring)
+      }
+
+      return formatLong(substring)
+    })
+    .replace(formattingTokensRegExp, function (substring) {
+      var formatter = localeFormatters[substring] || formatters[substring]
+
+      if (formatter) {
+        return formatter(utcDate, formatterOptions)
+      } else {
+        return cleanEscapedString(substring)
+      }
+    })
+
+  return result
+}
+
+function cleanEscapedString (input) {
+  if (input.match(/\[[\s\S]/)) {
+    return input.replace(/^\[|]$/g, '')
+  }
+  return input.replace(/\\/g, '')
+}

--- a/src/utc/format/test.js
+++ b/src/utc/format/test.js
@@ -1,0 +1,506 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import format from '.'
+
+describe('utc/format', function () {
+  var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 0, 900))
+
+  var offset = date.getTimezoneOffset()
+  var absoluteOffset = Math.abs(offset)
+  var hours = Math.floor(absoluteOffset / 60)
+  var hoursLeadingZero = hours < 10 ? '0' : ''
+  var minutes = absoluteOffset % 60
+  var minutesLeadingZero = minutes < 10 ? '0' : ''
+  var sign = offset > 0 ? '-' : '+'
+  var timezone = sign + hoursLeadingZero + hours + ':' + minutesLeadingZero + minutes
+  var timezoneShort = timezone.replace(':', '')
+
+  var timestamp = date.getTime().toString()
+  var secondsTimestamp = Math.floor(date.getTime() / 1000).toString()
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 3, 4)).toISOString()
+    assert(format(date, 'YYYY-MM-DD') === '2014-04-04')
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 3, 4)
+    assert(format(date, 'YYYY-MM-DD') === '2014-04-04')
+  })
+
+  it('escapes characters between the square brackets', function () {
+    var result = format(date, '[YYYY-]MM-DD[THH:mm:ss.SSSZ] YYYY-[MM-DD]')
+    assert(result === 'YYYY-04-04THH:mm:ss.SSSZ 1986-MM-DD')
+  })
+
+  describe('ordinal numbers', function () {
+    it('ordinal day of an ordinal month', function () {
+      var result = format(date, 'Do of t[h][e] Mo in YYYY')
+      assert(result === '4th of the 4th in 1986')
+    })
+
+    it('should return a correct ordinal number', function () {
+      var result = []
+      for (var i = 1; i <= 31; i++) {
+        result.push(format(new Date(Date.UTC(2015, 0, i)), 'Do'))
+      }
+      var expected = [
+        '1st', '2nd', '3rd', '4th', '5th', '6th', '7th', '8th', '9th', '10th',
+        '11th', '12th', '13th', '14th', '15th', '16th', '17th', '18th', '19th', '20th',
+        '21st', '22nd', '23rd', '24th', '25th', '26th', '27th', '28th', '29th', '30th', '31st'
+      ]
+      assert.deepEqual(result, expected)
+    })
+  })
+
+  describe('months', function () {
+    it('cardinal number', function () {
+      assert(format(date, 'M') === '4')
+    })
+
+    it('cardinal number with a leading zero', function () {
+      assert(format(date, 'MM') === '04')
+    })
+
+    it('ordinal number', function () {
+      assert(format(date, 'Mo') === '4th')
+    })
+
+    it('short name', function () {
+      assert(format(date, 'MMM') === 'Apr')
+    })
+
+    it('full name', function () {
+      assert(format(date, 'MMMM') === 'April')
+    })
+
+    it('all variants', function () {
+      var result = format(date, 'M Mo MM MMM MMMM')
+      assert(result === '4 4th 04 Apr April')
+    })
+  })
+
+  describe('quarters', function () {
+    it('returns a correct quarter', function () {
+      var result = []
+      for (var i = 0; i <= 11; i++) {
+        result.push(format(new Date(Date.UTC(1986, i, 1)), 'Q'))
+      }
+      var expected = ['1', '1', '1', '2', '2', '2', '3', '3', '3', '4', '4', '4']
+      assert.deepEqual(result, expected)
+    })
+
+    it('all variants', function () {
+      assert(format(date, 'Q Qo') === '2 2nd')
+    })
+  })
+
+  describe('days of a month', function () {
+    it('all variants', function () {
+      assert(format(date, 'D Do DD') === '4 4th 04')
+    })
+  })
+
+  describe('days of a year', function () {
+    context('for the first day of a year', function () {
+      it('returns a correct day number', function () {
+        var result = format(new Date(Date.UTC(1992, 0 /* Jan */, 1)), 'DDD')
+        assert(result === '1')
+      })
+    })
+
+    context('for the last day of a common year', function () {
+      it('returns a correct day number', function () {
+        var result = format(new Date(Date.UTC(1986, 11 /* Dec */, 31, 23, 59, 59, 999)), 'DDD')
+        assert(result === '365')
+      })
+    })
+
+    context('for the last day of a leap year', function () {
+      it('returns a correct day number', function () {
+        var result = format(new Date(Date.UTC(1992, 11 /* Dec */, 31, 23, 59, 59, 999)), 'DDD')
+        assert(result === '366')
+      })
+    })
+
+    it('ordinal number', function () {
+      var result = format(new Date(Date.UTC(1992, 0 /* Jan */, 1)), 'DDDo')
+      assert(result === '1st')
+    })
+
+    it('cardinal number with leading zeros', function () {
+      var result = format(new Date(Date.UTC(1992, 0 /* Jan */, 1)), 'DDDD')
+      assert(result === '001')
+    })
+  })
+
+  describe('days of a week', function () {
+    it('all variants', function () {
+      var result = format(date, 'd do dd ddd dddd')
+      assert(result === '5 5th Fr Fri Friday')
+    })
+  })
+
+  describe('days of an ISO week', function () {
+    it('returns a correct day of an ISO week', function () {
+      var result = []
+      for (var i = 1; i <= 7; i++) {
+        result.push(format(new Date(Date.UTC(1986, 8 /* Sep */, i)), 'E'))
+      }
+      var expected = ['1', '2', '3', '4', '5', '6', '7']
+      assert.deepEqual(result, expected)
+    })
+  })
+
+  describe('ISO weeks', function () {
+    it('cardinal number with a leading zero', function () {
+      var result = format(new Date(Date.UTC(1992, 0 /* Jan */, 5)), 'WW')
+      assert(result === '01')
+    })
+
+    it('all variants', function () {
+      var result = format(date, 'W Wo WW')
+      assert(result === '14 14th 14')
+    })
+  })
+
+  describe('years', function () {
+    it('all variants', function () {
+      var result = format(date, 'YY YYYY')
+      assert(result === '86 1986')
+    })
+
+    it('years less than 100', function () {
+      var result = format('0001-01-01', 'YY YYYY')
+      assert(result === '01 0001')
+    })
+  })
+
+  describe('ISO week-numbering years', function () {
+    it('the first week of the next year', function () {
+      var result = format(new Date(Date.UTC(2013, 11 /* Dec */, 30)), 'GGGG')
+      assert(result === '2014')
+    })
+
+    it('the last week of the previous year', function () {
+      var result = format(new Date(Date.UTC(2016, 0 /* Jan */, 1)), 'GGGG')
+      assert(result === '2015')
+    })
+
+    it('all variants', function () {
+      var result = format(date, 'GG GGGG')
+      assert(result === '86 1986')
+    })
+  })
+
+  describe('hours and am/pm', function () {
+    it('am/pm', function () {
+      assert(format(date, 'hh:mm a') === '10:32 am')
+    })
+
+    it('12 pm', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 900))
+      assert(format(date, 'hh:mm a') === '12:00 pm')
+    })
+
+    it('12 am', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 6, 0, 0, 0, 900))
+      assert(format(date, 'h:mm a') === '12:00 am')
+    })
+
+    it('12 a.m.', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 6, 0, 0, 0, 900))
+      assert(format(date, 'h:mm aa') === '12:00 a.m.')
+    })
+
+    it('12 p.m.', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 900))
+      assert(format(date, 'hh:mm aa') === '12:00 p.m.')
+    })
+
+    it('12PM', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 900))
+      assert(format(date, 'hh:mmA') === '12:00PM')
+    })
+
+    it('cardinal numbers with leading zeros', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 5, 0, 0, 900))
+      assert(format(date, 'HH hh') === '05 05')
+    })
+
+    it('all hour variants', function () {
+      assert(format(date, 'H HH h hh') === '10 10 10 10')
+    })
+  })
+
+  describe('minutes', function () {
+    it('cardinal number with a leading zero', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 900))
+      assert(format(date, 'mm') === '00')
+    })
+
+    it('all variants', function () {
+      assert(format(date, 'm mm') === '32 32')
+    })
+  })
+
+  describe('seconds', function () {
+    it('all variants', function () {
+      assert(format(date, 's ss') === '0 00')
+    })
+  })
+
+  describe('fractions of a second', function () {
+    it('1/10 of a second', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 859))
+      assert(format(date, 'S') === '8')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 0))
+      assert(format(date, 'S') === '0')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 1))
+      assert(format(date, 'S') === '0')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 10))
+      assert(format(date, 'S') === '0')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 100))
+      assert(format(date, 'S') === '1')
+    })
+
+    it('1/100 of a second', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 859))
+      assert(format(date, 'SS') === '85')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 0))
+      assert(format(date, 'SS') === '00')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 1))
+      assert(format(date, 'SS') === '00')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 10))
+      assert(format(date, 'SS') === '01')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 42))
+      assert(format(date, 'SS') === '04')
+    })
+
+    it('a millisecond', function () {
+      var date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 859))
+      assert(format(date, 'SSS') === '859')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 0))
+      assert(format(date, 'SSS') === '000')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 1))
+      assert(format(date, 'SSS') === '001')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 10))
+      assert(format(date, 'SSS') === '010')
+      date = new Date(Date.UTC(1986, 3 /* Apr */, 4, 12, 0, 0, 42))
+      assert(format(date, 'SSS') === '042')
+    })
+  })
+
+  describe('timezones', function () {
+    it('should toDate the given date in a local timezone', function () {
+      assert(format('2015-01-01', 'YYYY-MM-DD') === '2015-01-01')
+    })
+
+    it('all variants', function () {
+      var result = format(date, 'Z ZZ')
+      assert(result === timezone + ' ' + timezoneShort)
+    })
+  })
+
+  describe('timestamps', function () {
+    it('unix seconds timestamp', function () {
+      assert(format(date, 'X') === secondsTimestamp)
+    })
+
+    it('unix milliseconds timestamp', function () {
+      assert(format(date, 'x') === timestamp)
+    })
+  })
+
+  describe('long formats', function () {
+    it('LT', function () {
+      var result = format(date, 'LT')
+      assert(result === '10:32 a.m.')
+    })
+
+    it('LTS', function () {
+      var result = format(date, 'LTS')
+      assert(result === '10:32:00 a.m.')
+    })
+
+    it('L', function () {
+      var result = format(date, 'L')
+      assert(result === '04/04/1986')
+    })
+
+    it('l', function () {
+      var result = format(date, 'l')
+      assert(result === '4/4/1986')
+    })
+
+    it('LL', function () {
+      var result = format(date, 'LL')
+      assert(result === 'April 4 1986')
+    })
+
+    it('ll', function () {
+      var result = format(date, 'll')
+      assert(result === 'Apr 4 1986')
+    })
+
+    it('LLL', function () {
+      var result = format(date, 'LLL')
+      assert(result === 'April 4 1986 10:32 a.m.')
+    })
+
+    it('lll', function () {
+      var result = format(date, 'lll')
+      assert(result === 'Apr 4 1986 10:32 a.m.')
+    })
+
+    it('LLLL', function () {
+      var result = format(date, 'LLLL')
+      assert(result === 'Friday, April 4 1986 10:32 a.m.')
+    })
+
+    it('llll', function () {
+      var result = format(date, 'llll')
+      assert(result === 'Fri, Apr 4 1986 10:32 a.m.')
+    })
+  })
+
+  describe('edge cases', function () {
+    it("returns String('Invalid Date') if the date isn't valid", function () {
+      assert(format(new Date(NaN), 'MMMM D, YYYY') === 'Invalid Date')
+    })
+
+    it('handles dates before 100 AD', function () {
+      var initialDate = new Date(0)
+      initialDate.setUTCFullYear(7, 11 /* Dec */, 31)
+      initialDate.setUTCHours(0, 0, 0, 0)
+      assert(format(initialDate, 'GGGG WW E') === '8 01 1')
+    })
+  })
+
+  it('implicitly converts `formatString`', function () {
+    // eslint-disable-next-line no-new-wrappers
+    var formatString = new String('YYYY-MM-DD')
+
+    var date = new Date(Date.UTC(2014, 3, 4))
+
+    // $ExpectedMistake
+    assert(format(date, formatString) === '2014-04-04')
+  })
+
+  describe('custom locale', function () {
+    it('can be passed to the function', function () {
+      var formatters = {
+        'ABC': function (date) {
+          return 'It'
+        },
+
+        'EFG': function (date, options) {
+          return options.locale.localize.efg(date)
+        }
+      }
+
+      var localize = {
+        efg: function (date) {
+          return 'works'
+        }
+      }
+
+      var formattingTokensRegExp = /(\[[^[]*])|(\\)?(ABC|EFG|.)/g
+
+      var formatLong = function (token) {
+        if (token === 'LTS') {
+          return 'ABC'
+        } else {
+          return '[Nothing]'
+        }
+      }
+
+      var customLocale = {
+        // $ExpectedMistake
+        localize: localize,
+        formatLong: formatLong,
+        formatters: formatters,
+        formattingTokensRegExp: formattingTokensRegExp
+      }
+
+      // $ExpectedMistake
+      var result = format(date, 'LTS EFG [correctly!]', {locale: customLocale})
+      assert(result === 'It works correctly!')
+    })
+
+    context('does not contain `localize` property', function () {
+      it('throws `RangeError`', function () {
+        var customLocale = {formatLong: function () {}}
+        // $ExpectedMistake
+        var block = format.bind(null, date, 'MMMM', {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `formatLong` property', function () {
+      it('throws `RangeError`', function () {
+        // $ExpectedMistake
+        var customLocale = {localize: {}}
+        // $ExpectedMistake
+        var block = format.bind(null, date, 'MMMM', {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `format` property', function () {
+      it('works correctly', function () {
+        var localize = {
+          month: function (date) {
+            return 'foobar'
+          }
+        }
+        var customLocale = {localize: localize, formatLong: function () {}}
+        // $ExpectedMistake
+        assert(format(date, 'MMMM', {locale: customLocale}) === 'foobar')
+      })
+    })
+
+    context('does not contain `format.formattingTokensRegExp` property', function () {
+      it('uses default `formattingTokensRegExp`', function () {
+        var formatters = {
+          'MMMM': function (date, options) {
+            return options.locale.localize.month(date)
+          },
+
+          'YYYY': function (date) {
+            return 'works'
+          }
+        }
+
+        var localize = {
+          month: function (date) {
+            return 'It'
+          }
+        }
+
+        var customLocale = {
+          formatLong: function () {},
+          localize: localize,
+          formatters: formatters
+        }
+
+        // $ExpectedMistake
+        var result = format(date, 'MMMM YYYY [correctly!] GGGG', {locale: customLocale})
+        assert(result === 'It works correctly! 1986')
+      })
+    })
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = format.bind(null, date, 'Do of t[h][e] Mo in YYYY', {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(format.bind(null), TypeError)
+    assert.throws(format.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/formatDistance/index.js
+++ b/src/utc/formatDistance/index.js
@@ -1,0 +1,214 @@
+import compareAsc from '../compareAsc/index.js'
+import toDate from '../toDate/index.js'
+import differenceInSeconds from '../differenceInSeconds/index.js'
+import differenceInMonths from '../differenceInMonths/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+import defaultLocale from '../../locale/en-US/index.js'
+
+var MINUTES_IN_DAY = 1440
+var MINUTES_IN_ALMOST_TWO_DAYS = 2520
+var MINUTES_IN_MONTH = 43200
+var MINUTES_IN_TWO_MONTHS = 86400
+
+/**
+ * @name formatDistance
+ * @category Common Helpers
+ * @summary Return the distance between the given dates in words.
+ *
+ * @description
+ * Return the distance between the given dates in words.
+ *
+ * | Distance between dates                                            | Result              |
+ * |-------------------------------------------------------------------|---------------------|
+ * | 0 ... 30 secs                                                     | less than a minute  |
+ * | 30 secs ... 1 min 30 secs                                         | 1 minute            |
+ * | 1 min 30 secs ... 44 mins 30 secs                                 | [2..44] minutes     |
+ * | 44 mins ... 30 secs ... 89 mins 30 secs                           | about 1 hour        |
+ * | 89 mins 30 secs ... 23 hrs 59 mins 30 secs                        | about [2..24] hours |
+ * | 23 hrs 59 mins 30 secs ... 41 hrs 59 mins 30 secs                 | 1 day               |
+ * | 41 hrs 59 mins 30 secs ... 29 days 23 hrs 59 mins 30 secs         | [2..30] days        |
+ * | 29 days 23 hrs 59 mins 30 secs ... 44 days 23 hrs 59 mins 30 secs | about 1 month       |
+ * | 44 days 23 hrs 59 mins 30 secs ... 59 days 23 hrs 59 mins 30 secs | about 2 months      |
+ * | 59 days 23 hrs 59 mins 30 secs ... 1 yr                           | [2..12] months      |
+ * | 1 yr ... 1 yr 3 months                                            | about 1 year        |
+ * | 1 yr 3 months ... 1 yr 9 month s                                  | over 1 year         |
+ * | 1 yr 9 months ... 2 yrs                                           | almost 2 years      |
+ * | N yrs ... N yrs 3 months                                          | about N years       |
+ * | N yrs 3 months ... N yrs 9 months                                 | over N years        |
+ * | N yrs 9 months ... N+1 yrs                                        | almost N+1 years    |
+ *
+ * With `options.includeSeconds == true`:
+ * | Distance between dates | Result               |
+ * |------------------------|----------------------|
+ * | 0 secs ... 5 secs      | less than 5 seconds  |
+ * | 5 secs ... 10 secs     | less than 10 seconds |
+ * | 10 secs ... 20 secs    | less than 20 seconds |
+ * | 20 secs ... 40 secs    | half a minute        |
+ * | 40 secs ... 60 secs    | less than a minute   |
+ * | 60 secs ... 90 secs    | 1 minute             |
+ *
+ * @param {Date|String|Number} date - the date
+ * @param {Date|String|Number} baseDate - the date to compare with
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {Boolean} [options.includeSeconds=false] - distances less than a minute are more detailed
+ * @param {Boolean} [options.addSuffix=false] - result indicates if the second date is earlier or later than the first
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {String} the distance in words
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.locale` must contain `formatDistance` property
+ *
+ * @example
+ * // What is the distance between 2 July 2014 and 1 January 2015?
+ * var result = formatDistance(
+ *   new Date(Date.UTC(2014, 6, 2)),
+ *   new Date(Date.UTC(2015, 0, 1))
+ * )
+ * //=> '6 months'
+ *
+ * @example
+ * // What is the distance between 1 January 2015 00:00:15
+ * // and 1 January 2015 00:00:00, including seconds?
+ * var result = formatDistance(
+ *   new Date(Date.UTC(2015, 0, 1, 0, 0, 15)),
+ *   new Date(Date.UTC(2015, 0, 1, 0, 0, 0)),
+ *   {includeSeconds: true}
+ * )
+ * //=> 'less than 20 seconds'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 1 January 2015, with a suffix?
+ * var result = formatDistance(
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   new Date(Date.UTC(2016, 0, 1)),
+ *   {addSuffix: true}
+ * )
+ * //=> 'about 1 year ago'
+ *
+ * @example
+ * // What is the distance between 1 August 2016 and 1 January 2015 in Esperanto?
+ * import { eoLocale } from 'date-fns/locale/eo'
+ * var result = formatDistance(
+ *   new Date(Date.UTC(2016, 7, 1)),
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   {locale: eoLocale}
+ * )
+ * //=> 'pli ol 1 jaro'
+ */
+export default function formatDistance (dirtyDate, dirtyBaseDate, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale || defaultLocale
+
+  if (!locale.formatDistance) {
+    throw new RangeError('locale must contain formatDistance property')
+  }
+
+  var comparison = compareAsc(dirtyDate, dirtyBaseDate, options)
+
+  if (isNaN(comparison)) {
+    return 'Invalid Date'
+  }
+
+  var localizeOptions = cloneObject(options)
+  localizeOptions.addSuffix = Boolean(options.addSuffix)
+  localizeOptions.comparison = comparison
+
+  var dateLeft
+  var dateRight
+  if (comparison > 0) {
+    dateLeft = toDate(dirtyBaseDate, options)
+    dateRight = toDate(dirtyDate, options)
+  } else {
+    dateLeft = toDate(dirtyDate, options)
+    dateRight = toDate(dirtyBaseDate, options)
+  }
+
+  var seconds = differenceInSeconds(dateRight, dateLeft, options)
+  var offset = dateRight.getTimezoneOffset() - dateLeft.getTimezoneOffset()
+  var minutes = Math.round(seconds / 60) - offset
+  var months
+
+  // 0 up to 2 mins
+  if (minutes < 2) {
+    if (options.includeSeconds) {
+      if (seconds < 5) {
+        return locale.formatDistance('lessThanXSeconds', 5, localizeOptions)
+      } else if (seconds < 10) {
+        return locale.formatDistance('lessThanXSeconds', 10, localizeOptions)
+      } else if (seconds < 20) {
+        return locale.formatDistance('lessThanXSeconds', 20, localizeOptions)
+      } else if (seconds < 40) {
+        return locale.formatDistance('halfAMinute', null, localizeOptions)
+      } else if (seconds < 60) {
+        return locale.formatDistance('lessThanXMinutes', 1, localizeOptions)
+      } else {
+        return locale.formatDistance('xMinutes', 1, localizeOptions)
+      }
+    } else {
+      if (minutes === 0) {
+        return locale.formatDistance('lessThanXMinutes', 1, localizeOptions)
+      } else {
+        return locale.formatDistance('xMinutes', minutes, localizeOptions)
+      }
+    }
+
+  // 2 mins up to 0.75 hrs
+  } else if (minutes < 45) {
+    return locale.formatDistance('xMinutes', minutes, localizeOptions)
+
+  // 0.75 hrs up to 1.5 hrs
+  } else if (minutes < 90) {
+    return locale.formatDistance('aboutXHours', 1, localizeOptions)
+
+  // 1.5 hrs up to 24 hrs
+  } else if (minutes < MINUTES_IN_DAY) {
+    var hours = Math.round(minutes / 60)
+    return locale.formatDistance('aboutXHours', hours, localizeOptions)
+
+  // 1 day up to 1.75 days
+  } else if (minutes < MINUTES_IN_ALMOST_TWO_DAYS) {
+    return locale.formatDistance('xDays', 1, localizeOptions)
+
+  // 1.75 days up to 30 days
+  } else if (minutes < MINUTES_IN_MONTH) {
+    var days = Math.round(minutes / MINUTES_IN_DAY)
+    return locale.formatDistance('xDays', days, localizeOptions)
+
+  // 1 month up to 2 months
+  } else if (minutes < MINUTES_IN_TWO_MONTHS) {
+    months = Math.round(minutes / MINUTES_IN_MONTH)
+    return locale.formatDistance('aboutXMonths', months, localizeOptions)
+  }
+
+  months = differenceInMonths(dateRight, dateLeft, options)
+
+  // 2 months up to 12 months
+  if (months < 12) {
+    var nearestMonth = Math.round(minutes / MINUTES_IN_MONTH)
+    return locale.formatDistance('xMonths', nearestMonth, localizeOptions)
+
+  // 1 year up to max Date
+  } else {
+    var monthsSinceStartOfYear = months % 12
+    var years = Math.floor(months / 12)
+
+    // N years up to 1 years 3 months
+    if (monthsSinceStartOfYear < 3) {
+      return locale.formatDistance('aboutXYears', years, localizeOptions)
+
+    // N years 3 months up to N years 9 months
+    } else if (monthsSinceStartOfYear < 9) {
+      return locale.formatDistance('overXYears', years, localizeOptions)
+
+    // N years 9 months up to N year 12 months
+    } else {
+      return locale.formatDistance('almostXYears', years + 1, localizeOptions)
+    }
+  }
+}

--- a/src/utc/formatDistance/test.js
+++ b/src/utc/formatDistance/test.js
@@ -1,0 +1,324 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import formatDistance from '.'
+
+describe('utc/formatDistance', function () {
+  describe('seconds', function () {
+    context('when the includeSeconds option is true', function () {
+      it('less than 5 seconds', function () {
+        var result = formatDistance(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 3)),
+          {includeSeconds: true}
+        )
+        assert(result === 'less than 5 seconds')
+      })
+
+      it('less than 10 seconds', function () {
+        var result = formatDistance(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 7)),
+          {includeSeconds: true}
+        )
+        assert(result === 'less than 10 seconds')
+      })
+
+      it('less than 20 seconds', function () {
+        var result = formatDistance(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 15)),
+          {includeSeconds: true}
+        )
+        assert(result === 'less than 20 seconds')
+      })
+
+      it('half a minute', function () {
+        var result = formatDistance(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 25)),
+          {includeSeconds: true}
+        )
+        assert(result === 'half a minute')
+      })
+
+      it('less than a minute', function () {
+        var result = formatDistance(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 45)),
+          {includeSeconds: true}
+        )
+        assert(result === 'less than a minute')
+      })
+
+      it('1 minute', function () {
+        var result = formatDistance(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 33, 0)),
+          {includeSeconds: true}
+        )
+        assert(result === '1 minute')
+      })
+    })
+  })
+
+  describe('minutes', function () {
+    it('less than a minute', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 20))
+      )
+      assert(result === 'less than a minute')
+    })
+
+    it('1 minute', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 50))
+      )
+      assert(result === '1 minute')
+    })
+
+    it('n minutes', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 34, 50))
+      )
+      assert(result === '3 minutes')
+    })
+  })
+
+  describe('hours', function () {
+    it('about 1 hour', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 11, 32, 0))
+      )
+      assert(result === 'about 1 hour')
+    })
+
+    it('about n hours', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 13, 32, 0))
+      )
+      assert(result === 'about 3 hours')
+    })
+  })
+
+  describe('days', function () {
+    it('1 day', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 5, 10, 32, 0))
+      )
+      assert(result === '1 day')
+    })
+
+    it('n days', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 7, 10, 32, 0))
+      )
+      assert(result === '3 days')
+    })
+  })
+
+  describe('months', function () {
+    it('about 1 month', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 4, 4, 10, 32, 0))
+      )
+      assert(result === 'about 1 month')
+    })
+
+    it('n months', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 6, 4, 10, 32, 0))
+      )
+      assert(result === '3 months')
+    })
+  })
+
+  describe('years', function () {
+    it('about 1 year', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1987, 3, 4, 10, 32, 0))
+      )
+      assert(result === 'about 1 year')
+    })
+
+    it('over 1 year', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1987, 9, 4, 10, 32, 0))
+      )
+      assert(result === 'over 1 year')
+    })
+
+    it('almost n years', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1989, 2, 4, 10, 32, 0))
+      )
+      assert(result === 'almost 3 years')
+    })
+
+    it('about n years', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1989, 3, 4, 10, 32, 0))
+      )
+      assert(result === 'about 3 years')
+    })
+
+    it('over n years', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1989, 9, 4, 10, 32, 0))
+      )
+      assert(result === 'over 3 years')
+    })
+  })
+
+  it('accepts strings', function () {
+    var result = formatDistance(
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)).toISOString(),
+      new Date(Date.UTC(1986, 3, 4, 11, 32, 0)).toISOString()
+    )
+    assert(result === 'about 1 hour')
+  })
+
+  it('accepts timestamps', function () {
+    var result = formatDistance(
+      Date.UTC(1986, 3, 4, 10, 32, 0),
+      Date.UTC(1986, 3, 4, 11, 32, 0)
+    )
+    assert(result === 'about 1 hour')
+  })
+
+  describe('when the addSuffix option is true', function () {
+    it('adds a past suffix', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 25)),
+        {includeSeconds: true, addSuffix: true}
+      )
+      assert(result === 'half a minute ago')
+    })
+
+    it('adds a future suffix', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 11, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        {addSuffix: true}
+      )
+      assert(result === 'in about 1 hour')
+    })
+  })
+
+  describe('implicit conversion of options', function () {
+    it('`options.includeSeconds`', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 7)),
+        // $ExpectedMistake
+        {includeSeconds: 1}
+      )
+      assert(result === 'less than 10 seconds')
+    })
+
+    it('`options.addSuffix`', function () {
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 11, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        // $ExpectedMistake
+        {addSuffix: 1}
+      )
+      assert(result === 'in about 1 hour')
+    })
+  })
+
+  describe('custom locale', function () {
+    it('can be passed to the function', function () {
+      function localizeDistance (token, count, options) {
+        assert(token === 'lessThanXSeconds')
+        assert(count === 5)
+        assert(options.addSuffix === true)
+        assert(options.comparison > 0)
+        return 'It works!'
+      }
+
+      var customLocale = {
+        formatDistance: localizeDistance
+      }
+
+      var result = formatDistance(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 3)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        // $ExpectedMistake
+        {includeSeconds: true, addSuffix: true, locale: customLocale}
+      )
+
+      assert(result === 'It works!')
+    })
+
+    context('does not contain `formatDistance` property', function () {
+      it('throws `RangeError`', function () {
+        var customLocale = {}
+        var block = formatDistance.bind(
+          null,
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 3)),
+          // $ExpectedMistake
+          {includeSeconds: true, locale: customLocale}
+        )
+        assert.throws(block, RangeError)
+      })
+    })
+  })
+
+  it("returns String('Invalid Date') if the first date is `Invalid Date`", function () {
+    var result = formatDistance(
+      new Date(NaN),
+      new Date(Date.UTC(1986, 3, 7, 10, 32, 0))
+    )
+    assert(result === 'Invalid Date')
+  })
+
+  it("returns String('Invalid Date') if the second date is `Invalid Date`", function () {
+    var result = formatDistance(
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+      new Date(NaN)
+    )
+    assert(result === 'Invalid Date')
+  })
+
+  it("returns String('Invalid Date') if the both dates are `Invalid Date`", function () {
+    var result = formatDistance(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === 'Invalid Date')
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = formatDistance.bind(
+      this,
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 3)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(formatDistance.bind(null), TypeError)
+    assert.throws(formatDistance.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/formatDistanceStrict/index.js
+++ b/src/utc/formatDistanceStrict/index.js
@@ -1,0 +1,200 @@
+import compareAsc from '../compareAsc/index.js'
+import toDate from '../toDate/index.js'
+import differenceInSeconds from '../differenceInSeconds/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+import defaultLocale from '../../locale/en-US/index.js'
+
+var MINUTES_IN_DAY = 1440
+var MINUTES_IN_MONTH = 43200
+var MINUTES_IN_YEAR = 525600
+
+/**
+ * @name formatDistanceStrict
+ * @category Common Helpers
+ * @summary Return the distance between the given dates in words.
+ *
+ * @description
+ * Return the distance between the given dates in words, using strict units.
+ * This is like `formatDistance`, but does not use helpers like 'almost', 'over',
+ * 'less than' and the like.
+ *
+ * | Distance between dates | Result              |
+ * |------------------------|---------------------|
+ * | 0 ... 59 secs          | [0..59] seconds     |
+ * | 1 ... 59 mins          | [1..59] minutes     |
+ * | 1 ... 23 hrs           | [1..23] hours       |
+ * | 1 ... 29 days          | [1..29] days        |
+ * | 1 ... 11 months        | [1..11] months      |
+ * | 1 ... N years          | [1..N]  years       |
+ *
+ * @param {Date|String|Number} date - the date
+ * @param {Date|String|Number} baseDate - the date to compare with
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {Boolean} [options.addSuffix=false] - result indicates if the second date is earlier or later than the first
+ * @param {'s'|'m'|'h'|'d'|'M'|'Y'} [options.unit] - if specified, will force a unit
+ * @param {'floor'|'ceil'|'round'} [options.roundingMethod='floor'] - which way to round partial units
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {String} the distance in words
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.roundingMethod` must be 'floor', 'ceil' or 'round'
+ * @throws {RangeError} `options.unit` must be 's', 'm', 'h', 'd', 'M' or 'Y'
+ * @throws {RangeError} `options.locale` must contain `formatDistance` property
+ *
+ * @example
+ * // What is the distance between 2 July 2014 and 1 January 2015?
+ * var result = formatDistanceStrict(
+ *   new Date(Date.UTC(2014, 6, 2)),
+ *   new Date(Date.UTC(2015, 0, 2))
+ * )
+ * //=> '6 months'
+ *
+ * @example
+ * // What is the distance between 1 January 2015 00:00:15
+ * // and 1 January 2015 00:00:00?
+ * var result = formatDistanceStrict(
+ *   new Date(Date.UTC(2015, 0, 1, 0, 0, 15)),
+ *   new Date(Date.UTC(2015, 0, 1, 0, 0, 0)),
+ * )
+ * //=> '15 seconds'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 1 January 2015, with a suffix?
+ * var result = formatDistanceStrict(
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   new Date(Date.UTC(2016, 0, 1)),
+ *   {addSuffix: true}
+ * )
+ * //=> '1 year ago'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 1 January 2015, in minutes?
+ * var result = formatDistanceStrict(
+ *   new Date(Date.UTC(2016, 0, 1)),
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   {unit: 'm'}
+ * )
+ * //=> '525600 minutes'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 28 January 2015, in months, rounded up?
+ * var result = formatDistanceStrict(
+ *   new Date(Date.UTC(2015, 0, 28)),
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   {unit: 'M', roundingMethod: 'ceil'}
+ * )
+ * //=> '1 month'
+ *
+ * @example
+ * // What is the distance between 1 August 2016 and 1 January 2015 in Esperanto?
+ * import { eoLocale } from 'date-fns/locale/eo'
+ * var result = formatDistanceStrict(
+ *   new Date(Date.UTC(2016, 7, 1)),
+ *   new Date(Date.UTC(2015, 0, 1)),
+ *   {locale: eoLocale}
+ * )
+ * //=> '1 jaro'
+ */
+export default function formatDistanceStrict (dirtyDate, dirtyBaseDate, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale || defaultLocale
+
+  if (!locale.formatDistance) {
+    throw new RangeError('locale must contain localize.formatDistance property')
+  }
+
+  var comparison = compareAsc(dirtyDate, dirtyBaseDate, options)
+
+  if (isNaN(comparison)) {
+    return 'Invalid Date'
+  }
+
+  var localizeOptions = cloneObject(options)
+  localizeOptions.addSuffix = Boolean(options.addSuffix)
+  localizeOptions.comparison = comparison
+
+  var dateLeft
+  var dateRight
+  if (comparison > 0) {
+    dateLeft = toDate(dirtyBaseDate, options)
+    dateRight = toDate(dirtyDate, options)
+  } else {
+    dateLeft = toDate(dirtyDate, options)
+    dateRight = toDate(dirtyBaseDate, options)
+  }
+
+  var roundingMethod = options.roundingMethod === undefined ? 'floor' : String(options.roundingMethod)
+  var roundingMethodFn
+
+  if (roundingMethod === 'floor') {
+    roundingMethodFn = Math.floor
+  } else if (roundingMethod === 'ceil') {
+    roundingMethodFn = Math.ceil
+  } else if (roundingMethod === 'round') {
+    roundingMethodFn = Math.round
+  } else {
+    throw new RangeError("roundingMethod must be 'floor', 'ceil' or 'round'")
+  }
+
+  var seconds = differenceInSeconds(dateRight, dateLeft, dirtyOptions)
+  var offset = dateRight.getTimezoneOffset() - dateLeft.getTimezoneOffset()
+  var minutes = roundingMethodFn(seconds / 60) - offset
+
+  var unit
+  if (options.unit === undefined) {
+    if (minutes < 1) {
+      unit = 's'
+    } else if (minutes < 60) {
+      unit = 'm'
+    } else if (minutes < MINUTES_IN_DAY) {
+      unit = 'h'
+    } else if (minutes < MINUTES_IN_MONTH) {
+      unit = 'd'
+    } else if (minutes < MINUTES_IN_YEAR) {
+      unit = 'M'
+    } else {
+      unit = 'Y'
+    }
+  } else {
+    unit = String(options.unit)
+  }
+
+  // 0 up to 60 seconds
+  if (unit === 's') {
+    return locale.formatDistance('xSeconds', seconds, localizeOptions)
+
+  // 1 up to 60 mins
+  } else if (unit === 'm') {
+    return locale.formatDistance('xMinutes', minutes, localizeOptions)
+
+  // 1 up to 24 hours
+  } else if (unit === 'h') {
+    var hours = roundingMethodFn(minutes / 60)
+    return locale.formatDistance('xHours', hours, localizeOptions)
+
+  // 1 up to 30 days
+  } else if (unit === 'd') {
+    var days = roundingMethodFn(minutes / MINUTES_IN_DAY)
+    return locale.formatDistance('xDays', days, localizeOptions)
+
+  // 1 up to 12 months
+  } else if (unit === 'M') {
+    var months = roundingMethodFn(minutes / MINUTES_IN_MONTH)
+    return locale.formatDistance('xMonths', months, localizeOptions)
+
+  // 1 year up to max Date
+  } else if (unit === 'Y') {
+    var years = roundingMethodFn(minutes / MINUTES_IN_YEAR)
+    return locale.formatDistance('xYears', years, localizeOptions)
+  }
+
+  throw new RangeError("unit must be 's', 'm', 'h', 'd', 'M' or 'Y'")
+}

--- a/src/utc/formatDistanceStrict/test.js
+++ b/src/utc/formatDistanceStrict/test.js
@@ -1,0 +1,501 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import formatDistanceStrict from '.'
+
+describe('utc/formatDistanceStrict', function () {
+  describe('seconds', function () {
+    context('when no unit is set', function () {
+      it('0 seconds', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 5)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 5))
+        )
+        assert(result === '0 seconds')
+      })
+
+      it('5 seconds', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 5))
+        )
+        assert(result === '5 seconds')
+      })
+    })
+  })
+
+  describe('minutes', function () {
+    it('1 minute', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 0))
+      )
+      assert(result === '1 minute')
+    })
+
+    it('n minutes', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 35, 0))
+      )
+      assert(result === '3 minutes')
+    })
+  })
+
+  describe('hours', function () {
+    it('1 hour', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 11, 32, 0))
+      )
+      assert(result === '1 hour')
+    })
+
+    it('n hours', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 13, 32, 0))
+      )
+      assert(result === '3 hours')
+    })
+  })
+
+  describe('days', function () {
+    it('1 day', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 5, 10, 32, 0))
+      )
+      assert(result === '1 day')
+    })
+
+    it('n days', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 7, 10, 32, 0))
+      )
+      assert(result === '3 days')
+    })
+  })
+
+  describe('months', function () {
+    it('1 month', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 4, 4, 10, 32, 0))
+      )
+      assert(result === '1 month')
+    })
+
+    it('n months', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 6, 4, 10, 32, 0))
+      )
+      assert(result === '3 months')
+    })
+  })
+
+  describe('years', function () {
+    it('1 year', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1987, 3, 4, 10, 32, 0))
+      )
+      assert(result === '1 year')
+    })
+
+    it('n years', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1991, 3, 4, 10, 32, 0))
+      )
+      assert(result === '5 years')
+    })
+  })
+
+  describe('when the unit option is supplied', function () {
+    context('s', function () {
+      it('0 seconds', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          {unit: 's'}
+        )
+        assert(result === '0 seconds')
+      })
+
+      it('5 seconds', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 5)),
+          {unit: 's'}
+        )
+        assert(result === '5 seconds')
+      })
+
+      it('120 seconds', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 34, 0)),
+          {unit: 's'}
+        )
+        assert(result === '120 seconds')
+      })
+    })
+
+    context('m', function () {
+      it('0 minutes', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          {unit: 'm'}
+        )
+        assert(result === '0 minutes')
+      })
+
+      it('5 minutes', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 37, 0)),
+          {unit: 'm'}
+        )
+        assert(result === '5 minutes')
+      })
+
+      it('120 minutes', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 12, 32, 0)),
+          {unit: 'm'}
+        )
+        assert(result === '120 minutes')
+      })
+    })
+    context('h', function () {
+      it('0 hours', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          {unit: 'h'}
+        )
+        assert(result === '0 hours')
+      })
+
+      it('5 hours', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 15, 32, 0)),
+          {unit: 'h'}
+        )
+        assert(result === '5 hours')
+      })
+
+      it('48 hours', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 6, 10, 32, 0)),
+          {unit: 'h'}
+        )
+        assert(result === '48 hours')
+      })
+    })
+    context('d', function () {
+      it('0 days', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          {unit: 'd'}
+        )
+        assert(result === '0 days')
+      })
+
+      it('5 days', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 9, 10, 32, 0)),
+          {unit: 'd'}
+        )
+        assert(result === '5 days')
+      })
+
+      it('60 days', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 5, 3, 10, 32, 0)),
+          {unit: 'd'}
+        )
+        assert(result === '60 days')
+      })
+    })
+    context('M', function () {
+      it('0 months', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          {unit: 'M'}
+        )
+        assert(result === '0 months')
+      })
+
+      it('5 months', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 7, 4, 10, 32, 0)),
+          {unit: 'M'}
+        )
+        assert(result === '4 months')
+      })
+
+      it('24 months', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1988, 3, 4, 10, 32, 0)),
+          {unit: 'M'}
+        )
+        assert(result === '24 months')
+      })
+    })
+    context('Y', function () {
+      it('0 years', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          {unit: 'Y'}
+        )
+        assert(result === '0 years')
+      })
+
+      it('5 years', function () {
+        var result = formatDistanceStrict(
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1991, 3, 4, 15, 32, 0)),
+          {unit: 'Y'}
+        )
+        assert(result === '5 years')
+      })
+    })
+  })
+
+  it('accepts strings', function () {
+    var result = formatDistanceStrict(
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)).toISOString(),
+      new Date(Date.UTC(1986, 3, 4, 11, 32, 0)).toISOString()
+    )
+    assert(result === '1 hour')
+  })
+
+  it('accepts timestamps', function () {
+    var result = formatDistanceStrict(
+      Date.UTC(1986, 3, 4, 10, 32, 0),
+      Date.UTC(1986, 3, 4, 11, 32, 0)
+    )
+    assert(result === '1 hour')
+  })
+
+  describe('when the addSuffix option is true', function () {
+    it('adds a past suffix', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 25)),
+        {addSuffix: true}
+      )
+      assert(result === '25 seconds ago')
+    })
+
+    it('adds a future suffix', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 11, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        {addSuffix: true}
+      )
+      assert(result === 'in 1 hour')
+    })
+  })
+
+  describe('when the roundingMethod option is supplied', function () {
+    it('default is "floor"', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 59))
+      )
+      assert(result === '1 minute')
+    })
+
+    it('"floor"', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 59)),
+        {roundingMethod: 'floor'}
+      )
+      assert(result === '1 minute')
+    })
+
+    it('"ceil"', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 1)),
+        {roundingMethod: 'ceil'}
+      )
+      assert(result === '2 minutes')
+    })
+
+    it('"round" (down)', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 29)),
+        {roundingMethod: 'round'}
+      )
+      assert(result === '1 minute')
+    })
+
+    it('"round" (up)', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 30)),
+        {roundingMethod: 'round'}
+      )
+      assert(result === '2 minutes')
+    })
+  })
+
+  describe('implicit conversion of options', function () {
+    it('`options.unit`', function () {
+      // eslint-disable-next-line no-new-wrappers
+      var unit = new String('Y')
+
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        // $ExpectedMistake
+        {unit: unit}
+      )
+      assert(result === '0 years')
+    })
+
+    it('`options.addSuffix`', function () {
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 25)),
+        // $ExpectedMistake
+        {addSuffix: 1}
+      )
+      assert(result === '25 seconds ago')
+    })
+
+    it('`options.ceil`', function () {
+      // eslint-disable-next-line no-new-wrappers
+      var roundingMethod = new String('ceil')
+
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 33, 1)),
+        // $ExpectedMistake
+        {roundingMethod: roundingMethod}
+      )
+      assert(result === '2 minutes')
+    })
+  })
+
+  describe('custom locale', function () {
+    it('can be passed to the function', function () {
+      function localizeDistance (token, count, options) {
+        assert(token === 'xSeconds')
+        assert(count === 25)
+        assert(options.addSuffix === true)
+        assert(options.comparison < 0)
+        return 'It works!'
+      }
+
+      var customLocale = {
+        formatDistance: localizeDistance
+      }
+
+      var result = formatDistanceStrict(
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+        new Date(Date.UTC(1986, 3, 4, 10, 32, 25)),
+        // $ExpectedMistake
+        {addSuffix: true, locale: customLocale}
+      )
+
+      assert(result === 'It works!')
+    })
+
+    context('does not contain `formatDistance` property', function () {
+      it('throws `RangeError`', function () {
+        var customLocale = {}
+        var block = formatDistanceStrict.bind(
+          null,
+          new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+          new Date(Date.UTC(1986, 3, 4, 10, 37, 0)),
+          // $ExpectedMistake
+          {unit: 'm', locale: customLocale}
+        )
+        assert.throws(block, RangeError)
+      })
+    })
+  })
+
+  it("returns String('Invalid Date') if the first date is `Invalid Date`", function () {
+    var result = formatDistanceStrict(
+      new Date(NaN),
+      new Date(Date.UTC(1986, 3, 7, 10, 32, 0))
+    )
+    assert(result === 'Invalid Date')
+  })
+
+  it("returns String('Invalid Date') if the second date is `Invalid Date`", function () {
+    var result = formatDistanceStrict(
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+      new Date(NaN)
+    )
+    assert(result === 'Invalid Date')
+  })
+
+  it("returns String('Invalid Date') if the both dates are `Invalid Date`", function () {
+    var result = formatDistanceStrict(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === 'Invalid Date')
+  })
+
+  it("throws `RangeError` if `options.roundingMethod` is not 'floor', 'ceil', 'round' or undefined", function () {
+    var block = formatDistanceStrict.bind(
+      null,
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+      new Date(Date.UTC(1986, 3, 4, 10, 33, 29)),
+      // $ExpectedMistake
+      {roundingMethod: 'foobar'}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it("throws `RangeError` if `options.unit` is not 's', 'm', 'h', 'd', 'M', 'Y' or undefined", function () {
+    var block = formatDistanceStrict.bind(
+      null,
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 0)),
+      new Date(Date.UTC(1986, 3, 4, 10, 33, 29)),
+      // $ExpectedMistake
+      {unit: 'foobar'}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = formatDistanceStrict.bind(
+      this,
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 5)),
+      new Date(Date.UTC(1986, 3, 4, 10, 32, 5)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(formatDistanceStrict.bind(null), TypeError)
+    assert.throws(formatDistanceStrict.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/formatRelative/index.js
+++ b/src/utc/formatRelative/index.js
@@ -1,0 +1,85 @@
+import toDate from '../toDate/index.js'
+import format from '../format/index.js'
+import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+import defaultLocale from '../../locale/en-US/index.js'
+import subMinutes from '../subMinutes/index.js'
+
+/**
+ * @name formatRelative
+ * @category Common Helpers
+ * @summary Represent the date in words relative to the given base date.
+ *
+ * @description
+ * Represent the date in words relative to the given base date.
+ *
+ * | Distance to the base date | Result                    |
+ * |---------------------------|---------------------------|
+ * | Previous 6 days           | last Sunday at 04:30 a.m. |
+ * | Last day                  | yesterday at 04:30 a.m.   |
+ * | Same day                  | today at 04:30 a.m.       |
+ * | Next day                  | tomorrow at 04:30 a.m.    |
+ * | Next 6 days               | Sunday at 04:30 a.m.      |
+ * | Other                     | 12/31/2017                |
+ *
+ * @param {Date|String|Number} date - the date to format
+ * @param {Date|String|Number} baseDate - the date to compare with
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {String} the date in words
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.locale` must contain `localize` property
+ * @throws {RangeError} `options.locale` must contain `formatLong` property
+ * @throws {RangeError} `options.locale` must contain `formatRelative` property
+ */
+export default function formatRelative (dirtyDate, dirtyBaseDate, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var baseDate = toDate(dirtyBaseDate, dirtyOptions)
+
+  var options = dirtyOptions || {}
+  var locale = options.locale || defaultLocale
+
+  if (!locale.localize) {
+    throw new RangeError('locale must contain localize property')
+  }
+
+  if (!locale.formatLong) {
+    throw new RangeError('locale must contain formatLong property')
+  }
+
+  if (!locale.formatRelative) {
+    throw new RangeError('locale must contain formatRelative property')
+  }
+
+  var diff = differenceInCalendarDays(date, baseDate, options)
+
+  if (isNaN(diff)) {
+    return 'Invalid Date'
+  }
+
+  var token
+  if (diff < -6) {
+    token = 'other'
+  } else if (diff < -1) {
+    token = 'lastWeek'
+  } else if (diff < 0) {
+    token = 'yesterday'
+  } else if (diff < 1) {
+    token = 'today'
+  } else if (diff < 2) {
+    token = 'tomorrow'
+  } else if (diff < 7) {
+    token = 'nextWeek'
+  } else {
+    token = 'other'
+  }
+
+  var utcDate = subMinutes(date, date.getTimezoneOffset(), options)
+  var utcBaseDate = subMinutes(baseDate, date.getTimezoneOffset(), options)
+  var formatStr = locale.formatRelative(token, utcDate, utcBaseDate, options)
+  return format(date, formatStr, options)
+}

--- a/src/utc/formatRelative/test.js
+++ b/src/utc/formatRelative/test.js
@@ -1,0 +1,223 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import formatRelative from '.'
+
+describe('utc/formatRelative', function () {
+  var baseDate = new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 0, 900))
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 3 /* Apr */, 4))
+    assert(formatRelative(date.toISOString(), baseDate.toISOString()) === '04/04/2014')
+  })
+
+  it('accepts a timestamp', function () {
+    var date = new Date(Date.UTC(2014, 3 /* Apr */, 4))
+    assert(formatRelative(date.getTime(), baseDate.getTime()) === '04/04/2014')
+  })
+
+  it('before the last week', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 2 /* Mar */, 28, 16, 50)), baseDate)
+    assert(result === '03/28/1986')
+  })
+
+  it('last week', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 1)), baseDate)
+    assert(result === 'last Tuesday at 12:00 a.m.')
+  })
+
+  it('yesterday', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 3, 22, 22)), baseDate)
+    assert(result === 'yesterday at 10:22 p.m.')
+  })
+
+  it('today', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 4, 16, 50)), baseDate)
+    assert(result === 'today at 4:50 p.m.')
+  })
+
+  it('tomorrow', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 5, 7, 30)), baseDate)
+    assert(result === 'tomorrow at 7:30 a.m.')
+  })
+
+  it('next week', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 6, 12, 0)), baseDate)
+    assert(result === 'Sunday at 12:00 p.m.')
+  })
+
+  it('after the next week', function () {
+    var result = formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 11, 16, 50)), baseDate)
+    assert(result === '04/11/1986')
+  })
+
+  describe('edge cases', function () {
+    it("returns String('Invalid Date') if the date isn't valid", function () {
+      assert(formatRelative(new Date(NaN), baseDate) === 'Invalid Date')
+    })
+
+    it("returns String('Invalid Date') if the base date isn't valid", function () {
+      assert(formatRelative(new Date(Date.UTC(2017, 0 /* Jan */, 1)), new Date(NaN)) === 'Invalid Date')
+    })
+
+    it("returns String('Invalid Date') if both dates aren't valid", function () {
+      assert(formatRelative(new Date(NaN), new Date(NaN)) === 'Invalid Date')
+    })
+
+    it('handles dates before 100 AD', function () {
+      var date = new Date(0)
+      date.setUTCFullYear(7, 11 /* Dec */, 31)
+      date.setUTCHours(0, 0, 0, 0)
+      assert(formatRelative(date, baseDate) === '12/31/0007')
+    })
+  })
+
+  describe('custom locale', function () {
+    it('can be passed to the function', function () {
+      var formatters = {
+        'ABC': function (date) {
+          return 'It'
+        },
+
+        'EFG': function (date, options) {
+          return options.locale.localize.efg(date)
+        }
+      }
+
+      var localize = {
+        efg: function (date) {
+          return 'works'
+        }
+      }
+
+      var formattingTokensRegExp = /(\[[^[]*])|(\\)?(ABC|EFG|.)/g
+
+      var formatLong = function (token) {
+        if (token === 'LTS') {
+          return 'ABC'
+        } else {
+          return '[Nothing]'
+        }
+      }
+
+      var localizeFormatRelative = function (token) {
+        if (token === 'other') {
+          return 'LTS EFG[!]'
+        } else {
+          return "[It doesn't work!]"
+        }
+      }
+
+      var customLocale = {
+        // $ExpectedMistake
+        localize: localize,
+        formatLong: formatLong,
+        formatRelative: localizeFormatRelative,
+        formatters: formatters,
+        formattingTokensRegExp: formattingTokensRegExp
+      }
+
+      // $ExpectedMistake
+      var result = formatRelative(new Date(Date.UTC(2017, 0 /* Jan */, 1)), baseDate, {locale: customLocale})
+      assert(result === 'It works!')
+    })
+
+    context('does not contain `localize` property', function () {
+      it('throws `RangeError`', function () {
+        var customLocale = {formatLong: function () {}, formatRelative: function () {}}
+        // $ExpectedMistake
+        var block = formatRelative.bind(null, new Date(Date.UTC(2017, 0 /* Jan */, 1)), baseDate, {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `formatLong` property', function () {
+      it('throws `RangeError`', function () {
+        // $ExpectedMistake
+        var customLocale = {localize: {}, formatRelative: function () {}}
+        // $ExpectedMistake
+        var block = formatRelative.bind(null, new Date(Date.UTC(2017, 0 /* Jan */, 1)), baseDate, {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `formatRelative` property', function () {
+      it('throws `RangeError`', function () {
+        // $ExpectedMistake
+        var customLocale = {localize: {}, formatLong: function () {}}
+        // $ExpectedMistake
+        var block = formatRelative.bind(null, new Date(Date.UTC(2017, 0 /* Jan */, 1)), baseDate, {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `format` property', function () {
+      it('works correctly', function () {
+        var localize = {
+          month: function (date) {
+            return 'foobar'
+          }
+        }
+
+        var localizeFormatRelative = function (token) {
+          if (token === 'today') {
+            return 'MMMM'
+          } else {
+            return '[qwerty]'
+          }
+        }
+
+        var customLocale = {localize: localize, formatLong: function () {}, formatRelative: localizeFormatRelative}
+        // $ExpectedMistake
+        assert(formatRelative(new Date(Date.UTC(1986, 3 /* Apr */, 4)), baseDate, {locale: customLocale}) === 'foobar')
+      })
+    })
+
+    context('does not contain `format.formattingTokensRegExp` property', function () {
+      it('uses default `formattingTokensRegExp`', function () {
+        var formatters = {
+          'MMMM': function (date, options) {
+            return options.locale.localize.month(date)
+          },
+
+          'YYYY': function (date) {
+            return 'works'
+          }
+        }
+
+        var localize = {
+          month: function (date) {
+            return 'It'
+          }
+        }
+
+        var localizeFormatRelative = function () {
+          return 'MMMM YYYY [correctly!] GGGG'
+        }
+
+        var customLocale = {
+          formatLong: function () {},
+          formatRelative: localizeFormatRelative,
+          localize: localize,
+          formatters: formatters
+        }
+
+        // $ExpectedMistake
+        var result = formatRelative(new Date(Date.UTC(2017, 6 /* Jul */, 2)), baseDate, {locale: customLocale})
+        assert(result === 'It works correctly! 2017')
+      })
+    })
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = formatRelative.bind(null, new Date(Date.UTC(2017, 0, 1)), baseDate, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(formatRelative.bind(null), TypeError)
+    assert.throws(formatRelative.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/getDate/index.js
+++ b/src/utc/getDate/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getUTCDate
+ * @category Day Helpers
+ * @summary Get the day of the month of the given date.
+ *
+ * @description
+ * Get the day of the month of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the day of month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which day of the month is 29 February 2012?
+ * var result = getUTCDate(new Date(Date.UTC(2012, 1, 29)))
+ * //=> 29
+ */
+export default function getUTCDate (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var dayOfMonth = date.getUTCDate()
+  return dayOfMonth
+}

--- a/src/utc/getDate/test.js
+++ b/src/utc/getDate/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getDate from '.'
+
+describe('utc/getDate', function () {
+  it('returns the day of the month of the given date', function () {
+    var result = getDate(new Date(Date.UTC(2012, 1 /* Feb */, 29)))
+    assert(result === 29)
+  })
+
+  it('accepts a string', function () {
+    var result = getDate(new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString())
+    assert(result === 2)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getDate(Date.UTC(2014, 11 /* Dec */, 31))
+    assert(result === 31)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getDate(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getDate.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getDate.bind(null), TypeError)
+  })
+})

--- a/src/utc/getDay/index.js
+++ b/src/utc/getDay/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getDay
+ * @category Weekday Helpers
+ * @summary Get the day of the week of the given date.
+ *
+ * @description
+ * Get the day of the week of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the day of week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which day of the week is 29 February 2012?
+ * var result = getDay(new Date(Date.UTC(2012, 1, 29)))
+ * //=> 3
+ */
+export default function getDay (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var day = date.getUTCDay()
+  return day
+}

--- a/src/utc/getDay/test.js
+++ b/src/utc/getDay/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getDay from '.'
+
+describe('utc/getDay', function () {
+  it('returns the day of the week of the given date', function () {
+    var result = getDay(new Date(Date.UTC(2012, 1 /* Feb */, 29)))
+    assert(result === 3)
+  })
+
+  it('accepts a string', function () {
+    var result = getDay(new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString())
+    assert(result === 3)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getDay(Date.UTC(2014, 5 /* Jun */, 1))
+    assert(result === 0)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getDay(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getDay.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getDay.bind(null), TypeError)
+  })
+})

--- a/src/utc/getDayOfYear/index.js
+++ b/src/utc/getDayOfYear/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+import startOfYear from '../startOfYear/index.js'
+import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+
+/**
+ * @name getDayOfYear
+ * @category Day Helpers
+ * @summary Get the day of the year of the given date.
+ *
+ * @description
+ * Get the day of the year of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the day of year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which day of the year is 2 July 2014?
+ * var result = getDayOfYear(new Date(Date.UTC(2014, 6, 2)))
+ * //=> 183
+ */
+export default function getDayOfYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var diff = differenceInCalendarDays(date, startOfYear(date, dirtyOptions), dirtyOptions)
+  var dayOfYear = diff + 1
+  return dayOfYear
+}

--- a/src/utc/getDayOfYear/test.js
+++ b/src/utc/getDayOfYear/test.js
@@ -1,0 +1,45 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getDayOfYear from '.'
+
+describe('utc/getDayOfYear', function () {
+  it('returns the day of the year of the given date', function () {
+    var result = getDayOfYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+    assert(result === 183)
+  })
+
+  it('accepts a string', function () {
+    var result = getDayOfYear(new Date(Date.UTC(2014, 0 /* Jan */, 2)).toISOString())
+    assert(result === 2)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getDayOfYear(Date.UTC(2014, 0 /* Jan */, 2))
+    assert(result === 2)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 11 /* Dec */, 31)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var result = getDayOfYear(initialDate)
+    assert(result === 366)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getDayOfYear(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getDayOfYear.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getDayOfYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/getDaysInMonth/index.js
+++ b/src/utc/getDaysInMonth/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getDaysInMonth
+ * @category Month Helpers
+ * @summary Get the number of days in a month of the given date.
+ *
+ * @description
+ * Get the number of days in a month of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of days in a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many days are in February 2000?
+ * var result = getDaysInMonth(new Date(Date.UTC(2000, 1)))
+ * //=> 29
+ */
+export default function getDaysInMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = date.getUTCFullYear()
+  var monthIndex = date.getUTCMonth()
+  var lastDayOfMonth = new Date(0)
+  lastDayOfMonth.setUTCFullYear(year, monthIndex + 1, 0)
+  lastDayOfMonth.setUTCHours(0, 0, 0, 0)
+  return lastDayOfMonth.getUTCDate()
+}

--- a/src/utc/getDaysInMonth/test.js
+++ b/src/utc/getDaysInMonth/test.js
@@ -1,0 +1,52 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getDaysInMonth from '.'
+
+describe('utc/getDaysInMonth', function () {
+  it('returns the number of days in the month of the given date', function () {
+    var result = getDaysInMonth(new Date(Date.UTC(2100, 1 /* Feb */, 11)))
+    assert(result === 28)
+  })
+
+  it('works for the February of a leap year', function () {
+    var result = getDaysInMonth(new Date(Date.UTC(2000, 1 /* Feb */, 11)))
+    assert(result === 29)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    var result = getDaysInMonth(date)
+    assert(result === 31)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 6 /* Jul */, 2)
+    var result = getDaysInMonth(date)
+    assert(result === 31)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var date = new Date(0)
+    date.setUTCFullYear(0, 1 /* Feb */, 15)
+    date.setUTCHours(0, 0, 0, 0)
+    var result = getDaysInMonth(date)
+    assert(result === 29)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getDaysInMonth(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getDaysInMonth.bind(null, new Date(Date.UTC(2100, 1 /* Feb */, 11)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getDaysInMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/getDaysInYear/index.js
+++ b/src/utc/getDaysInYear/index.js
@@ -1,0 +1,36 @@
+import toDate from '../toDate/index.js'
+import isLeapYear from '../isLeapYear/index.js'
+
+/**
+ * @name getDaysInYear
+ * @category Year Helpers
+ * @summary Get the number of days in a year of the given date.
+ *
+ * @description
+ * Get the number of days in a year of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of days in a year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many days are in 2012?
+ * var result = getDaysInYear(new Date(Date.UTC(2012, 0, 1)))
+ * //=> 366
+ */
+export default function getDaysInYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+
+  if (isNaN(date)) {
+    return NaN
+  }
+
+  return isLeapYear(date, dirtyOptions) ? 366 : 365
+}

--- a/src/utc/getDaysInYear/test.js
+++ b/src/utc/getDaysInYear/test.js
@@ -1,0 +1,54 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getDaysInYear from '.'
+
+describe('utc/getDaysInYear', function () {
+  it('returns the number of days in the year of the given date', function () {
+    var result = getDaysInYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+    assert(result === 365)
+  })
+
+  it('works for a leap year', function () {
+    var result = getDaysInYear(new Date(Date.UTC(2012, 6 /* Jul */, 2)))
+    assert(result === 366)
+  })
+
+  it('works for the years divisible by 100 but not by 400', function () {
+    var result = getDaysInYear(new Date(Date.UTC(2100, 6 /* Jul */, 2)))
+    assert(result === 365)
+  })
+
+  it('works for the years divisible by 400', function () {
+    var result = getDaysInYear(new Date(Date.UTC(2000, 6 /* Jul */, 2)))
+    assert(result === 366)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2012, 6 /* Jul */, 2)).toISOString()
+    var result = getDaysInYear(date)
+    assert(result === 366)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2012, 6 /* Jul */, 2)
+    var result = getDaysInYear(date)
+    assert(result === 366)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getDaysInYear(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getDaysInYear.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getDaysInYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/getHours/index.js
+++ b/src/utc/getHours/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getHours
+ * @category Hour Helpers
+ * @summary Get the hours of the given date.
+ *
+ * @description
+ * Get the hours of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the hours
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Get the hours of 29 February 2012 11:45:00:
+ * var result = getHours(new Date(Date.UTC(2012, 1, 29, 11, 45)))
+ * //=> 11
+ */
+export default function getHours (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var hours = date.getUTCHours()
+  return hours
+}

--- a/src/utc/getHours/test.js
+++ b/src/utc/getHours/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getHours from '.'
+
+describe('utc/getHours', function () {
+  it('returns the hours of the given date', function () {
+    var result = getHours(new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45)))
+    assert(result === 11)
+  })
+
+  it('accepts a string', function () {
+    var result = getHours(new Date(Date.UTC(2014, 6 /* Jul */, 2, 5)).toISOString())
+    assert(result === 5)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getHours(Date.UTC(2014, 3 /* Apr */, 2, 23, 30))
+    assert(result === 23)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getHours(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getHours.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getHours.bind(null), TypeError)
+  })
+})

--- a/src/utc/getISODay/index.js
+++ b/src/utc/getISODay/index.js
@@ -1,0 +1,39 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getISODay
+ * @category Weekday Helpers
+ * @summary Get the day of the ISO week of the given date.
+ *
+ * @description
+ * Get the day of the ISO week of the given date,
+ * which is 7 for Sunday, 1 for Monday etc.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the day of ISO week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which day of the ISO week is 26 February 2012?
+ * var result = getISODay(new Date(Date.UTC(2012, 1, 26)))
+ * //=> 7
+ */
+export default function getISODay (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var day = date.getUTCDay()
+
+  if (day === 0) {
+    day = 7
+  }
+
+  return day
+}

--- a/src/utc/getISODay/test.js
+++ b/src/utc/getISODay/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getISODay from '.'
+
+describe('utc/getISODay', function () {
+  it('returns the day of the ISO week of the given date', function () {
+    var result = getISODay(new Date(Date.UTC(2012, 1 /* Feb */, 29)))
+    assert(result === 3)
+  })
+
+  it('returns 7 if the given day is Sunday', function () {
+    var result = getISODay(new Date(Date.UTC(2014, 5 /* Jun */, 1)))
+    assert(result === 7)
+  })
+
+  it('accepts a string', function () {
+    var result = getISODay(new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString())
+    assert(result === 3)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getISODay(Date.UTC(2014, 5 /* Jun */, 1))
+    assert(result === 7)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getISODay(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getISODay.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getISODay.bind(null), TypeError)
+  })
+})

--- a/src/utc/getISOWeek/index.js
+++ b/src/utc/getISOWeek/index.js
@@ -1,0 +1,41 @@
+import toDate from '../toDate/index.js'
+import startOfISOWeek from '../startOfISOWeek/index.js'
+import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
+
+var MILLISECONDS_IN_WEEK = 604800000
+
+/**
+ * @name getISOWeek
+ * @category ISO Week Helpers
+ * @summary Get the ISO week of the given date.
+ *
+ * @description
+ * Get the ISO week of the given date.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the ISO week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which week of the ISO-week numbering year is 2 January 2005?
+ * var result = getISOWeek(new Date(Date.UTC(2005, 0, 2)))
+ * //=> 53
+ */
+export default function getISOWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var diff = startOfISOWeek(date, dirtyOptions).getTime() - startOfISOWeekYear(date, dirtyOptions).getTime()
+
+  // Round the number of days to the nearest integer
+  // because the number of milliseconds in a week is not constant
+  // (e.g. it's different in the week of the daylight saving time clock shift)
+  return Math.round(diff / MILLISECONDS_IN_WEEK) + 1
+}

--- a/src/utc/getISOWeek/test.js
+++ b/src/utc/getISOWeek/test.js
@@ -1,0 +1,67 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getISOWeek from '.'
+
+describe('utc/getISOWeek', function () {
+  it('returns the ISO week of the given date', function () {
+    var result = getISOWeek(new Date(Date.UTC(2005, 0 /* Jan */, 2)))
+    assert(result === 53)
+  })
+
+  it('accepts a string', function () {
+    var result = getISOWeek(new Date(Date.UTC(2008, 11 /* Dec */, 29)).toISOString())
+    assert(result === 1)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getISOWeek(Date.UTC(2008, 11 /* Dec */, 29))
+    assert(result === 1)
+  })
+
+  describe('edge cases', function () {
+    it('returns the ISO week at 1 January 2016', function () {
+      var result = getISOWeek(new Date(Date.UTC(2016, 0 /* Jan */, 1)))
+      assert(result === 53)
+    })
+
+    it('returns the ISO week at 1 May 2016', function () {
+      var result = getISOWeek(new Date(Date.UTC(2016, 4 /* May */, 1)))
+      assert(result === 17)
+    })
+
+    it('returns the ISO week at 2 May 2016', function () {
+      var result = getISOWeek(new Date(Date.UTC(2016, 4 /* May */, 2)))
+      assert(result === 18)
+    })
+
+    it('returns the ISO week at 31 May 2016', function () {
+      var result = getISOWeek(new Date(Date.UTC(2016, 4 /* May */, 31)))
+      assert(result === 22)
+    })
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(7, 11 /* Dec */, 30)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var result = getISOWeek(initialDate)
+    assert(result === 52)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getISOWeek(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getISOWeek.bind(null, new Date(Date.UTC(2005, 0 /* Jan */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getISOWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/getISOWeekYear/index.js
+++ b/src/utc/getISOWeekYear/index.js
@@ -1,0 +1,52 @@
+import toDate from '../toDate/index.js'
+import startOfISOWeek from '../startOfISOWeek/index.js'
+
+/**
+ * @name getISOWeekYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Get the ISO week-numbering year of the given date.
+ *
+ * @description
+ * Get the ISO week-numbering year of the given date,
+ * which always starts 3 days before the year's first Thursday.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the ISO week-numbering year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which ISO-week numbering year is 2 January 2005?
+ * var result = getISOWeekYear(new Date(Date.UTC(2005, 0, 2)))
+ * //=> 2004
+ */
+export default function getISOWeekYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = date.getUTCFullYear()
+
+  var fourthOfJanuaryOfNextYear = new Date(0)
+  fourthOfJanuaryOfNextYear.setUTCFullYear(year + 1, 0, 4)
+  fourthOfJanuaryOfNextYear.setUTCHours(0, 0, 0, 0)
+  var startOfNextYear = startOfISOWeek(fourthOfJanuaryOfNextYear, dirtyOptions)
+
+  var fourthOfJanuaryOfThisYear = new Date(0)
+  fourthOfJanuaryOfThisYear.setUTCFullYear(year, 0, 4)
+  fourthOfJanuaryOfThisYear.setUTCHours(0, 0, 0, 0)
+  var startOfThisYear = startOfISOWeek(fourthOfJanuaryOfThisYear, dirtyOptions)
+
+  if (date.getTime() >= startOfNextYear.getTime()) {
+    return year + 1
+  } else if (date.getTime() >= startOfThisYear.getTime()) {
+    return year
+  } else {
+    return year - 1
+  }
+}

--- a/src/utc/getISOWeekYear/test.js
+++ b/src/utc/getISOWeekYear/test.js
@@ -1,0 +1,45 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getISOWeekYear from '.'
+
+describe('utc/getISOWeekYear', function () {
+  it('returns the ISO week-numbering year of the given date', function () {
+    var result = getISOWeekYear(new Date(Date.UTC(2007, 11 /* Dec */, 31)))
+    assert(result === 2008)
+  })
+
+  it('accepts a string', function () {
+    var result = getISOWeekYear(new Date(Date.UTC(2005, 0 /* Jan */, 1)).toISOString())
+    assert(result === 2004)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getISOWeekYear(Date.UTC(2005, 0 /* Jan */, 1))
+    assert(result === 2004)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(7, 11 /* Dec */, 31)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var result = getISOWeekYear(initialDate)
+    assert(result === 8)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getISOWeekYear(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getISOWeekYear.bind(null, new Date(Date.UTC(2007, 11 /* Dec */, 31)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getISOWeekYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/getISOWeeksInYear/index.js
+++ b/src/utc/getISOWeeksInYear/index.js
@@ -1,0 +1,40 @@
+import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
+import addWeeks from '../addWeeks/index.js'
+
+var MILLISECONDS_IN_WEEK = 604800000
+
+/**
+ * @name getISOWeeksInYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Get the number of weeks in an ISO week-numbering year of the given date.
+ *
+ * @description
+ * Get the number of weeks in an ISO week-numbering year of the given date.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of ISO weeks in a year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // How many weeks are in ISO week-numbering year 2015?
+ * var result = getISOWeeksInYear(new Date(Date.UTC(2015, 1, 11)))
+ * //=> 53
+ */
+export default function getISOWeeksInYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var thisYear = startOfISOWeekYear(dirtyDate, dirtyOptions)
+  var nextYear = startOfISOWeekYear(addWeeks(thisYear, 60, dirtyOptions), dirtyOptions)
+  var diff = nextYear.valueOf() - thisYear.valueOf()
+  // Round the number of weeks to the nearest integer
+  // because the number of milliseconds in a week is not constant
+  // (e.g. it's different in the week of the daylight saving time clock shift)
+  return Math.round(diff / MILLISECONDS_IN_WEEK)
+}

--- a/src/utc/getISOWeeksInYear/test.js
+++ b/src/utc/getISOWeeksInYear/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getISOWeeksInYear from '.'
+
+describe('utc/getISOWeeksInYear', function () {
+  it('returns the number of ISO weeks in the ISO week-numbering year of the given date', function () {
+    var result = getISOWeeksInYear(new Date(Date.UTC(2015, 1 /* Feb */, 11)))
+    assert(result === 53)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 1 /* Feb */, 11)).toISOString()
+    var result = getISOWeeksInYear(date)
+    assert(result === 52)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2003, 11 /* Dec */, 30)
+    var result = getISOWeeksInYear(date)
+    assert(result === 53)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(4, 0 /* Jan */, 4)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var result = getISOWeeksInYear(initialDate)
+    assert(result === 53)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getISOWeeksInYear(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getISOWeeksInYear.bind(null, new Date(Date.UTC(2015, 1 /* Feb */, 11)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getISOWeeksInYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/getMilliseconds/index.js
+++ b/src/utc/getMilliseconds/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getMilliseconds
+ * @category Millisecond Helpers
+ * @summary Get the milliseconds of the given date.
+ *
+ * @description
+ * Get the milliseconds of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the milliseconds
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Get the milliseconds of 29 February 2012 11:45:05.123:
+ * var result = getMilliseconds(new Date(Date.UTC(2012, 1, 29, 11, 45, 5, 123)))
+ * //=> 123
+ */
+export default function getMilliseconds (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var milliseconds = date.getUTCMilliseconds()
+  return milliseconds
+}

--- a/src/utc/getMilliseconds/test.js
+++ b/src/utc/getMilliseconds/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getMilliseconds from '.'
+
+describe('utc/getMilliseconds', function () {
+  it('returns the milliseconds of the given date', function () {
+    var result = getMilliseconds(new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45, 5, 123)))
+    assert(result === 123)
+  })
+
+  it('accepts a string', function () {
+    var result = getMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 2, 5, 15)).toISOString())
+    assert(result === 0)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getMilliseconds(Date.UTC(2014, 3 /* Apr */, 2, 23, 30, 42, 500))
+    assert(result === 500)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getMilliseconds(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getMilliseconds.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45, 5, 123)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getMilliseconds.bind(null), TypeError)
+  })
+})

--- a/src/utc/getMinutes/index.js
+++ b/src/utc/getMinutes/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getMinutes
+ * @category Minute Helpers
+ * @summary Get the minutes of the given date.
+ *
+ * @description
+ * Get the minutes of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the minutes
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Get the minutes of 29 February 2012 11:45:05:
+ * var result = getMinutes(new Date(Date.UTC(2012, 1, 29, 11, 45, 5)))
+ * //=> 45
+ */
+export default function getMinutes (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var minutes = date.getUTCMinutes()
+  return minutes
+}

--- a/src/utc/getMinutes/test.js
+++ b/src/utc/getMinutes/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getMinutes from '.'
+
+describe('utc/getMinutes', function () {
+  it('returns the minutes of the given date', function () {
+    var result = getMinutes(new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45, 5)))
+    assert(result === 45)
+  })
+
+  it('accepts a string', function () {
+    var result = getMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 2, 5)).toISOString())
+    assert(result === 0)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getMinutes(Date.UTC(2014, 3 /* Apr */, 2, 23, 30))
+    assert(result === 30)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getMinutes(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getMinutes.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45, 5)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getMinutes.bind(null), TypeError)
+  })
+})

--- a/src/utc/getMonth/index.js
+++ b/src/utc/getMonth/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getMonth
+ * @category Month Helpers
+ * @summary Get the month of the given date.
+ *
+ * @description
+ * Get the month of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which month is 29 February 2012?
+ * var result = getMonth(new Date(Date.UTC(2012, 1, 29)))
+ * //=> 1
+ */
+export default function getMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var month = date.getUTCMonth()
+  return month
+}

--- a/src/utc/getMonth/test.js
+++ b/src/utc/getMonth/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getMonth from '.'
+
+describe('utc/getMonth', function () {
+  it('returns the month of the given date', function () {
+    var result = getMonth(new Date(Date.UTC(2012, 1 /* Feb */, 29)))
+    assert(result === 1)
+  })
+
+  it('accepts a string', function () {
+    var result = getMonth(new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString())
+    assert(result === 6)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getMonth(Date.UTC(2014, 3 /* Apr */, 2))
+    assert(result === 3)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getMonth(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getMonth.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/getOverlappingDaysInIntervals/index.js
+++ b/src/utc/getOverlappingDaysInIntervals/index.js
@@ -1,0 +1,73 @@
+import toDate from '../toDate/index.js'
+
+var MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * @name getOverlappingDaysInIntervals
+ * @category Interval Helpers
+ * @summary Get the number of days that overlap in two time intervals
+ *
+ * @description
+ * Get the number of days that overlap in two time intervals
+ *
+ * @param {Interval} intervalLeft - the first interval to compare. See [Interval]{@link docs/Interval}
+ * @param {Interval} intervalRight - the second interval to compare. See [Interval]{@link docs/Interval}
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the number of days that overlap in two time intervals
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} The start of an interval cannot be after its end
+ * @throws {RangeError} Date in interval cannot be `Invalid Date`
+ *
+ * @example
+ * // For overlapping time intervals adds 1 for each started overlapping day:
+ * getOverlappingDaysInIntervals(
+ *   {start: new Date(Date.UTC(2014, 0, 10)), end: new Date(Date.UTC(2014, 0, 20))},
+ *   {start: new Date(Date.UTC(2014, 0, 17)), end: new Date(Date.UTC(2014, 0, 21))}
+ * )
+ * //=> 3
+ *
+ * @example
+ * // For non-overlapping time intervals returns 0:
+ * getOverlappingDaysInIntervals(
+ *   {start: new Date(Date.UTC(2014, 0, 10)), end: new Date(Date.UTC(2014, 0, 20))},
+ *   {start: new Date(Date.UTC(2014, 0, 21)), end: new Date(Date.UTC(2014, 0, 22))}
+ * )
+ * //=> 0
+ */
+export default function getOverlappingDaysInIntervals (dirtyIntervalLeft, dirtyIntervalRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var intervalLeft = dirtyIntervalLeft || {}
+  var intervalRight = dirtyIntervalRight || {}
+  var leftStartTime = toDate(intervalLeft.start, dirtyOptions).getTime()
+  var leftEndTime = toDate(intervalLeft.end, dirtyOptions).getTime()
+  var rightStartTime = toDate(intervalRight.start, dirtyOptions).getTime()
+  var rightEndTime = toDate(intervalRight.end, dirtyOptions).getTime()
+
+  // Throw an exception if start date is after end date or if any date is `Invalid Date`
+  if (!(leftStartTime <= leftEndTime && rightStartTime <= rightEndTime)) {
+    throw new RangeError('Invalid interval')
+  }
+
+  var isOverlapping = leftStartTime < rightEndTime && rightStartTime < leftEndTime
+
+  if (!isOverlapping) {
+    return 0
+  }
+
+  var overlapStartDate = rightStartTime < leftStartTime
+    ? leftStartTime
+    : rightStartTime
+
+  var overlapEndDate = rightEndTime > leftEndTime
+    ? leftEndTime
+    : rightEndTime
+
+  var differenceInMs = overlapEndDate - overlapStartDate
+
+  return Math.ceil(differenceInMs / MILLISECONDS_IN_DAY)
+}

--- a/src/utc/getOverlappingDaysInIntervals/test.js
+++ b/src/utc/getOverlappingDaysInIntervals/test.js
@@ -1,0 +1,259 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getOverlappingDaysInIntervals from '.'
+
+describe('utc/getOverlappingDaysInIntervals', function () {
+  var initialIntervalStart = new Date(Date.UTC(2016, 10, 10, 13, 0, 0))
+  var initialIntervalEnd = new Date(Date.UTC(2016, 11, 3, 15, 0, 0))
+
+  context('when the time intervals don\'t overlap', function () {
+    it('returns 0 for a valid non overlapping interval before another interval', function () {
+      var earlierIntervalStart = new Date(Date.UTC(2016, 9, 25))
+      var earlierIntervalEnd = new Date(Date.UTC(2016, 10, 9))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: earlierIntervalStart, end: earlierIntervalEnd}
+      )
+      assert(numOverlappingDays === 0)
+    })
+
+    it('returns 0 for a valid non overlapping interval after another interval', function () {
+      var laterIntervalStart = new Date(Date.UTC(2016, 11, 4))
+      var laterIntervalEnd = new Date(Date.UTC(2016, 11, 9))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: laterIntervalStart, end: laterIntervalEnd}
+      )
+      assert(numOverlappingDays === 0)
+    })
+
+    it('returns 0 for a non overlapping same-day interval', function () {
+      var sameDayIntervalStart = new Date(Date.UTC(2016, 11, 4, 9, 0, 0))
+      var sameDayIntervalEnd = new Date(Date.UTC(2016, 11, 4, 18, 0, 0))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: sameDayIntervalStart, end: sameDayIntervalEnd}
+      )
+      assert(numOverlappingDays === 0)
+    })
+
+    it('returns 0 for an interval differing by a few hours', function () {
+      var oneDayOverlappingIntervalStart = new Date(Date.UTC(2016, 11, 3, 18, 0, 0))
+      var oneDayOverlappingIntervalEnd = new Date(Date.UTC(2016, 11, 14, 13, 0, 0))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: oneDayOverlappingIntervalStart, end: oneDayOverlappingIntervalEnd}
+      )
+      assert(numOverlappingDays === 0)
+    })
+
+    it('returns 0 for an interval with the same startDateTime as the initial time intervals\'s endDateTime', function () {
+      var oneDayOverlapIntervalStart = new Date(Date.UTC(2016, 11, 3, 15, 0, 0))
+      var oneDayOverlapIntervalEnd = new Date(Date.UTC(2016, 11, 14, 13, 0, 0))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: oneDayOverlapIntervalStart, end: oneDayOverlapIntervalEnd}
+      )
+      assert(numOverlappingDays === 0)
+    })
+
+    it('returns 0 for an interval with the same endDateTime as the initial time interval\'s startDateTime', function () {
+      var oneDayOverlapIntervalStart = new Date(Date.UTC(2016, 10, 3, 15, 0, 0))
+      var oneDayOverlapIntervalEnd = new Date(Date.UTC(2016, 10, 10, 13, 0, 0))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: oneDayOverlapIntervalStart, end: oneDayOverlapIntervalEnd}
+      )
+      assert(numOverlappingDays === 0)
+    })
+  })
+
+  context('when the time intervals overlap', function () {
+    it('rounds up the result to include each started overlapping day', function () {
+      var includedIntervalStart = new Date(Date.UTC(2016, 10, 14, 9, 0, 0))
+      var includedIntervalEnd = new Date(Date.UTC(2016, 10, 15, 18, 0, 0))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: includedIntervalStart, end: includedIntervalEnd}
+      )
+      assert(numOverlappingDays === 2)
+    })
+
+    it('returns the correct value for an interval included within another interval', function () {
+      var includedIntervalStart = new Date(Date.UTC(2016, 10, 14))
+      var includedIntervalEnd = new Date(Date.UTC(2016, 10, 15))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: includedIntervalStart, end: includedIntervalEnd}
+      )
+      assert(numOverlappingDays === 1)
+    })
+
+    it('returns the correct value for an interval overlapping at the end', function () {
+      var endOverlappingIntervalStart = new Date(Date.UTC(2016, 10, 5))
+      var endOverlappingIntervalEnd = new Date(Date.UTC(2016, 10, 14))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: endOverlappingIntervalStart, end: endOverlappingIntervalEnd}
+      )
+      assert(numOverlappingDays === 4)
+    })
+
+    it('returns the correct value for an interval overlapping at the beginning', function () {
+      var startOverlappingIntervalStart = new Date(Date.UTC(2016, 10, 20))
+      var startOverlappingIntervalEnd = new Date(Date.UTC(2016, 11, 14))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: startOverlappingIntervalStart, end: startOverlappingIntervalEnd}
+      )
+      assert(numOverlappingDays === 14)
+    })
+
+    it('returns the correct value for an interval including another interval', function () {
+      var includingIntervalStart = new Date(Date.UTC(2016, 10, 5))
+      var includingIntervalEnd = new Date(Date.UTC(2016, 11, 15))
+
+      var numOverlappingDays = getOverlappingDaysInIntervals(
+        {start: initialIntervalStart, end: initialIntervalEnd},
+        {start: includingIntervalStart, end: includingIntervalEnd}
+      )
+      assert(numOverlappingDays === 24)
+    })
+  })
+
+  it('accepts strings', function () {
+    var initialIntervalStart = new Date(Date.UTC(2016, 10, 10, 13, 0, 0)).toISOString()
+    var initialIntervalEnd = new Date(Date.UTC(2016, 11, 3, 15, 0, 0)).toISOString()
+
+    var endOverlappingIntervalStart = new Date(Date.UTC(2016, 10, 5)).toISOString()
+    var endOverlappingIntervalEnd = new Date(Date.UTC(2016, 10, 14)).toISOString()
+
+    var numOverlappingDays = getOverlappingDaysInIntervals(
+      {start: initialIntervalStart, end: initialIntervalEnd},
+      {start: endOverlappingIntervalStart, end: endOverlappingIntervalEnd}
+    )
+    assert(numOverlappingDays === 4)
+  })
+
+  it('accepts timestamp', function () {
+    var initialIntervalStart = Date.UTC(2016, 10, 10, 13, 0, 0)
+    var initialIntervalEnd = Date.UTC(2016, 11, 3, 15, 0, 0)
+
+    var endOverlappingIntervalStart = Date.UTC(2016, 10, 5)
+    var endOverlappingIntervalEnd = Date.UTC(2016, 10, 14)
+
+    var numOverlappingDays = getOverlappingDaysInIntervals(
+      {start: initialIntervalStart, end: initialIntervalEnd},
+      {start: endOverlappingIntervalStart, end: endOverlappingIntervalEnd}
+    )
+    assert(numOverlappingDays === 4)
+  })
+
+  it('throws an exception if the start date of the initial time interval is after the end date', function () {
+    var block = getOverlappingDaysInIntervals.bind(
+      null,
+      {start: new Date(Date.UTC(2016, 10, 7)), end: new Date(Date.UTC(2016, 10, 3))},
+      {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the start date of the compared time interval is after the end date', function () {
+    var block = getOverlappingDaysInIntervals.bind(
+      null,
+      {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+      {start: new Date(Date.UTC(2016, 10, 15)), end: new Date(Date.UTC(2016, 10, 5))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the initial interval is undefined', function () {
+    var block = getOverlappingDaysInIntervals.bind(
+      null,
+      // $ExpectedMistake
+      undefined,
+      {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the compared interval is undefined', function () {
+    var block = getOverlappingDaysInIntervals.bind(
+      null,
+      {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+      // $ExpectedMistake
+      undefined
+    )
+    assert.throws(block, RangeError)
+  })
+
+  context('one of the dates is `Invalid Date`', function () {
+    it('throws an exception if the start date of the initial time interval is `Invalid Date`', function () {
+      var block = getOverlappingDaysInIntervals.bind(
+        null,
+        {start: new Date(NaN), end: new Date(Date.UTC(2016, 10, 3))},
+        {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+      )
+      assert.throws(block, RangeError)
+    })
+
+    it('throws an exception if the end date of the initial time interval is `Invalid Date`', function () {
+      var block = getOverlappingDaysInIntervals.bind(
+        null,
+        {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(NaN)},
+        {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(Date.UTC(2016, 10, 15))}
+      )
+      assert.throws(block, RangeError)
+    })
+
+    it('throws an exception if the start date of the compared time interval is `Invalid Date`', function () {
+      var block = getOverlappingDaysInIntervals.bind(
+        null,
+        {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+        {start: new Date(NaN), end: new Date(Date.UTC(2016, 10, 5))}
+      )
+      assert.throws(block, RangeError)
+    })
+
+    it('throws an exception if the end date of the compared time interval is `Invalid Date`', function () {
+      var block = getOverlappingDaysInIntervals.bind(
+        null,
+        {start: new Date(Date.UTC(2016, 10, 3)), end: new Date(Date.UTC(2016, 10, 7))},
+        {start: new Date(Date.UTC(2016, 10, 5)), end: new Date(NaN)}
+      )
+      assert.throws(block, RangeError)
+    })
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var earlierIntervalStart = new Date(Date.UTC(2016, 9, 25))
+    var earlierIntervalEnd = new Date(Date.UTC(2016, 10, 9))
+
+    var block = getOverlappingDaysInIntervals.bind(
+      null,
+      {start: initialIntervalStart, end: initialIntervalEnd},
+      {start: earlierIntervalStart, end: earlierIntervalEnd},
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(getOverlappingDaysInIntervals.bind(null), TypeError)
+    // $ExpectedMistake
+    assert.throws(getOverlappingDaysInIntervals.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/getQuarter/index.js
+++ b/src/utc/getQuarter/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getQuarter
+ * @category Quarter Helpers
+ * @summary Get the year quarter of the given date.
+ *
+ * @description
+ * Get the year quarter of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the quarter
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which quarter is 2 July 2014?
+ * var result = getQuarter(new Date(Date.UTC(2014, 6, 2)))
+ * //=> 3
+ */
+export default function getQuarter (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var quarter = Math.floor(date.getUTCMonth() / 3) + 1
+  return quarter
+}

--- a/src/utc/getQuarter/test.js
+++ b/src/utc/getQuarter/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getQuarter from '.'
+
+describe('utc/getQuarter', function () {
+  it('returns the quarter of the given date', function () {
+    var result = getQuarter(new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+    assert(result === 3)
+  })
+
+  it('accepts a string', function () {
+    var result = getQuarter(new Date(Date.UTC(2014, 3 /* Apr */, 2)).toISOString())
+    assert(result === 2)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getQuarter(Date.UTC(2014, 3 /* Apr */, 2))
+    assert(result === 2)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getQuarter(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getQuarter.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getQuarter.bind(null), TypeError)
+  })
+})

--- a/src/utc/getSeconds/index.js
+++ b/src/utc/getSeconds/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getSeconds
+ * @category Second Helpers
+ * @summary Get the seconds of the given date.
+ *
+ * @description
+ * Get the seconds of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the seconds
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Get the seconds of 29 February 2012 11:45:05.123:
+ * var result = getSeconds(new Date(Date.UTC(2012, 1, 29, 11, 45, 5, 123)))
+ * //=> 5
+ */
+export default function getSeconds (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var seconds = date.getUTCSeconds()
+  return seconds
+}

--- a/src/utc/getSeconds/test.js
+++ b/src/utc/getSeconds/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getSeconds from '.'
+
+describe('utc/getSeconds', function () {
+  it('returns the seconds of the given date', function () {
+    var result = getSeconds(new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45, 5, 123)))
+    assert(result === 5)
+  })
+
+  it('accepts a string', function () {
+    var result = getSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 2, 5, 15)).toISOString())
+    assert(result === 0)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getSeconds(Date.UTC(2014, 3 /* Apr */, 2, 23, 30, 42))
+    assert(result === 42)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getSeconds(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getSeconds.bind(null, new Date(Date.UTC(2012, 1 /* Feb */, 29, 11, 45, 5, 123)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getSeconds.bind(null), TypeError)
+  })
+})

--- a/src/utc/getTime/index.js
+++ b/src/utc/getTime/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getTime
+ * @category Timestamp Helpers
+ * @summary Get the milliseconds timestamp of the given date.
+ *
+ * @description
+ * Get the milliseconds timestamp of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the timestamp
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Get the timestamp of 29 February 2012 11:45:05.123:
+ * var result = getTime(new Date(Date.UTC(2012, 1, 29, 11, 45, 5, 123)))
+ * //=> 1330515905123
+ */
+export default function getTime (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var timestamp = date.getTime()
+  return timestamp
+}

--- a/src/utc/getTime/test.js
+++ b/src/utc/getTime/test.js
@@ -1,0 +1,41 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getTime from '.'
+
+describe('utc/getTime', function () {
+  it('returns the timestamp of the given date', function () {
+    var timestamp = 1483228800000
+    var result = getTime(new Date(timestamp))
+    assert(result === timestamp)
+  })
+
+  it('accepts a string', function () {
+    var timestamp = 1484503736150
+    var result = getTime(new Date(timestamp).toISOString())
+    assert(result === timestamp)
+  })
+
+  it('accepts a timestamp (and returns it unchanged)', function () {
+    var timestamp = 804643200000
+    var result = getTime(timestamp)
+    assert(result === timestamp)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getTime(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var timestamp = 1483228800000
+    // $ExpectedMistake
+    var block = getTime.bind(null, new Date(timestamp), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getTime.bind(null), TypeError)
+  })
+})

--- a/src/utc/getWeekOfMonth/index.js
+++ b/src/utc/getWeekOfMonth/index.js
@@ -1,0 +1,49 @@
+import getDate from '../getDate/index.js'
+import startOfMonth from '../startOfMonth/index.js'
+import getDay from '../getDay/index.js'
+
+/**
+ * @name getWeekOfMonth
+ * @category Week Helpers
+ * @summary Get the week of the month of the given date.
+ *
+ * @description
+ * Get the week of the month of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @returns {Number} the week of month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which week of the month is 9 November 2017?
+ * var result = getWeekOfMonth(new Date(Date.UTC(2017, 10, 9)))
+ * //=> 2
+ */
+export default function getWeekOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var startWeekDay = getDay(startOfMonth(dirtyDate, dirtyOptions), dirtyOptions)
+  var currentWeekDay = getDay(dirtyDate, dirtyOptions)
+
+  var startWeekDayWithOptions = startWeekDay < weekStartsOn ? 7 - weekStartsOn : startWeekDay
+  var diff = startWeekDayWithOptions > currentWeekDay ? 7 - weekStartsOn : 0
+
+  return Math.ceil((getDate(dirtyDate, dirtyOptions) + diff) / 7)
+}

--- a/src/utc/getWeekOfMonth/test.js
+++ b/src/utc/getWeekOfMonth/test.js
@@ -1,0 +1,95 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getWeekOfMonth from '.'
+
+describe('utc/getWeekOfMonth', function () {
+  it('returns the week of the month of the given date', function () {
+    var result = getWeekOfMonth(new Date(Date.UTC(2017, 10 /* Nov */, 15)))
+    assert(result === 3)
+  })
+
+  describe('edge cases', function () {
+    context('when the given day is the first of a month', function () {
+      it('returns the week of the month of the given date', function () {
+        var result = getWeekOfMonth(new Date(Date.UTC(2017, 10 /* Nov */, 1)))
+        assert(result === 1)
+      })
+    })
+
+    context('when the given day is the last of a month #1', function () {
+      it('returns the week of the month of the given date', function () {
+        var result = getWeekOfMonth(new Date(Date.UTC(2017, 10 /* Nov */, 30)))
+        assert(result === 5)
+      })
+    })
+
+    context('when the given day is the last of a month #2', function () {
+      it('returns the week of the month of the given date', function () {
+        var result = getWeekOfMonth(new Date(Date.UTC(2017, 9 /* Oct */, 31)))
+        assert(result === 5)
+      })
+    })
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var result = getWeekOfMonth(
+      new Date(Date.UTC(2017, 9 /* Oct */, 1)),
+      {weekStartsOn: 1}
+    )
+    assert(result === 1)
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var result = getWeekOfMonth(
+      new Date(Date.UTC(2017, 9 /* Oct */, 31)),
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert(result === 6)
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var result = getWeekOfMonth(
+      new Date(Date.UTC(2017, 10 /* Nov */, 13)),
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert(result === 3)
+  })
+
+  it('accepts a string', function () {
+    var result = getWeekOfMonth(new Date(Date.UTC(2017, 10 /* Nov */, 1)).toISOString())
+    assert(result === 1)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getWeekOfMonth(Date.UTC(2017, 10 /* Nov */, 1))
+    assert(result === 1)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getWeekOfMonth(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getWeekOfMonth.bind(null, new Date(Date.UTC(2017, 10 /* Nov */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getWeekOfMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/getWeeksInMonth/index.js
+++ b/src/utc/getWeeksInMonth/index.js
@@ -1,0 +1,49 @@
+import differenceInCalendarWeeks from '../differenceInCalendarWeeks/index.js'
+import lastDayOfMonth from '../lastDayOfMonth/index.js'
+import startOfMonth from '../startOfMonth/index.js'
+
+/**
+ * @name getWeeksInMonth
+ * @category Week Helpers
+ * @summary Get the number of calendar weeks a month spans.
+ *
+ * @description
+ * Get the number of calendar weeks the month in the given date spans.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Number} the number of calendar weeks
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // How many calendar weeks does February 2015 span?
+ * var result = getWeeksInMonth(
+ *   new Date(Date.UTC(2015, 1, 8))
+ * )
+ * //=> 4
+ *
+ * @example
+ * // If the week starts on Monday,
+ * // how many calendar weeks does July 2017 span?
+ * var result = getWeeksInMonth(
+ *   new Date(Date.UTC(2017, 6, 5)),
+ *   {weekStartsOn: 1}
+ * )
+ * //=> 6
+ */
+export default function getWeeksInMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return differenceInCalendarWeeks(
+    lastDayOfMonth(dirtyDate, dirtyOptions),
+    startOfMonth(dirtyDate, dirtyOptions),
+    dirtyOptions
+  ) + 1
+}

--- a/src/utc/getWeeksInMonth/test.js
+++ b/src/utc/getWeeksInMonth/test.js
@@ -1,0 +1,100 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getWeeksInMonth from '.'
+
+describe('utc/getWeeksInMonth', function () {
+  it('returns the number of calendar weeks the month in the given date spans', function () {
+    var result = getWeeksInMonth(
+      new Date(Date.UTC(2015, 1 /* Feb */, 8, 18, 0))
+    )
+    assert(result === 4)
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var result = getWeeksInMonth(
+      new Date(Date.UTC(2015, 1 /* Feb */, 8, 18, 0)),
+      {weekStartsOn: 1}
+    )
+    assert(result === 5)
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var result = getWeeksInMonth(
+      new Date(Date.UTC(2015, 1 /* Feb */, 8, 18, 0)),
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert(result === 5)
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var result = getWeeksInMonth(
+      new Date(Date.UTC(2015, 1 /* Feb */, 8, 18, 0)),
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert(result === 5)
+  })
+
+  it('accepts strings', function () {
+    var result = getWeeksInMonth(
+      new Date(Date.UTC(2017, 2 /* Mar */, 8, 18, 0)).toISOString()
+    )
+    assert(result === 5)
+  })
+
+  it('accepts timestamps', function () {
+    var result = getWeeksInMonth(
+      Date.UTC(2017, 3 /* Apr */, 8, 18, 0)
+    )
+    assert(result === 6)
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    getWeeksInMonth(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns NaN if the date is `Invalid Date`', function () {
+    var result = getWeeksInMonth(
+      new Date(NaN)
+    )
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    var block = getWeeksInMonth.bind(
+      null,
+      new Date(Date.UTC(2014, 6 /* Jul */, 8, 18, 0)),
+      // $ExpectedMistake
+      {weekStartsOn: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = getWeeksInMonth.bind(
+      null,
+      new Date(Date.UTC(2014, 5 /* Jun */, 29, 6, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getWeeksInMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/getYear/index.js
+++ b/src/utc/getYear/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name getYear
+ * @category Year Helpers
+ * @summary Get the year of the given date.
+ *
+ * @description
+ * Get the year of the given date.
+ *
+ * @param {Date|String|Number} date - the given date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Number} the year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which year is 2 July 2014?
+ * var result = getYear(new Date(Date.UTC(2014, 6, 2)))
+ * //=> 2014
+ */
+export default function getYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = date.getUTCFullYear()
+  return year
+}

--- a/src/utc/getYear/test.js
+++ b/src/utc/getYear/test.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getYear from '.'
+
+describe('utc/getYear', function () {
+  it('returns the year of the given date', function () {
+    var result = getYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+    assert(result === 2014)
+  })
+
+  it('accepts a string', function () {
+    var result = getYear(new Date(Date.UTC(700, 6 /* Jul */, 2)).toISOString())
+    assert(result === 700)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = getYear(Date.UTC(20000, 3 /* Apr */, 2))
+    assert(result === 20000)
+  })
+
+  it('returns NaN if the given date is invalid', function () {
+    var result = getYear(new Date(NaN))
+    assert(isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = getYear.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/isAfter/index.js
+++ b/src/utc/isAfter/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isAfter
+ * @category Common Helpers
+ * @summary Is the first date after the second one?
+ *
+ * @description
+ * Is the first date after the second one?
+ *
+ * @param {Date|String|Number} date - the date that should be after the other one to return true
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the first date is after the second date
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 10 July 1989 after 11 February 1987?
+ * var result = isAfter(new Date(Date.UTC(1989, 6, 10)), new Date(Date.UTC(1987, 1, 11)))
+ * //=> true
+ */
+export default function isAfter (dirtyDate, dirtyDateToCompare, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var dateToCompare = toDate(dirtyDateToCompare, dirtyOptions)
+  return date.getTime() > dateToCompare.getTime()
+}

--- a/src/utc/isAfter/test.js
+++ b/src/utc/isAfter/test.js
@@ -1,0 +1,87 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isAfter from '.'
+
+describe('utc/isAfter', function () {
+  it('returns true if the first date is after the second one', function () {
+    var result = isAfter(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is before the second one', function () {
+    var result = isAfter(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the first date is equal to the second one', function () {
+    var result = isAfter(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isAfter(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)).toISOString(),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isAfter(
+      Date.UTC(1989, 6 /* Jul */, 10),
+      Date.UTC(1987, 1 /* Feb */, 11)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isAfter(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isAfter(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isAfter(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isAfter.bind(
+      null,
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isAfter.bind(null), TypeError)
+    assert.throws(isAfter.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isBefore/index.js
+++ b/src/utc/isBefore/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isBefore
+ * @category Common Helpers
+ * @summary Is the first date before the second one?
+ *
+ * @description
+ * Is the first date before the second one?
+ *
+ * @param {Date|String|Number} date - the date that should be before the other one to return true
+ * @param {Date|String|Number} dateToCompare - the date to compare with
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the first date is before the second date
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 10 July 1989 before 11 February 1987?
+ * var result = isBefore(new Date(Date.UTC(1989, 6, 10)), new Date(Date.UTC(1987, 1, 11)))
+ * //=> false
+ */
+export default function isBefore (dirtyDate, dirtyDateToCompare, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var dateToCompare = toDate(dirtyDateToCompare, dirtyOptions)
+  return date.getTime() < dateToCompare.getTime()
+}

--- a/src/utc/isBefore/test.js
+++ b/src/utc/isBefore/test.js
@@ -1,0 +1,87 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isBefore from '.'
+
+describe('utc/isBefore', function () {
+  it('returns true if the first date is before the second one', function () {
+    var result = isBefore(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is after the second one', function () {
+    var result = isBefore(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the first date is equal to the second one', function () {
+    var result = isBefore(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isBefore(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString(),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isBefore(
+      Date.UTC(1987, 1 /* Feb */, 11),
+      Date.UTC(1989, 6 /* Jul */, 10)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isBefore(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isBefore(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isBefore(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isBefore.bind(
+      null,
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isBefore.bind(null), TypeError)
+    assert.throws(isBefore.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isEqual/index.js
+++ b/src/utc/isEqual/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isEqual
+ * @category Common Helpers
+ * @summary Are the given dates equal?
+ *
+ * @description
+ * Are the given dates equal?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to compare
+ * @param {Date|String|Number} dateRight - the second date to compare
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are equal
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 2 July 2014 06:30:45.000 and 2 July 2014 06:30:45.500 equal?
+ * var result = isEqual(
+ *   new Date(Date.UTC(2014, 6, 2, 6, 30, 45, 0))
+ *   new Date(Date.UTC(2014, 6, 2, 6, 30, 45, 500))
+ * )
+ * //=> false
+ */
+export default function isEqual (dirtyLeftDate, dirtyRightDate, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyLeftDate, dirtyOptions)
+  var dateRight = toDate(dirtyRightDate, dirtyOptions)
+  return dateLeft.getTime() === dateRight.getTime()
+}

--- a/src/utc/isEqual/test.js
+++ b/src/utc/isEqual/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isEqual from '.'
+
+describe('utc/isEqual', function () {
+  it('returns true if the given dates are equal', function () {
+    var result = isEqual(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates are not equal', function () {
+    var result = isEqual(
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isEqual(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString(),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isEqual(
+      Date.UTC(1987, 1 /* Feb */, 11),
+      Date.UTC(1987, 1 /* Feb */, 11)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isEqual(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isEqual(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isEqual(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isEqual.bind(
+      null,
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isEqual.bind(null), TypeError)
+    assert.throws(isEqual.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isFirstDayOfMonth/index.js
+++ b/src/utc/isFirstDayOfMonth/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isFirstDayOfMonth
+ * @category Month Helpers
+ * @summary Is the given date the first day of a month?
+ *
+ * @description
+ * Is the given date the first day of a month?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is the first day of a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 1 September 2014 the first day of a month?
+ * var result = isFirstDayOfMonth(new Date(Date.UTC(2014, 8, 1)))
+ * //=> true
+ */
+export default function isFirstDayOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDate() === 1
+}

--- a/src/utc/isFirstDayOfMonth/test.js
+++ b/src/utc/isFirstDayOfMonth/test.js
@@ -1,0 +1,44 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isFirstDayOfMonth from '.'
+
+describe('utc/isFirstDayOfMonth', function () {
+  it('returns true if the given date is in the last day of month', function () {
+    var result = isFirstDayOfMonth(new Date(Date.UTC(2014, 9 /* Oct */, 1)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not in the last day of month', function () {
+    var result = isFirstDayOfMonth(new Date(Date.UTC(2014, 9 /* Oct */, 2)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 9 /* Oct */, 1)).toISOString()
+    var result = isFirstDayOfMonth(date)
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 9 /* Oct */, 1)
+    var result = isFirstDayOfMonth(date)
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isFirstDayOfMonth(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isFirstDayOfMonth.bind(null, new Date(Date.UTC(2014, 9 /* Oct */, 1)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isFirstDayOfMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/isFriday/index.js
+++ b/src/utc/isFriday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isFriday
+ * @category Weekday Helpers
+ * @summary Is the given date Friday?
+ *
+ * @description
+ * Is the given date Friday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Friday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 26 September 2014 Friday?
+ * var result = isFriday(new Date(Date.UTC(2014, 8, 26)))
+ * //=> true
+ */
+export default function isFriday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 5
+}

--- a/src/utc/isFriday/test.js
+++ b/src/utc/isFriday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isFriday from '.'
+
+describe('utc/isFriday', function () {
+  it('returns true if the given date is Friday', function () {
+    var result = isFriday(new Date(Date.UTC(2014, 8 /* Sep */, 26)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Friday', function () {
+    var result = isFriday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isFriday(new Date(Date.UTC(2014, 6 /* Jul */, 11)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isFriday(Date.UTC(2014, 1 /* Feb */, 14))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isFriday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isFriday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 26)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isFriday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isLastDayOfMonth/index.js
+++ b/src/utc/isLastDayOfMonth/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+import endOfDay from '../endOfDay/index.js'
+import endOfMonth from '../endOfMonth/index.js'
+
+/**
+ * @name isLastDayOfMonth
+ * @category Month Helpers
+ * @summary Is the given date the last day of a month?
+ *
+ * @description
+ * Is the given date the last day of a month?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is the last day of a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 28 February 2014 the last day of a month?
+ * var result = isLastDayOfMonth(new Date(Date.UTC(2014, 1, 28)))
+ * //=> true
+ */
+export default function isLastDayOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  return endOfDay(date, dirtyOptions).getTime() === endOfMonth(date, dirtyOptions).getTime()
+}

--- a/src/utc/isLastDayOfMonth/test.js
+++ b/src/utc/isLastDayOfMonth/test.js
@@ -1,0 +1,44 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isLastDayOfMonth from '.'
+
+describe('utc/isLastDayOfMonth', function () {
+  it('returns true if the given date is in the last day of month', function () {
+    var result = isLastDayOfMonth(new Date(Date.UTC(2014, 9 /* Oct */, 31)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not in the last day of month', function () {
+    var result = isLastDayOfMonth(new Date(Date.UTC(2014, 9 /* Oct */, 30)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 9 /* Oct */, 31)).toISOString()
+    var result = isLastDayOfMonth(date)
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 9 /* Oct */, 31)
+    var result = isLastDayOfMonth(date)
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isLastDayOfMonth(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isLastDayOfMonth.bind(null, new Date(Date.UTC(2014, 9 /* Oct */, 31)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isLastDayOfMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/isLeapYear/index.js
+++ b/src/utc/isLeapYear/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isLeapYear
+ * @category Year Helpers
+ * @summary Is the given date in the leap year?
+ *
+ * @description
+ * Is the given date in the leap year?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is in the leap year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 1 September 2012 in the leap year?
+ * var result = isLeapYear(new Date(Date.UTC(2012, 8, 1)))
+ * //=> true
+ */
+export default function isLeapYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = date.getUTCFullYear()
+  return year % 400 === 0 || year % 4 === 0 && year % 100 !== 0
+}

--- a/src/utc/isLeapYear/test.js
+++ b/src/utc/isLeapYear/test.js
@@ -1,0 +1,54 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isLeapYear from '.'
+
+describe('utc/isLeapYear', function () {
+  it('returns true if the given date is in the leap year', function () {
+    var result = isLeapYear(new Date(Date.UTC(2012, 6 /* Jul */, 2)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not in the leap year', function () {
+    var result = isLeapYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+    assert(result === false)
+  })
+
+  it('works for the years divisible by 100 but not by 400', function () {
+    var result = isLeapYear(new Date(Date.UTC(2100, 6 /* Jul */, 2)))
+    assert(result === false)
+  })
+
+  it('works for the years divisible by 400', function () {
+    var result = isLeapYear(new Date(Date.UTC(2000, 6 /* Jul */, 2)))
+    assert(result === true)
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2012, 6 /* Jul */, 2)).toISOString()
+    var result = isLeapYear(date)
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2012, 6 /* Jul */, 2)
+    var result = isLeapYear(date)
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isLeapYear(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isLeapYear.bind(null, new Date(Date.UTC(2012, 6 /* Jul */, 2)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isLeapYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/isMonday/index.js
+++ b/src/utc/isMonday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isMonday
+ * @category Weekday Helpers
+ * @summary Is the given date Monday?
+ *
+ * @description
+ * Is the given date Monday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Monday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 22 September 2014 Monday?
+ * var result = isMonday(new Date(Date.UTC(2014, 8, 22)))
+ * //=> true
+ */
+export default function isMonday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 1
+}

--- a/src/utc/isMonday/test.js
+++ b/src/utc/isMonday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isMonday from '.'
+
+describe('utc/isMonday', function () {
+  it('returns true if the given date is Monday', function () {
+    var result = isMonday(new Date(Date.UTC(2014, 8 /* Sep */, 22)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Monday', function () {
+    var result = isMonday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isMonday(new Date(Date.UTC(2014, 6 /* Jul */, 7)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isMonday(Date.UTC(2014, 1 /* Feb */, 10))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isMonday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isMonday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 22)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isMonday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isSameDay/index.js
+++ b/src/utc/isSameDay/index.js
@@ -1,0 +1,36 @@
+import startOfDay from '../startOfDay/index.js'
+
+/**
+ * @name isSameDay
+ * @category Day Helpers
+ * @summary Are the given dates in the same day?
+ *
+ * @description
+ * Are the given dates in the same day?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same day
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 4 September 06:00:00 and 4 September 18:00:00 in the same day?
+ * var result = isSameDay(
+ *   new Date(Date.UTC(2014, 8, 4, 6, 0)),
+ *   new Date(Date.UTC(2014, 8, 4, 18, 0))
+ * )
+ * //=> true
+ */
+export default function isSameDay (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfDay = startOfDay(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfDay = startOfDay(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfDay.getTime() === dateRightStartOfDay.getTime()
+}

--- a/src/utc/isSameDay/test.js
+++ b/src/utc/isSameDay/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameDay from '.'
+
+describe('utc/isSameDay', function () {
+  it('returns true if the given dates have the same day', function () {
+    var result = isSameDay(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 0)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 0))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different days', function () {
+    var result = isSameDay(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 23, 59)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 5, 0, 0))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameDay(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 0)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 0)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameDay(
+      Date.UTC(2014, 8 /* Sep */, 4, 6, 0),
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 0)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameDay(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameDay(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameDay(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameDay.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 0)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 0)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameDay.bind(null), TypeError)
+    assert.throws(isSameDay.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameHour/index.js
+++ b/src/utc/isSameHour/index.js
@@ -1,0 +1,36 @@
+import startOfHour from '../startOfHour/index.js'
+
+/**
+ * @name isSameHour
+ * @category Hour Helpers
+ * @summary Are the given dates in the same hour?
+ *
+ * @description
+ * Are the given dates in the same hour?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same hour
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 4 September 2014 06:00:00 and 4 September 06:30:00 in the same hour?
+ * var result = isSameHour(
+ *   new Date(Date.UTC(2014, 8, 4, 6, 0)),
+ *   new Date(Date.UTC(2014, 8, 4, 6, 30))
+ * )
+ * //=> true
+ */
+export default function isSameHour (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfHour = startOfHour(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfHour = startOfHour(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfHour.getTime() === dateRightStartOfHour.getTime()
+}

--- a/src/utc/isSameHour/test.js
+++ b/src/utc/isSameHour/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameHour from '.'
+
+describe('utc/isSameHour', function () {
+  it('returns true if the given dates have the same hour', function () {
+    var result = isSameHour(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 0)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different hours', function () {
+    var result = isSameHour(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 0)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 5, 0))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameHour(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 0)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 45)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameHour(
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 0),
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 45)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameHour(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameHour(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameHour(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameHour.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 0)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameHour.bind(null), TypeError)
+    assert.throws(isSameHour.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameISOWeek/index.js
+++ b/src/utc/isSameISOWeek/index.js
@@ -1,0 +1,38 @@
+import isSameWeek from '../isSameWeek/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+
+/**
+ * @name isSameISOWeek
+ * @category ISO Week Helpers
+ * @summary Are the given dates in the same ISO week?
+ *
+ * @description
+ * Are the given dates in the same ISO week?
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same ISO week
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 1 September 2014 and 7 September 2014 in the same ISO week?
+ * var result = isSameISOWeek(
+ *   new Date(Date.UTC(2014, 8, 1)),
+ *   new Date(Date.UTC(2014, 8, 7))
+ * )
+ * //=> true
+ */
+export default function isSameISOWeek (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var isSameWeekOptions = cloneObject(dirtyOptions)
+  isSameWeekOptions.weekStartsOn = 1
+  return isSameWeek(dirtyDateLeft, dirtyDateRight, isSameWeekOptions)
+}

--- a/src/utc/isSameISOWeek/test.js
+++ b/src/utc/isSameISOWeek/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameISOWeek from '.'
+
+describe('utc/isSameISOWeek', function () {
+  it('returns true if the given dates have the same ISO week', function () {
+    var result = isSameISOWeek(
+      new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 7))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different ISO weeks', function () {
+    var result = isSameISOWeek(
+      new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 14))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameISOWeek(
+      new Date(Date.UTC(2014, 5 /* Jun */, 30)).toISOString(),
+      new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameISOWeek(
+      Date.UTC(2014, 5 /* Jun */, 30),
+      Date.UTC(2014, 6 /* Jul */, 2)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameISOWeek(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameISOWeek(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameISOWeek(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameISOWeek.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 7)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameISOWeek.bind(null), TypeError)
+    assert.throws(isSameISOWeek.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameISOWeekYear/index.js
+++ b/src/utc/isSameISOWeekYear/index.js
@@ -1,0 +1,38 @@
+import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
+
+/**
+ * @name isSameISOWeekYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Are the given dates in the same ISO week-numbering year?
+ *
+ * @description
+ * Are the given dates in the same ISO week-numbering year?
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same ISO week-numbering year
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 29 December 2003 and 2 January 2005 in the same ISO week-numbering year?
+ * var result = isSameISOWeekYear(
+ *   new Date(Date.UTC(2003, 11, 29)),
+ *   new Date(Date.UTC(2005, 0, 2))
+ * )
+ * //=> true
+ */
+export default function isSameISOWeekYear (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfYear = startOfISOWeekYear(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfYear = startOfISOWeekYear(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfYear.getTime() === dateRightStartOfYear.getTime()
+}

--- a/src/utc/isSameISOWeekYear/test.js
+++ b/src/utc/isSameISOWeekYear/test.js
@@ -1,0 +1,90 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameISOWeekYear from '.'
+
+describe('utc/isSameISOWeekYear', function () {
+  it('returns true if the given dates have the same ISO week-numbering year', function () {
+    var result = isSameISOWeekYear(
+      new Date(Date.UTC(2003, 11 /* Dec */, 29)),
+      new Date(Date.UTC(2005, 0 /* Jan */, 2))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different ISO week-numbering years', function () {
+    var result = isSameISOWeekYear(
+      new Date(Date.UTC(2014, 11 /* Dec */, 28)),
+      new Date(Date.UTC(2014, 11 /* Dec */, 29))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameISOWeekYear(
+      new Date(Date.UTC(2003, 11 /* Dec */, 29)).toISOString(),
+      new Date(Date.UTC(2005, 0 /* Jan */, 2)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameISOWeekYear(
+      Date.UTC(2003, 11 /* Dec */, 29),
+      Date.UTC(2005, 0 /* Jan */, 2)
+    )
+    assert(result === true)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var firstDate = new Date(0)
+    firstDate.setUTCFullYear(5, 0 /* Jan */, 1)
+    firstDate.setUTCHours(0, 0, 0, 0)
+    var secondDate = new Date(0)
+    secondDate.setUTCFullYear(5, 0 /* Jan */, 2)
+    secondDate.setUTCHours(0, 0, 0, 0)
+    var result = isSameISOWeekYear(firstDate, secondDate)
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameISOWeekYear(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameISOWeekYear(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameISOWeekYear(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameISOWeekYear.bind(
+      null,
+      new Date(Date.UTC(2003, 11 /* Dec */, 29)),
+      new Date(Date.UTC(2005, 0 /* Jan */, 2)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameISOWeekYear.bind(null), TypeError)
+    assert.throws(isSameISOWeekYear.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameMinute/index.js
+++ b/src/utc/isSameMinute/index.js
@@ -1,0 +1,37 @@
+import startOfMinute from '../startOfMinute/index.js'
+
+/**
+ * @name isSameMinute
+ * @category Minute Helpers
+ * @summary Are the given dates in the same minute?
+ *
+ * @description
+ * Are the given dates in the same minute?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same minute
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 4 September 2014 06:30:00 and 4 September 2014 06:30:15
+ * // in the same minute?
+ * var result = isSameMinute(
+ *   new Date(Date.UTC(2014, 8, 4, 6, 30)),
+ *   new Date(Date.UTC(2014, 8, 4, 6, 30, 15))
+ * )
+ * //=> true
+ */
+export default function isSameMinute (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfMinute = startOfMinute(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfMinute = startOfMinute(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfMinute.getTime() === dateRightStartOfMinute.getTime()
+}

--- a/src/utc/isSameMinute/test.js
+++ b/src/utc/isSameMinute/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameMinute from '.'
+
+describe('utc/isSameMinute', function () {
+  it('returns true if the given dates have the same minute', function () {
+    var result = isSameMinute(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 15))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different minutes', function () {
+    var result = isSameMinute(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 59)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 31))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameMinute(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 45)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 45, 30)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameMinute(
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 45),
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 45, 30)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameMinute(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameMinute(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameMinute(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameMinute.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 15)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameMinute.bind(null), TypeError)
+    assert.throws(isSameMinute.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameMonth/index.js
+++ b/src/utc/isSameMonth/index.js
@@ -1,0 +1,36 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isSameMonth
+ * @category Month Helpers
+ * @summary Are the given dates in the same month?
+ *
+ * @description
+ * Are the given dates in the same month?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same month
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 2 September 2014 and 25 September 2014 in the same month?
+ * var result = isSameMonth(
+ *   new Date(Date.UTC(2014, 8, 2)),
+ *   new Date(Date.UTC(2014, 8, 25))
+ * )
+ * //=> true
+ */
+export default function isSameMonth (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+  return dateLeft.getUTCFullYear() === dateRight.getUTCFullYear() &&
+    dateLeft.getUTCMonth() === dateRight.getUTCMonth()
+}

--- a/src/utc/isSameMonth/test.js
+++ b/src/utc/isSameMonth/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameMonth from '.'
+
+describe('utc/isSameMonth', function () {
+  it('returns true if the given dates have the same month (and year)', function () {
+    var result = isSameMonth(
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different months', function () {
+    var result = isSameMonth(
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)),
+      new Date(Date.UTC(2013, 8 /* Sep */, 25))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameMonth(
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameMonth(
+      Date.UTC(2014, 8 /* Sep */, 2),
+      Date.UTC(2014, 8 /* Sep */, 25)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameMonth(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameMonth(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameMonth(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameMonth.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameMonth.bind(null), TypeError)
+    assert.throws(isSameMonth.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameQuarter/index.js
+++ b/src/utc/isSameQuarter/index.js
@@ -1,0 +1,36 @@
+import startOfQuarter from '../startOfQuarter/index.js'
+
+/**
+ * @name isSameQuarter
+ * @category Quarter Helpers
+ * @summary Are the given dates in the same year quarter?
+ *
+ * @description
+ * Are the given dates in the same year quarter?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same quarter
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 1 January 2014 and 8 March 2014 in the same quarter?
+ * var result = isSameQuarter(
+ *   new Date(Date.UTC(2014, 0, 1)),
+ *   new Date(Date.UTC(2014, 2, 8))
+ * )
+ * //=> true
+ */
+export default function isSameQuarter (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfQuarter = startOfQuarter(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfQuarter = startOfQuarter(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfQuarter.getTime() === dateRightStartOfQuarter.getTime()
+}

--- a/src/utc/isSameQuarter/test.js
+++ b/src/utc/isSameQuarter/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameQuarter from '.'
+
+describe('utc/isSameQuarter', function () {
+  it('returns true if the given dates have the same quarter (and year)', function () {
+    var result = isSameQuarter(
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)),
+      new Date(Date.UTC(2014, 2 /* Mar */, 8))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different quarters', function () {
+    var result = isSameQuarter(
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)),
+      new Date(Date.UTC(2013, 8 /* Sep */, 25))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameQuarter(
+      new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameQuarter(
+      Date.UTC(2014, 6 /* Jul */, 2),
+      Date.UTC(2014, 8 /* Sep */, 25)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameQuarter(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameQuarter(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameQuarter(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameQuarter.bind(
+      null,
+      new Date(Date.UTC(2014, 0 /* Jan */, 1)),
+      new Date(Date.UTC(2014, 2 /* Mar */, 8)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameQuarter.bind(null), TypeError)
+    assert.throws(isSameQuarter.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameSecond/index.js
+++ b/src/utc/isSameSecond/index.js
@@ -1,0 +1,37 @@
+import startOfSecond from '../startOfSecond/index.js'
+
+/**
+ * @name isSameSecond
+ * @category Second Helpers
+ * @summary Are the given dates in the same second?
+ *
+ * @description
+ * Are the given dates in the same second?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same second
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 4 September 2014 06:30:15.000 and 4 September 2014 06:30.15.500
+ * // in the same second?
+ * var result = isSameSecond(
+ *   new Date(Date.UTC(2014, 8, 4, 6, 30, 15)),
+ *   new Date(Date.UTC(2014, 8, 4, 6, 30, 15, 500))
+ * )
+ * //=> true
+ */
+export default function isSameSecond (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfSecond = startOfSecond(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfSecond = startOfSecond(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfSecond.getTime() === dateRightStartOfSecond.getTime()
+}

--- a/src/utc/isSameSecond/test.js
+++ b/src/utc/isSameSecond/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameSecond from '.'
+
+describe('utc/isSameSecond', function () {
+  it('returns true if the given dates have the same second', function () {
+    var result = isSameSecond(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 15)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 15, 500))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different seconds', function () {
+    var result = isSameSecond(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 58, 999)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 59))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameSecond(
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 45, 30)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 18, 45, 30, 400)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameSecond(
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 45, 30),
+      Date.UTC(2014, 8 /* Sep */, 4, 18, 45, 30, 400)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameSecond(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameSecond(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameSecond(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameSecond.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 15)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4, 6, 30, 15, 500)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameSecond.bind(null), TypeError)
+    assert.throws(isSameSecond.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameWeek/index.js
+++ b/src/utc/isSameWeek/index.js
@@ -1,0 +1,49 @@
+import startOfWeek from '../startOfWeek/index.js'
+
+/**
+ * @name isSameWeek
+ * @category Week Helpers
+ * @summary Are the given dates in the same week?
+ *
+ * @description
+ * Are the given dates in the same week?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Boolean} the dates are in the same week
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // Are 31 August 2014 and 4 September 2014 in the same week?
+ * var result = isSameWeek(
+ *   new Date(Date.UTC(2014, 7, 31)),
+ *   new Date(Date.UTC(2014, 8, 4))
+ * )
+ * //=> true
+ *
+ * @example
+ * // If week starts with Monday,
+ * // are 31 August 2014 and 4 September 2014 in the same week?
+ * var result = isSameWeek(
+ *   new Date(Date.UTC(2014, 7, 31)),
+ *   new Date(Date.UTC(2014, 8, 4)),
+ *   {weekStartsOn: 1}
+ * )
+ * //=> false
+ */
+export default function isSameWeek (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeftStartOfWeek = startOfWeek(dirtyDateLeft, dirtyOptions)
+  var dateRightStartOfWeek = startOfWeek(dirtyDateRight, dirtyOptions)
+
+  return dateLeftStartOfWeek.getTime() === dateRightStartOfWeek.getTime()
+}

--- a/src/utc/isSameWeek/test.js
+++ b/src/utc/isSameWeek/test.js
@@ -1,0 +1,138 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameWeek from '.'
+
+describe('utc/isSameWeek', function () {
+  it('returns true if the given dates have the same week', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different weeks', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 30)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4))
+    )
+    assert(result === false)
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)),
+      {weekStartsOn: 1}
+    )
+    assert(result === false)
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)),
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert(result === false)
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)),
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert(result === false)
+  })
+
+  it('implicitly converts options', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)),
+      // $ExpectedMistake
+      {weekStartsOn: '1'}
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameWeek(
+      Date.UTC(2014, 7 /* Aug */, 31),
+      Date.UTC(2014, 8 /* Sep */, 4)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameWeek(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameWeek(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameWeek(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    var block = isSameWeek.bind(
+      null,
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)),
+      // $ExpectedMistake
+      {weekStartsOn: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameWeek.bind(
+      null,
+      new Date(Date.UTC(2014, 7 /* Aug */, 31)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 4)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameWeek.bind(null), TypeError)
+    assert.throws(isSameWeek.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSameYear/index.js
+++ b/src/utc/isSameYear/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isSameYear
+ * @category Year Helpers
+ * @summary Are the given dates in the same year?
+ *
+ * @description
+ * Are the given dates in the same year?
+ *
+ * @param {Date|String|Number} dateLeft - the first date to check
+ * @param {Date|String|Number} dateRight - the second date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the dates are in the same year
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Are 2 September 2014 and 25 September 2014 in the same year?
+ * var result = isSameYear(
+ *   new Date(Date.UTC(2014, 8, 2)),
+ *   new Date(Date.UTC(2014, 8, 25))
+ * )
+ * //=> true
+ */
+export default function isSameYear (dirtyDateLeft, dirtyDateRight, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateLeft = toDate(dirtyDateLeft, dirtyOptions)
+  var dateRight = toDate(dirtyDateRight, dirtyOptions)
+  return dateLeft.getUTCFullYear() === dateRight.getUTCFullYear()
+}

--- a/src/utc/isSameYear/test.js
+++ b/src/utc/isSameYear/test.js
@@ -1,0 +1,79 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSameYear from '.'
+
+describe('utc/isSameYear', function () {
+  it('returns true if the given dates have the same year', function () {
+    var result = isSameYear(
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25))
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given dates have different years', function () {
+    var result = isSameYear(
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)),
+      new Date(Date.UTC(2013, 8 /* Sep */, 25))
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSameYear(
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)).toISOString(),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25)).toISOString()
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSameYear(
+      Date.UTC(2014, 8 /* Sep */, 2),
+      Date.UTC(2014, 8 /* Sep */, 25)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function () {
+    var result = isSameYear(
+      new Date(NaN),
+      new Date(Date.UTC(1989, 6 /* Jul */, 10))
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function () {
+    var result = isSameYear(
+      new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function () {
+    var result = isSameYear(
+      new Date(NaN),
+      new Date(NaN)
+    )
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isSameYear.bind(
+      null,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2)),
+      new Date(Date.UTC(2014, 8 /* Sep */, 25)),
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isSameYear.bind(null), TypeError)
+    assert.throws(isSameYear.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/isSaturday/index.js
+++ b/src/utc/isSaturday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isSaturday
+ * @category Weekday Helpers
+ * @summary Is the given date Saturday?
+ *
+ * @description
+ * Is the given date Saturday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Saturday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 27 September 2014 Saturday?
+ * var result = isSaturday(new Date(Date.UTC(2014, 8, 27)))
+ * //=> true
+ */
+export default function isSaturday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 6
+}

--- a/src/utc/isSaturday/test.js
+++ b/src/utc/isSaturday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSaturday from '.'
+
+describe('utc/isSaturday', function () {
+  it('returns true if the given date is Saturday', function () {
+    var result = isSaturday(new Date(Date.UTC(2014, 8 /* Sep */, 27)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Saturday', function () {
+    var result = isSaturday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSaturday(new Date(Date.UTC(2014, 6 /* Jul */, 12)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSaturday(Date.UTC(2014, 1 /* Feb */, 15))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isSaturday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isSaturday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 27)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isSaturday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isSunday/index.js
+++ b/src/utc/isSunday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isSunday
+ * @category Weekday Helpers
+ * @summary Is the given date Sunday?
+ *
+ * @description
+ * Is the given date Sunday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Sunday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 21 September 2014 Sunday?
+ * var result = isSunday(new Date(Date.UTC(2014, 8, 21)))
+ * //=> true
+ */
+export default function isSunday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 0
+}

--- a/src/utc/isSunday/test.js
+++ b/src/utc/isSunday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isSunday from '.'
+
+describe('utc/isSunday', function () {
+  it('returns true if the given date is Sunday', function () {
+    var result = isSunday(new Date(Date.UTC(2014, 8 /* Sep */, 21)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Sunday', function () {
+    var result = isSunday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isSunday(new Date(Date.UTC(2014, 6 /* Jul */, 6)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isSunday(Date.UTC(2014, 1 /* Feb */, 9))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isSunday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isSunday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 21)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isSunday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isThursday/index.js
+++ b/src/utc/isThursday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isThursday
+ * @category Weekday Helpers
+ * @summary Is the given date Thursday?
+ *
+ * @description
+ * Is the given date Thursday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Thursday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 25 September 2014 Thursday?
+ * var result = isThursday(new Date(Date.UTC(2014, 8, 25)))
+ * //=> true
+ */
+export default function isThursday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 4
+}

--- a/src/utc/isThursday/test.js
+++ b/src/utc/isThursday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isThursday from '.'
+
+describe('utc/isThursday', function () {
+  it('returns true if the given date is Thursday', function () {
+    var result = isThursday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Thursday', function () {
+    var result = isThursday(new Date(Date.UTC(2014, 8 /* Sep */, 24)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isThursday(new Date(Date.UTC(2014, 6 /* Jul */, 10)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isThursday(Date.UTC(2014, 1 /* Feb */, 13))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isThursday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isThursday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 25)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isThursday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isTuesday/index.js
+++ b/src/utc/isTuesday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isTuesday
+ * @category Weekday Helpers
+ * @summary Is the given date Tuesday?
+ *
+ * @description
+ * Is the given date Tuesday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Tuesday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 23 September 2014 Tuesday?
+ * var result = isTuesday(new Date(Date.UTC(2014, 8, 23)))
+ * //=> true
+ */
+export default function isTuesday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 2
+}

--- a/src/utc/isTuesday/test.js
+++ b/src/utc/isTuesday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isTuesday from '.'
+
+describe('utc/isTuesday', function () {
+  it('returns true if the given date is Tuesday', function () {
+    var result = isTuesday(new Date(Date.UTC(2014, 8 /* Sep */, 23)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Tuesday', function () {
+    var result = isTuesday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isTuesday(new Date(Date.UTC(2014, 6 /* Jul */, 8)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isTuesday(Date.UTC(2014, 1 /* Feb */, 11))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isTuesday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isTuesday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 23)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isTuesday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isValid/index.js
+++ b/src/utc/isValid/index.js
@@ -1,0 +1,44 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isValid
+ * @category Common Helpers
+ * @summary Is the given date valid?
+ *
+ * @description
+ * Returns false if argument is Invalid Date and true otherwise.
+ * Argument is converted to Date using `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * Invalid Date is a Date, whose time value is NaN.
+ *
+ * Time value of Date: http://es5.github.io/#x15.9.1.1
+ *
+ * @param {*} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is valid
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // For the valid date:
+ * var result = isValid(new Date(Date.UTC(2014, 1, 31)))
+ * //=> true
+ *
+ * @example
+ * // For the value, convertable into a date:
+ * var result = isValid('2014-02-31')
+ * //=> true
+ *
+ * @example
+ * // For the invalid date:
+ * var result = isValid(new Date(''))
+ * //=> false
+ */
+export default function isValid (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  return !isNaN(date)
+}

--- a/src/utc/isValid/test.js
+++ b/src/utc/isValid/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isValid from '.'
+
+describe('utc/isValid', function () {
+  it('returns true if the given date is valid', function () {
+    var result = isValid(new Date())
+    assert(result === true)
+  })
+
+  it('returns false if the given date is invalid', function () {
+    var result = isValid(new Date(''))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    assert(isValid(new Date(Date.UTC(2014, 6 /* Jul */, 8)).toString()) === true)
+    assert(isValid('') === false)
+  })
+
+  it('accepts a timestamp', function () {
+    assert(isValid(Date.UTC(2014, 1 /* Feb */, 11)) === true)
+    assert(isValid(NaN) === false)
+  })
+
+  it('treats null as an invalid date', function () {
+    var result = isValid(null)
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isValid.bind(null, new Date(), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isValid.bind(null), TypeError)
+  })
+})

--- a/src/utc/isWednesday/index.js
+++ b/src/utc/isWednesday/index.js
@@ -1,0 +1,29 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isWednesday
+ * @category Weekday Helpers
+ * @summary Is the given date Wednesday?
+ *
+ * @description
+ * Is the given date Wednesday?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is Wednesday
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Is 24 September 2014 Wednesday?
+ * var result = isWednesday(new Date(Date.UTC(2014, 8, 24)))
+ * //=> true
+ */
+export default function isWednesday (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  return toDate(dirtyDate, dirtyOptions).getUTCDay() === 3
+}

--- a/src/utc/isWednesday/test.js
+++ b/src/utc/isWednesday/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isWednesday from '.'
+
+describe('utc/isWednesday', function () {
+  it('returns true if the given date is Wednesday', function () {
+    var result = isWednesday(new Date(Date.UTC(2014, 8 /* Sep */, 24)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not Wednesday', function () {
+    var result = isWednesday(new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isWednesday(new Date(Date.UTC(2014, 6 /* Jul */, 9)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isWednesday(Date.UTC(2014, 1 /* Feb */, 12))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isWednesday(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isWednesday.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 24)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isWednesday.bind(null), TypeError)
+  })
+})

--- a/src/utc/isWeekend/index.js
+++ b/src/utc/isWeekend/index.js
@@ -1,0 +1,31 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isWeekend
+ * @category Weekday Helpers
+ * @summary Does the given date fall on a weekend?
+ *
+ * @description
+ * Does the given date fall on a weekend?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date falls on a weekend
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Does 5 October 2014 fall on a weekend?
+ * var result = isWeekend(new Date(Date.UTC(2014, 9, 5)))
+ * //=> true
+ */
+export default function isWeekend (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var day = date.getUTCDay()
+  return day === 0 || day === 6
+}

--- a/src/utc/isWeekend/test.js
+++ b/src/utc/isWeekend/test.js
@@ -1,0 +1,42 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isWeekend from '.'
+
+describe('utc/isWeekend', function () {
+  it('returns true if the given date is in a weekend', function () {
+    var result = isWeekend(new Date(Date.UTC(2014, 9 /* Oct */, 5)))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is not in a weekend', function () {
+    var result = isWeekend(new Date(Date.UTC(2014, 9 /* Oct */, 6)))
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isWeekend(new Date(Date.UTC(2014, 9 /* Oct */, 5)).toString())
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isWeekend(Date.UTC(2014, 9 /* Oct */, 5))
+    assert(result === true)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isWeekend(new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    // $ExpectedMistake
+    var block = isWeekend.bind(null, new Date(Date.UTC(2014, 9 /* Oct */, 5)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(isWeekend.bind(null), TypeError)
+  })
+})

--- a/src/utc/isWithinInterval/index.js
+++ b/src/utc/isWithinInterval/index.js
@@ -1,0 +1,53 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name isWithinInterval
+ * @category Interval Helpers
+ * @summary Is the given date within the interval?
+ *
+ * @description
+ * Is the given date within the interval?
+ *
+ * @param {Date|String|Number} date - the date to check
+ * @param {Interval} interval - the interval to check
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Boolean} the date is within the interval
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} The start of an interval cannot be after its end
+ * @throws {RangeError} Date in interval cannot be `Invalid Date`
+ *
+ * @example
+ * // For the date within the interval:
+ * isWithinInterval(
+ *   new Date(Date.UTC(2014, 0, 3)),
+ *   {start: new Date(Date.UTC(2014, 0, 1)), end: new Date(Date.UTC(2014, 0, 7))}
+ * )
+ * //=> true
+ *
+ * @example
+ * // For the date outside of the interval:
+ * isWithinInterval(
+ *   new Date(Date.UTC(2014, 0, 10)),
+ *   {start: new Date(Date.UTC(2014, 0, 1)), end: new Date(Date.UTC(2014, 0, 7))}
+ * )
+ * //=> false
+ */
+export default function isWithinInterval (dirtyDate, dirtyInterval, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var interval = dirtyInterval || {}
+  var time = toDate(dirtyDate, dirtyOptions).getTime()
+  var startTime = toDate(interval.start, dirtyOptions).getTime()
+  var endTime = toDate(interval.end, dirtyOptions).getTime()
+
+  // Throw an exception if start date is after end date or if any date is `Invalid Date`
+  if (!(startTime <= endTime)) {
+    throw new RangeError('Invalid interval')
+  }
+
+  return time >= startTime && time <= endTime
+}

--- a/src/utc/isWithinInterval/test.js
+++ b/src/utc/isWithinInterval/test.js
@@ -1,0 +1,124 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isWithinInterval from '.'
+
+describe('utc/isWithinInterval', function () {
+  it('returns true if the given date in within the given interval', function () {
+    var result = isWithinInterval(
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))}
+    )
+    assert(result === true)
+  })
+
+  it('returns true if the given date has same time as the left boundary of the interval', function () {
+    var result = isWithinInterval(
+      new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))}
+    )
+    assert(result === true)
+  })
+
+  it('returns true if the given date has same time as the right boundary of the interval', function () {
+    var result = isWithinInterval(
+      new Date(Date.UTC(2014, 11 /* Dec */, 31)),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))}
+    )
+    assert(result === true)
+  })
+
+  it('returns true if the given date and the both boundaries are the same', function () {
+    var result = isWithinInterval(
+      new Date(Date.UTC(2014, 11 /* Dec */, 31)),
+      {start: new Date(Date.UTC(2014, 11 /* Dec */, 31)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))}
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given date is outside of the interval', function () {
+    var result = isWithinInterval(
+      new Date(Date.UTC(2014, 1 /* Feb */, 11)),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))}
+    )
+    assert(result === false)
+  })
+
+  it('accepts a string', function () {
+    var result = isWithinInterval(
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)).toISOString(),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), end: new Date(Date.UTC(2014, 11 /* Dec */, 31)).toISOString()}
+    )
+    assert(result === true)
+  })
+
+  it('accepts a timestamp', function () {
+    var result = isWithinInterval(
+      Date.UTC(2014, 9 /* Oct */, 31),
+      {start: Date.UTC(2014, 8 /* Sep */, 1), end: Date.UTC(2014, 11 /* Dec */, 31)}
+    )
+    assert(result === true)
+  })
+
+  it('throws an exception if the start date is after the end date', function () {
+    var block = isWithinInterval.bind(
+      null,
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)),
+      {start: new Date(Date.UTC(2014, 11 /* Dec */, 31)), end: new Date(Date.UTC(2014, 8 /* Sep */, 1))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the interval is undefined', function () {
+    var block = isWithinInterval.bind(
+      null,
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)),
+      // $ExpectedMistake
+      undefined
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('returns false if the given date is `Invalid Date`', function () {
+    var result = isWithinInterval(
+      new Date(NaN),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))}
+    )
+    assert(result === false)
+  })
+
+  it('throws an exception if the start date is `Invalid Date`', function () {
+    var block = isWithinInterval.bind(
+      null,
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)),
+      {start: new Date(NaN), end: new Date(Date.UTC(2014, 8 /* Sep */, 1))}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws an exception if the end date is `Invalid Date`', function () {
+    var block = isWithinInterval.bind(
+      null,
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)),
+      {start: new Date(Date.UTC(2014, 11 /* Dec */, 31)), end: new Date(NaN)}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+    var block = isWithinInterval.bind(
+      null,
+      new Date(Date.UTC(2014, 9 /* Oct */, 31)),
+      {start: new Date(Date.UTC(2014, 8 /* Sep */, 1)), end: new Date(Date.UTC(2014, 11 /* Dec */, 31))},
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(isWithinInterval.bind(null), TypeError)
+    assert.throws(isWithinInterval.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/lastDayOfISOWeek/index.js
+++ b/src/utc/lastDayOfISOWeek/index.js
@@ -1,0 +1,35 @@
+import lastDayOfWeek from '../lastDayOfWeek/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+
+/**
+ * @name lastDayOfISOWeek
+ * @category ISO Week Helpers
+ * @summary Return the last day of an ISO week for the given date.
+ *
+ * @description
+ * Return the last day of an ISO week for the given date.
+ * The result will be in the local timezone.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the last day of an ISO week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The last day of an ISO week for 2 September 2014 11:55:00:
+ * var result = lastDayOfISOWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Sun Sep 07 2014 00:00:00
+ */
+export default function lastDayOfISOWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var lastDayOfWeekOptions = cloneObject(dirtyOptions)
+  lastDayOfWeekOptions.weekStartsOn = 1
+  return lastDayOfWeek(dirtyDate, lastDayOfWeekOptions)
+}

--- a/src/utc/lastDayOfISOWeek/test.js
+++ b/src/utc/lastDayOfISOWeek/test.js
@@ -1,0 +1,53 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import lastDayOfISOWeek from '.'
+
+describe('utc/lastDayOfISOWeek', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last day of an ISO week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfISOWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2, 11, 55, 0)).toISOString()
+    var result = lastDayOfISOWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 6 /* Jul */, 6))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 1 /* Feb */, 11, 11, 55, 0)
+    var result = lastDayOfISOWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 1 /* Feb */, 16))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    lastDayOfISOWeek(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = lastDayOfISOWeek(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = lastDayOfISOWeek.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(lastDayOfISOWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/lastDayOfISOWeekYear/index.js
+++ b/src/utc/lastDayOfISOWeekYear/index.js
@@ -1,0 +1,40 @@
+import getISOWeekYear from '../getISOWeekYear/index.js'
+import startOfISOWeek from '../startOfISOWeek/index.js'
+
+/**
+ * @name lastDayOfISOWeekYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Return the last day of an ISO week-numbering year for the given date.
+ *
+ * @description
+ * Return the last day of an ISO week-numbering year,
+ * which always starts 3 days before the year's first Thursday.
+ * The result will be in the local timezone.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the end of an ISO week-numbering year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The last day of an ISO week-numbering year for 2 July 2005:
+ * var result = lastDayOfISOWeekYear(new Date(Date.UTC(2005, 6, 2)))
+ * //=> Sun Jan 01 2006 00:00:00
+ */
+export default function lastDayOfISOWeekYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var year = getISOWeekYear(dirtyDate, dirtyOptions)
+  var fourthOfJanuary = new Date(0)
+  fourthOfJanuary.setUTCFullYear(year + 1, 0, 4)
+  fourthOfJanuary.setUTCHours(0, 0, 0, 0)
+  var date = startOfISOWeek(fourthOfJanuary, dirtyOptions)
+  date.setUTCDate(date.getUTCDate() - 1)
+  return date
+}

--- a/src/utc/lastDayOfISOWeekYear/test.js
+++ b/src/utc/lastDayOfISOWeekYear/test.js
@@ -1,0 +1,54 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import lastDayOfISOWeekYear from '.'
+
+describe('utc/lastDayOfISOWeekYear', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last day of an ISO year', function () {
+    var result = lastDayOfISOWeekYear(new Date(Date.UTC(2009, 0 /* Jan */, 1, 16, 0)))
+    assert.deepEqual(result, new Date(Date.UTC(2010, 0 /* Jan */, 3)))
+  })
+
+  it('accepts a string', function () {
+    var result = lastDayOfISOWeekYear(new Date(Date.UTC(2005, 0 /* Jan */, 1, 6, 0)).toISOString())
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 2)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = lastDayOfISOWeekYear(Date.UTC(2005, 0 /* Jan */, 1, 6, 0))
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 2)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    lastDayOfISOWeekYear(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(5, 0 /* Jan */, 4)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(6, 0 /* Jan */, 1)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = lastDayOfISOWeekYear(initialDate)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = lastDayOfISOWeekYear(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = lastDayOfISOWeekYear.bind(null, new Date(Date.UTC(2009, 0 /* Jan */, 1, 16, 0)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(lastDayOfISOWeekYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/lastDayOfMonth/index.js
+++ b/src/utc/lastDayOfMonth/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name lastDayOfMonth
+ * @category Month Helpers
+ * @summary Return the last day of a month for the given date.
+ *
+ * @description
+ * Return the last day of a month for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the last day of a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The last day of a month for 2 September 2014 11:55:00:
+ * var result = lastDayOfMonth(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Sep 30 2014 00:00:00
+ */
+export default function lastDayOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var month = date.getUTCMonth()
+  date.setUTCFullYear(date.getUTCFullYear(), month + 1, 0)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/lastDayOfMonth/test.js
+++ b/src/utc/lastDayOfMonth/test.js
@@ -1,0 +1,71 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import lastDayOfMonth from '.'
+
+describe('utc/lastDayOfMonth', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last day of a month', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfMonth(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 30))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 2, 11, 55, 0)).toISOString()
+    var result = lastDayOfMonth(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 7 /* Aug */, 2, 11, 55, 0)
+    var result = lastDayOfMonth(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 7 /* Aug */, 31))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    lastDayOfMonth(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  describe('edge cases', function () {
+    it('works for the February of a leap year', function () {
+      var date = new Date(Date.UTC(2012, 1 /* Feb */, 11, 11, 55, 0))
+      var result = lastDayOfMonth(date)
+      assert.deepEqual(result,
+        new Date(Date.UTC(2012, 1 /* Feb */, 29))
+      )
+    })
+
+    it('works for the February of a non-leap year', function () {
+      var date = new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 55, 0))
+      var result = lastDayOfMonth(date)
+      assert.deepEqual(result,
+        new Date(Date.UTC(2014, 1 /* Feb */, 28))
+      )
+    })
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = lastDayOfMonth(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = lastDayOfMonth.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(lastDayOfMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/lastDayOfQuarter/index.js
+++ b/src/utc/lastDayOfQuarter/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name lastDayOfQuarter
+ * @category Quarter Helpers
+ * @summary Return the last day of a year quarter for the given date.
+ *
+ * @description
+ * Return the last day of a year quarter for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the last day of a quarter
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The last day of a quarter for 2 September 2014 11:55:00:
+ * var result = lastDayOfQuarter(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Sep 30 2014 00:00:00
+ */
+export default function lastDayOfQuarter (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var currentMonth = date.getUTCMonth()
+  var month = currentMonth - currentMonth % 3 + 3
+  date.setUTCMonth(month, 0)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/lastDayOfQuarter/test.js
+++ b/src/utc/lastDayOfQuarter/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import lastDayOfQuarter from '.'
+
+describe('utc/lastDayOfQuarter', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last day of a quarter', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 0 /* Jan */, 1, 11, 55, 0)).toISOString()
+    var result = lastDayOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 2 /* Mar */, 31)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = lastDayOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    lastDayOfQuarter(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = lastDayOfQuarter(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = lastDayOfQuarter.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(lastDayOfQuarter.bind(null), TypeError)
+  })
+})

--- a/src/utc/lastDayOfWeek/index.js
+++ b/src/utc/lastDayOfWeek/index.js
@@ -1,0 +1,55 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name lastDayOfWeek
+ * @category Week Helpers
+ * @summary Return the last day of a week for the given date.
+ *
+ * @description
+ * Return the last day of a week for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Date} the last day of a week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // The last day of a week for 2 September 2014 11:55:00:
+ * var result = lastDayOfWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Sat Sep 06 2014 00:00:00
+ *
+ * @example
+ * // If the week starts on Monday, the last day of the week for 2 September 2014 11:55:00:
+ * var result = lastDayOfWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)), {weekStartsOn: 1})
+ * //=> Sun Sep 07 2014 00:00:00
+ */
+export default function lastDayOfWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var day = date.getUTCDay()
+  var diff = (day < weekStartsOn ? -7 : 0) + 6 - (day - weekStartsOn)
+
+  date.setUTCHours(0, 0, 0, 0)
+  date.setUTCDate(date.getUTCDate() + diff)
+  return date
+}

--- a/src/utc/lastDayOfWeek/test.js
+++ b/src/utc/lastDayOfWeek/test.js
@@ -1,0 +1,141 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import lastDayOfWeek from '.'
+
+describe('utc/lastDayOfWeek', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last day of a week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 6))
+    )
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfWeek(date, {weekStartsOn: 1})
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7))
+    )
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfWeek(
+      date,
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7))
+    )
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfWeek(
+      date,
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7))
+    )
+  })
+
+  it('implicitly converts options', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var result = lastDayOfWeek(date, {weekStartsOn: '1'})
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 7))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = lastDayOfWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 6))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = lastDayOfWeek(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 6))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    lastDayOfWeek(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  describe('edge cases', function () {
+    context('when the given day is before the start of a week', function () {
+      it('it returns the last day of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 6))
+        var result = lastDayOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 7)))
+      })
+    })
+
+    context('when the given day is the start of a week', function () {
+      it('it returns the last day of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 8))
+        var result = lastDayOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 14)))
+      })
+    })
+
+    context('when the given day is after the start of a week', function () {
+      it('it returns the last day of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 10))
+        var result = lastDayOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 14)))
+      })
+    })
+
+    it('handles the week at the end of a year', function () {
+      var date = new Date(Date.UTC(2014, 11 /* Dec */, 29))
+      var result = lastDayOfWeek(date, {weekStartsOn: 5})
+      assert.deepEqual(result, new Date(Date.UTC(2015, 0 /* Jan */, 1)))
+    })
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = lastDayOfWeek(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // $ExpectedMistake
+    var block = lastDayOfWeek.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)), {weekStartsOn: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = lastDayOfWeek.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(lastDayOfWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/lastDayOfYear/index.js
+++ b/src/utc/lastDayOfYear/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name lastDayOfYear
+ * @category Year Helpers
+ * @summary Return the last day of a year for the given date.
+ *
+ * @description
+ * Return the last day of a year for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the last day of a year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The last day of a year for 2 September 2014 11:55:00:
+ * var result = lastDayOfYear(new Date(Date.UTC(2014, 8, 2, 11, 55, 00)))
+ * //=> Wed Dec 31 2014 00:00:00
+ */
+export default function lastDayOfYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = date.getUTCFullYear()
+  date.setUTCFullYear(year + 1, 0, 0)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/lastDayOfYear/test.js
+++ b/src/utc/lastDayOfYear/test.js
@@ -1,0 +1,53 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import lastDayOfYear from '.'
+
+describe('utc/lastDayOfYear', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last day of a year', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = lastDayOfYear(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = lastDayOfYear(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = lastDayOfYear(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    lastDayOfYear(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = lastDayOfYear(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = lastDayOfYear.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(lastDayOfYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/max/index.js
+++ b/src/utc/max/index.js
@@ -1,0 +1,59 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name max
+ * @category Common Helpers
+ * @summary Return the latest of the given dates.
+ *
+ * @description
+ * Return the latest of the given dates.
+ *
+ * @param {Date[]|String[]|Number[]} datesArray - the dates to compare
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the latest of the dates
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which of these dates is the latest?
+ * var result = max(
+ *  [
+ *    new Date(Date.UTC(1989, 6, 10)),
+ *    new Date(Date.UTC(1987, 1, 11)),
+ *    new Date(Date.UTC(1995, 6, 2)),
+ *    new Date(Date.UTC(1990, 0, 1))
+ *  ]
+ * )
+ * //=> Sun Jul 02 1995 00:00:00
+ */
+export default function max (dirtyDatesArray, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var datesArray
+  // `dirtyDatesArray` is undefined or null
+  if (dirtyDatesArray == null) {
+    datesArray = []
+
+  // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method
+  } else if (typeof dirtyDatesArray.forEach === 'function') {
+    datesArray = dirtyDatesArray
+
+  // If `dirtyDatesArray` is Array-like Object, convert to Array. Otherwise, make it empty Array
+  } else {
+    datesArray = Array.prototype.slice.call(dirtyDatesArray)
+  }
+
+  var result
+  datesArray.forEach(function (dirtyDate) {
+    var currentDate = toDate(dirtyDate, dirtyOptions)
+
+    if (result === undefined || result < currentDate || isNaN(currentDate)) {
+      result = currentDate
+    }
+  })
+
+  return result
+}

--- a/src/utc/max/test.js
+++ b/src/utc/max/test.js
@@ -1,0 +1,112 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import max from '.'
+
+describe('utc/max', function () {
+  it('returns the latest date', function () {
+    var result = max(
+      [
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+        new Date(Date.UTC(1987, 1 /* Feb */, 11))
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1989, 6 /* Jul */, 10)))
+  })
+
+  it('allows to pass more than 2 arguments', function () {
+    var result = max(
+      [
+        new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+        new Date(Date.UTC(1995, 6 /* Jul */, 2)),
+        new Date(Date.UTC(1990, 0 /* Jan */, 1))
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1995, 6 /* Jul */, 2)))
+  })
+
+  it('accepts strings', function () {
+    var result = max(
+      [
+        new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString(),
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)).toISOString()
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1989, 6 /* Jul */, 10)))
+  })
+
+  it('accepts timestamps', function () {
+    var result = max(
+      [
+        Date.UTC(1989, 6 /* Jul */, 10),
+        Date.UTC(1987, 1 /* Feb */, 11)
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1989, 6 /* Jul */, 10)))
+  })
+
+  it('returns `Invalid Date` if any given date is invalid', function () {
+    var result = max([
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(NaN),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if any given value is undefined', function () {
+    var result = max([
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      // $ExpectedMistake
+      undefined,
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns undefined for empty array', function () {
+    var result = max([])
+    assert(result === undefined)
+  })
+
+  it('converts Array-like objects into Array', function () {
+    // $ExpectedMistake
+    var result = max({
+      '0': new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      '1': new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      length: 2
+    })
+    assert.deepEqual(result, new Date(Date.UTC(1989, 6 /* Jul */, 10)))
+  })
+
+  it('converts undefined into empty array', function () {
+    // $ExpectedMistake
+    var result = max(undefined)
+    assert(result === undefined)
+  })
+
+  it('converts null into empty array', function () {
+    // $ExpectedMistake
+    var result = max(null)
+    assert(result === undefined)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var block = max.bind(
+      null,
+      [
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+        new Date(Date.UTC(1987, 1 /* Feb */, 11))
+      ],
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(max.bind(null), TypeError)
+  })
+})

--- a/src/utc/min/index.js
+++ b/src/utc/min/index.js
@@ -1,0 +1,59 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name min
+ * @category Common Helpers
+ * @summary Return the earliest of the given dates.
+ *
+ * @description
+ * Return the earliest of the given dates.
+ *
+ * @param {Date[]|String[]|Number[]} datesArray - the dates to compare
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the earliest of the dates
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Which of these dates is the earliest?
+ * var result = min(
+ *  [
+ *    new Date(Date.UTC(1989, 6, 10)),
+ *    new Date(Date.UTC(1987, 1, 11)),
+ *    new Date(Date.UTC(1995, 6, 2)),
+ *    new Date(Date.UTC(1990, 0, 1))
+ *  ]
+ * )
+ * //=> Wed Feb 11 1987 00:00:00
+ */
+export default function min (dirtyDatesArray, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var datesArray
+  // `dirtyDatesArray` is undefined or null
+  if (dirtyDatesArray == null) {
+    datesArray = []
+
+  // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method
+  } else if (typeof dirtyDatesArray.forEach === 'function') {
+    datesArray = dirtyDatesArray
+
+  // If `dirtyDatesArray` is Array-like Object, convert to Array. Otherwise, make it empty Array
+  } else {
+    datesArray = Array.prototype.slice.call(dirtyDatesArray)
+  }
+
+  var result
+  datesArray.forEach(function (dirtyDate) {
+    var currentDate = toDate(dirtyDate, dirtyOptions)
+
+    if (result === undefined || result > currentDate || isNaN(currentDate)) {
+      result = currentDate
+    }
+  })
+
+  return result
+}

--- a/src/utc/min/test.js
+++ b/src/utc/min/test.js
@@ -1,0 +1,112 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import min from '.'
+
+describe('utc/min', function () {
+  it('returns the earliest date', function () {
+    var result = min(
+      [
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+        new Date(Date.UTC(1987, 1 /* Feb */, 11))
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1987, 1 /* Feb */, 11)))
+  })
+
+  it('allows to pass more than 2 arguments', function () {
+    var result = min(
+      [
+        new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+        new Date(Date.UTC(1985, 6 /* Jul */, 2)),
+        new Date(Date.UTC(1990, 0 /* Jan */, 1))
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1985, 6 /* Jul */, 2)))
+  })
+
+  it('accepts strings', function () {
+    var result = min(
+      [
+        new Date(Date.UTC(1987, 1 /* Feb */, 11)).toISOString(),
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)).toISOString()
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1987, 1 /* Feb */, 11)))
+  })
+
+  it('accepts timestamps', function () {
+    var result = min(
+      [
+        Date.UTC(1989, 6 /* Jul */, 10),
+        Date.UTC(1987, 1 /* Feb */, 11)
+      ]
+    )
+    assert.deepEqual(result, new Date(Date.UTC(1987, 1 /* Feb */, 11)))
+  })
+
+  it('returns `Invalid Date` if any given date is invalid', function () {
+    var result = min([
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      new Date(NaN),
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if any given value is undefined', function () {
+    var result = min([
+      new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      // $ExpectedMistake
+      undefined,
+      new Date(Date.UTC(1987, 1 /* Feb */, 11))
+    ])
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns undefined for empty array', function () {
+    var result = min([])
+    assert(result === undefined)
+  })
+
+  it('converts Array-like objects into Array', function () {
+    // $ExpectedMistake
+    var result = min({
+      '0': new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+      '1': new Date(Date.UTC(1987, 1 /* Feb */, 11)),
+      length: 2
+    })
+    assert.deepEqual(result, new Date(Date.UTC(1987, 1 /* Feb */, 11)))
+  })
+
+  it('converts undefined into empty array', function () {
+    // $ExpectedMistake
+    var result = min(undefined)
+    assert(result === undefined)
+  })
+
+  it('converts null into empty array', function () {
+    // $ExpectedMistake
+    var result = min(null)
+    assert(result === undefined)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var block = min.bind(
+      null,
+      [
+        new Date(Date.UTC(1989, 6 /* Jul */, 10)),
+        new Date(Date.UTC(1987, 1 /* Feb */, 11))
+      ],
+      // $ExpectedMistake
+      {additionalDigits: NaN}
+    )
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(min.bind(null), TypeError)
+  })
+})

--- a/src/utc/parse/_lib/parsers/index.js
+++ b/src/utc/parse/_lib/parsers/index.js
@@ -1,0 +1,440 @@
+var patterns = {
+  'M': /^(1[0-2]|0?\d)/, // 0 to 12
+  'D': /^(3[0-1]|[0-2]?\d)/, // 0 to 31
+  'DDD': /^(36[0-6]|3[0-5]\d|[0-2]?\d?\d)/, // 0 to 366
+  'W': /^(5[0-3]|[0-4]?\d)/, // 0 to 53
+  'YYYY': /^(\d{1,4})/, // 0 to 9999
+  'H': /^(2[0-3]|[0-1]?\d)/, // 0 to 23
+  'm': /^([0-5]?\d)/, // 0 to 59
+  'Z': /^([+-])(\d{2}):(\d{2})/,
+  'ZZ': /^([+-])(\d{2})(\d{2})/,
+  singleDigit: /^(\d)/,
+  twoDigits: /^(\d{2})/,
+  threeDigits: /^(\d{3})/,
+  fourDigits: /^(\d{4})/,
+  anyDigits: /^(\d+)/
+}
+
+function parseDecimal (matchResult) {
+  return parseInt(matchResult[1], 10)
+}
+
+var parsers = {
+  // Year: 00, 01, ..., 99
+  'YY': {
+    unit: 'twoDigitYear',
+    match: patterns.twoDigits,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult)
+    }
+  },
+
+  // Year: 1900, 1901, ..., 2099
+  'YYYY': {
+    unit: 'year',
+    match: patterns.YYYY,
+    parse: parseDecimal
+  },
+
+  // ISO week-numbering year: 00, 01, ..., 99
+  'GG': {
+    unit: 'isoWeekYear',
+    match: patterns.twoDigits,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult) + 1900
+    }
+  },
+
+  // ISO week-numbering year: 1900, 1901, ..., 2099
+  'GGGG': {
+    unit: 'isoWeekYear',
+    match: patterns.YYYY,
+    parse: parseDecimal
+  },
+
+  // Quarter: 1, 2, 3, 4
+  'Q': {
+    unit: 'quarter',
+    match: patterns.singleDigit,
+    parse: parseDecimal
+  },
+
+  // Ordinal quarter
+  'Qo': {
+    unit: 'quarter',
+    match: function (string, options) {
+      return options.locale.match.ordinalNumbers(string, {unit: 'quarter'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.ordinalNumber(matchResult, {unit: 'quarter'})
+    }
+  },
+
+  // Month: 1, 2, ..., 12
+  'M': {
+    unit: 'month',
+    match: patterns.M,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult) - 1
+    }
+  },
+
+  // Ordinal month
+  'Mo': {
+    unit: 'month',
+    match: function (string, options) {
+      return options.locale.match.ordinalNumbers(string, {unit: 'month'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.ordinalNumber(matchResult, {unit: 'month'}) - 1
+    }
+  },
+
+  // Month: 01, 02, ..., 12
+  'MM': {
+    unit: 'month',
+    match: patterns.twoDigits,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult) - 1
+    }
+  },
+
+  // Month: Jan, Feb, ..., Dec
+  'MMM': {
+    unit: 'month',
+    match: function (string, options) {
+      return options.locale.match.months(string, {type: 'short'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.month(matchResult, {type: 'short'})
+    }
+  },
+
+  // Month: January, February, ..., December
+  'MMMM': {
+    unit: 'month',
+    match: function (string, options) {
+      return options.locale.match.months(string, {type: 'long'}) ||
+        options.locale.match.months(string, {type: 'short'})
+    },
+    parse: function (matchResult, options) {
+      var parseResult = options.locale.match.month(matchResult, {type: 'long'})
+
+      if (parseResult == null) {
+        parseResult = options.locale.match.month(matchResult, {type: 'short'})
+      }
+
+      return parseResult
+    }
+  },
+
+  // ISO week: 1, 2, ..., 53
+  'W': {
+    unit: 'isoWeek',
+    match: patterns.W,
+    parse: parseDecimal
+  },
+
+  // Ordinal ISO week
+  'Wo': {
+    unit: 'isoWeek',
+    match: function (string, options) {
+      return options.locale.match.ordinalNumbers(string, {unit: 'isoWeek'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.ordinalNumber(matchResult, {unit: 'isoWeek'})
+    }
+  },
+
+  // ISO week: 01, 02, ..., 53
+  'WW': {
+    unit: 'isoWeek',
+    match: patterns.twoDigits,
+    parse: parseDecimal
+  },
+
+  // Day of week: 0, 1, ..., 6
+  'd': {
+    unit: 'dayOfWeek',
+    match: patterns.singleDigit,
+    parse: parseDecimal
+  },
+
+  // Ordinal day of week
+  'do': {
+    unit: 'dayOfWeek',
+    match: function (string, options) {
+      return options.locale.match.ordinalNumbers(string, {unit: 'dayOfWeek'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.ordinalNumber(matchResult, {unit: 'dayOfWeek'})
+    }
+  },
+
+  // Day of week: Su, Mo, ..., Sa
+  'dd': {
+    unit: 'dayOfWeek',
+    match: function (string, options) {
+      return options.locale.match.weekdays(string, {type: 'narrow'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.weekday(matchResult, {type: 'narrow'})
+    }
+  },
+
+  // Day of week: Sun, Mon, ..., Sat
+  'ddd': {
+    unit: 'dayOfWeek',
+    match: function (string, options) {
+      return options.locale.match.weekdays(string, {type: 'short'}) ||
+        options.locale.match.weekdays(string, {type: 'narrow'})
+    },
+    parse: function (matchResult, options) {
+      var parseResult = options.locale.match.weekday(matchResult, {type: 'short'})
+
+      if (parseResult == null) {
+        parseResult = options.locale.match.weekday(matchResult, {type: 'narrow'})
+      }
+
+      return parseResult
+    }
+  },
+
+  // Day of week: Sunday, Monday, ..., Saturday
+  'dddd': {
+    unit: 'dayOfWeek',
+    match: function (string, options) {
+      return options.locale.match.weekdays(string, {type: 'long'}) ||
+        options.locale.match.weekdays(string, {type: 'short'}) ||
+        options.locale.match.weekdays(string, {type: 'narrow'})
+    },
+    parse: function (matchResult, options) {
+      var parseResult = options.locale.match.weekday(matchResult, {type: 'long'})
+
+      if (parseResult == null) {
+        parseResult = options.locale.match.weekday(matchResult, {type: 'short'})
+
+        if (parseResult == null) {
+          parseResult = options.locale.match.weekday(matchResult, {type: 'narrow'})
+        }
+      }
+
+      return parseResult
+    }
+  },
+
+  // Day of ISO week: 1, 2, ..., 7
+  'E': {
+    unit: 'dayOfISOWeek',
+    match: patterns.singleDigit,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult)
+    }
+  },
+
+  // Day of month: 1, 2, ..., 31
+  'D': {
+    unit: 'dayOfMonth',
+    match: patterns.D,
+    parse: parseDecimal
+  },
+
+  // Ordinal day of month
+  'Do': {
+    unit: 'dayOfMonth',
+    match: function (string, options) {
+      return options.locale.match.ordinalNumbers(string, {unit: 'dayOfMonth'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.ordinalNumber(matchResult, {unit: 'dayOfMonth'})
+    }
+  },
+
+  // Day of month: 01, 02, ..., 31
+  'DD': {
+    unit: 'dayOfMonth',
+    match: patterns.twoDigits,
+    parse: parseDecimal
+  },
+
+  // Day of year: 1, 2, ..., 366
+  'DDD': {
+    unit: 'dayOfYear',
+    match: patterns.DDD,
+    parse: parseDecimal
+  },
+
+  // Ordinal day of year
+  'DDDo': {
+    unit: 'dayOfYear',
+    match: function (string, options) {
+      return options.locale.match.ordinalNumbers(string, {unit: 'dayOfYear'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.ordinalNumber(matchResult, {unit: 'dayOfYear'})
+    }
+  },
+
+  // Day of year: 001, 002, ..., 366
+  'DDDD': {
+    unit: 'dayOfYear',
+    match: patterns.threeDigits,
+    parse: parseDecimal
+  },
+
+  // AM, PM
+  'A': {
+    unit: 'timeOfDay',
+    match: function (string, options) {
+      return options.locale.match.timesOfDay(string, {type: 'short'})
+    },
+    parse: function (matchResult, options) {
+      return options.locale.match.timeOfDay(matchResult, {type: 'short'})
+    }
+  },
+
+  // a.m., p.m.
+  'aa': {
+    unit: 'timeOfDay',
+    match: function (string, options) {
+      return options.locale.match.timesOfDay(string, {type: 'long'}) ||
+        options.locale.match.timesOfDay(string, {type: 'short'})
+    },
+    parse: function (matchResult, options) {
+      var parseResult = options.locale.match.timeOfDay(matchResult, {type: 'long'})
+
+      if (parseResult == null) {
+        parseResult = options.locale.match.timeOfDay(matchResult, {type: 'short'})
+      }
+
+      return parseResult
+    }
+  },
+
+  // Hour: 0, 1, ... 23
+  'H': {
+    unit: 'hours',
+    match: patterns.H,
+    parse: parseDecimal
+  },
+
+  // Hour: 00, 01, ..., 23
+  'HH': {
+    unit: 'hours',
+    match: patterns.twoDigits,
+    parse: parseDecimal
+  },
+
+  // Hour: 1, 2, ..., 12
+  'h': {
+    unit: 'timeOfDayHours',
+    match: patterns.M,
+    parse: parseDecimal
+  },
+
+  // Hour: 01, 02, ..., 12
+  'hh': {
+    unit: 'timeOfDayHours',
+    match: patterns.twoDigits,
+    parse: parseDecimal
+  },
+
+  // Minute: 0, 1, ..., 59
+  'm': {
+    unit: 'minutes',
+    match: patterns.m,
+    parse: parseDecimal
+  },
+
+  // Minute: 00, 01, ..., 59
+  'mm': {
+    unit: 'minutes',
+    match: patterns.twoDigits,
+    parse: parseDecimal
+  },
+
+  // Second: 0, 1, ..., 59
+  's': {
+    unit: 'seconds',
+    match: patterns.m,
+    parse: parseDecimal
+  },
+
+  // Second: 00, 01, ..., 59
+  'ss': {
+    unit: 'seconds',
+    match: patterns.twoDigits,
+    parse: parseDecimal
+  },
+
+  // 1/10 of second: 0, 1, ..., 9
+  'S': {
+    unit: 'milliseconds',
+    match: patterns.singleDigit,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult) * 100
+    }
+  },
+
+  // 1/100 of second: 00, 01, ..., 99
+  'SS': {
+    unit: 'milliseconds',
+    match: patterns.twoDigits,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult) * 10
+    }
+  },
+
+  // Millisecond: 000, 001, ..., 999
+  'SSS': {
+    unit: 'milliseconds',
+    match: patterns.threeDigits,
+    parse: parseDecimal
+  },
+
+  // Timezone: -01:00, +00:00, ... +12:00
+  'Z': {
+    unit: 'timezone',
+    match: patterns.Z,
+    parse: function (matchResult) {
+      var sign = matchResult[1]
+      var hours = parseInt(matchResult[2], 10)
+      var minutes = parseInt(matchResult[3], 10)
+      var absoluteOffset = hours * 60 + minutes
+      return (sign === '+') ? absoluteOffset : -absoluteOffset
+    }
+  },
+
+  // Timezone: -0100, +0000, ... +1200
+  'ZZ': {
+    unit: 'timezone',
+    match: patterns.ZZ,
+    parse: function (matchResult) {
+      var sign = matchResult[1]
+      var hours = parseInt(matchResult[2], 10)
+      var minutes = parseInt(matchResult[3], 10)
+      var absoluteOffset = hours * 60 + minutes
+      return (sign === '+') ? absoluteOffset : -absoluteOffset
+    }
+  },
+
+  // Seconds timestamp: 512969520
+  'X': {
+    unit: 'timestamp',
+    match: patterns.anyDigits,
+    parse: function (matchResult) {
+      return parseDecimal(matchResult) * 1000
+    }
+  },
+
+  // Milliseconds timestamp: 512969520900
+  'x': {
+    unit: 'timestamp',
+    match: patterns.anyDigits,
+    parse: parseDecimal
+  }
+}
+
+parsers['a'] = parsers['A']
+
+export default parsers

--- a/src/utc/parse/_lib/units/index.js
+++ b/src/utc/parse/_lib/units/index.js
@@ -1,0 +1,186 @@
+import setDay from '../../../setDay/index.js'
+import setISODay from '../../../setISODay/index.js'
+import setISOWeek from '../../../setISOWeek/index.js'
+import setISOWeekYear from '../../../setISOWeekYear/index.js'
+import startOfISOWeek from '../../../startOfISOWeek/index.js'
+import startOfISOWeekYear from '../../../startOfISOWeekYear/index.js'
+
+var MILLISECONDS_IN_MINUTE = 60000
+
+function setTimeOfDay (hours, timeOfDay) {
+  var isAM = timeOfDay === 0
+
+  if (isAM) {
+    if (hours === 12) {
+      return 0
+    }
+  } else {
+    if (hours !== 12) {
+      return 12 + hours
+    }
+  }
+
+  return hours
+}
+
+var units = {
+  twoDigitYear: {
+    priority: 10,
+    set: function (dateValues, value) {
+      var century = Math.floor(dateValues.date.getUTCFullYear() / 100)
+      var year = century * 100 + value
+      dateValues.date.setUTCFullYear(year, 0, 1)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  year: {
+    priority: 10,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCFullYear(value, 0, 1)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  isoWeekYear: {
+    priority: 10,
+    set: function (dateValues, value, options) {
+      dateValues.date = startOfISOWeekYear(setISOWeekYear(dateValues.date, value, options), options)
+      return dateValues
+    }
+  },
+
+  quarter: {
+    priority: 20,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCMonth((value - 1) * 3, 1)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  month: {
+    priority: 30,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCMonth(value, 1)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  isoWeek: {
+    priority: 40,
+    set: function (dateValues, value, options) {
+      dateValues.date = startOfISOWeek(setISOWeek(dateValues.date, value, options), options)
+      return dateValues
+    }
+  },
+
+  dayOfWeek: {
+    priority: 50,
+    set: function (dateValues, value, options) {
+      dateValues.date = setDay(dateValues.date, value, options)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  dayOfISOWeek: {
+    priority: 50,
+    set: function (dateValues, value, options) {
+      dateValues.date = setISODay(dateValues.date, value, options)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  dayOfMonth: {
+    priority: 50,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCDate(value)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  dayOfYear: {
+    priority: 50,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCMonth(0, value)
+      dateValues.date.setUTCHours(0, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  timeOfDay: {
+    priority: 60,
+    set: function (dateValues, value, options) {
+      dateValues.timeOfDay = value
+      return dateValues
+    }
+  },
+
+  hours: {
+    priority: 70,
+    set: function (dateValues, value, options) {
+      dateValues.date.setUTCHours(value, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  timeOfDayHours: {
+    priority: 70,
+    set: function (dateValues, value, options) {
+      var timeOfDay = dateValues.timeOfDay
+      if (timeOfDay != null) {
+        value = setTimeOfDay(value, timeOfDay)
+      }
+      dateValues.date.setUTCHours(value, 0, 0, 0)
+      return dateValues
+    }
+  },
+
+  minutes: {
+    priority: 80,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCMinutes(value, 0, 0)
+      return dateValues
+    }
+  },
+
+  seconds: {
+    priority: 90,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCSeconds(value, 0)
+      return dateValues
+    }
+  },
+
+  milliseconds: {
+    priority: 100,
+    set: function (dateValues, value) {
+      dateValues.date.setUTCMilliseconds(value)
+      return dateValues
+    }
+  },
+
+  timezone: {
+    priority: 110,
+    set: function (dateValues, value) {
+      dateValues.date = new Date(dateValues.date.getTime() - value * MILLISECONDS_IN_MINUTE)
+      return dateValues
+    }
+  },
+
+  timestamp: {
+    priority: 120,
+    set: function (dateValues, value) {
+      dateValues.date = new Date(value)
+      return dateValues
+    }
+  }
+}
+
+export default units

--- a/src/utc/parse/index.js
+++ b/src/utc/parse/index.js
@@ -1,5 +1,4 @@
 import toDate from '../toDate/index.js'
-import subMinutes from '../subMinutes/index.js'
 import defaultLocale from '../../locale/en-US/index.js'
 import parsers from './_lib/parsers/index.js'
 import units from './_lib/units/index.js'
@@ -192,12 +191,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   var tokens = formatString.match(locale.parsingTokensRegExp || defaultParsingTokensRegExp)
   var tokensLength = tokens.length
 
-  // If timezone isn't specified, it will be set to the system timezone
-  var setters = [{
-    priority: TIMEZONE_UNIT_PRIORITY,
-    set: dateToSystemTimezone,
-    index: 0
-  }]
+  var setters = []
 
   var i
   for (i = 0; i < tokensLength; i++) {
@@ -265,12 +259,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
     return new Date(NaN)
   }
 
-  // Convert the date in system timezone to the same date in UTC+00:00 timezone.
-  // This ensures that when UTC functions will be implemented, locales will be compatible with them.
-  // See an issue about UTC functions: https://github.com/date-fns/date-fns/issues/37
-  var utcDate = subMinutes(date, date.getTimezoneOffset())
-
-  var dateValues = {date: utcDate}
+  var dateValues = {date: date}
 
   var settersLength = uniquePrioritySetters.length
   for (i = 0; i < settersLength; i++) {
@@ -279,22 +268,6 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   }
 
   return dateValues.date
-}
-
-function dateToSystemTimezone (dateValues) {
-  var date = dateValues.date
-  var time = date.getTime()
-
-  // Get the system timezone offset at (moment of time - offset)
-  var offset = date.getTimezoneOffset()
-
-  // Get the system timezone offset at the exact moment of time
-  offset = new Date(time + offset * MILLISECONDS_IN_MINUTE).getTimezoneOffset()
-
-  // Convert date in timezone "UTC+00:00" to the system timezone
-  dateValues.date = new Date(time + offset * MILLISECONDS_IN_MINUTE)
-
-  return dateValues
 }
 
 function cleanEscapedString (input) {

--- a/src/utc/parse/index.js
+++ b/src/utc/parse/index.js
@@ -1,0 +1,305 @@
+import toDate from '../toDate/index.js'
+import subMinutes from '../subMinutes/index.js'
+import defaultLocale from '../../locale/en-US/index.js'
+import parsers from './_lib/parsers/index.js'
+import units from './_lib/units/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+
+var TIMEZONE_UNIT_PRIORITY = 110
+var MILLISECONDS_IN_MINUTE = 60000
+
+var longFormattingTokensRegExp = /(\[[^[]*])|(\\)?(LTS|LT|LLLL|LLL|LL|L|llll|lll|ll|l)/g
+var defaultParsingTokensRegExp = /(\[[^[]*])|(\\)?(x|ss|s|mm|m|hh|h|do|dddd|ddd|dd|d|aa|a|ZZ|Z|YYYY|YY|X|Wo|WW|W|SSS|SS|S|Qo|Q|Mo|MMMM|MMM|MM|M|HH|H|GGGG|GG|E|Do|DDDo|DDDD|DDD|DD|D|A|.)/g
+
+/**
+ * @name parse
+ * @category Common Helpers
+ * @summary Parse the date.
+ *
+ * @description
+ * Return the date parsed from string using the given format.
+ *
+ * Accepted format tokens:
+ * | Unit                    | Priority | Token | Input examples                   |
+ * |-------------------------|----------|-------|----------------------------------|
+ * | Year                    | 10       | YY    | 00, 01, ..., 99                  |
+ * |                         |          | YYYY  | 1900, 1901, ..., 2099            |
+ * | ISO week-numbering year | 10       | GG    | 00, 01, ..., 99                  |
+ * |                         |          | GGGG  | 1900, 1901, ..., 2099            |
+ * | Quarter                 | 20       | Q     | 1, 2, 3, 4                       |
+ * |                         |          | Qo    | 1st, 2nd, 3rd, 4th               |
+ * | Month                   | 30       | M     | 1, 2, ..., 12                    |
+ * |                         |          | Mo    | 1st, 2nd, ..., 12th              |
+ * |                         |          | MM    | 01, 02, ..., 12                  |
+ * |                         |          | MMM   | Jan, Feb, ..., Dec               |
+ * |                         |          | MMMM  | January, February, ..., December |
+ * | ISO week                | 40       | W     | 1, 2, ..., 53                    |
+ * |                         |          | Wo    | 1st, 2nd, ..., 53rd              |
+ * |                         |          | WW    | 01, 02, ..., 53                  |
+ * | Day of week             | 50       | d     | 0, 1, ..., 6                     |
+ * |                         |          | do    | 0th, 1st, ..., 6th               |
+ * |                         |          | dd    | Su, Mo, ..., Sa                  |
+ * |                         |          | ddd   | Sun, Mon, ..., Sat               |
+ * |                         |          | dddd  | Sunday, Monday, ..., Saturday    |
+ * | Day of ISO week         | 50       | E     | 1, 2, ..., 7                     |
+ * | Day of month            | 50       | D     | 1, 2, ..., 31                    |
+ * |                         |          | Do    | 1st, 2nd, ..., 31st              |
+ * |                         |          | DD    | 01, 02, ..., 31                  |
+ * | Day of year             | 50       | DDD   | 1, 2, ..., 366                   |
+ * |                         |          | DDDo  | 1st, 2nd, ..., 366th             |
+ * |                         |          | DDDD  | 001, 002, ..., 366               |
+ * | Time of day             | 60       | A     | AM, PM                           |
+ * |                         |          | a     | am, pm                           |
+ * |                         |          | aa    | a.m., p.m.                       |
+ * | Hour                    | 70       | H     | 0, 1, ... 23                     |
+ * |                         |          | HH    | 00, 01, ... 23                   |
+ * | Time of day hour        | 70       | h     | 1, 2, ..., 12                    |
+ * |                         |          | hh    | 01, 02, ..., 12                  |
+ * | Minute                  | 80       | m     | 0, 1, ..., 59                    |
+ * |                         |          | mm    | 00, 01, ..., 59                  |
+ * | Second                  | 90       | s     | 0, 1, ..., 59                    |
+ * |                         |          | ss    | 00, 01, ..., 59                  |
+ * | 1/10 of second          | 100      | S     | 0, 1, ..., 9                     |
+ * | 1/100 of second         | 100      | SS    | 00, 01, ..., 99                  |
+ * | Millisecond             | 100      | SSS   | 000, 001, ..., 999               |
+ * | Timezone                | 110      | Z     | -01:00, +00:00, ... +12:00       |
+ * |                         |          | ZZ    | -0100, +0000, ..., +1200         |
+ * | Seconds timestamp       | 120      | X     | 512969520                        |
+ * | Milliseconds timestamp  | 120      | x     | 512969520900                     |
+ *
+ * Values will be assigned to the date in the ascending order of its unit's priority.
+ * Units of an equal priority overwrite each other in the order of appearance.
+ *
+ * If no values of higher priority are parsed (e.g. when parsing string 'January 1st' without a year),
+ * the values will be taken from 3rd argument `baseDate` which works as a context of parsing.
+ *
+ * `baseDate` must be passed for correct work of the function.
+ * If you're not sure which `baseDate` to supply, create a new instance of Date:
+ * `parse('02/11/2014', 'MM/DD/YYYY', new Date())`
+ * In this case parsing will be done in the context of the current date.
+ * If `baseDate` is `Invalid Date` or a value not convertible to valid `Date`,
+ * then `Invalid Date` will be returned.
+ *
+ * Also, `parse` unfolds long formats like those in [format]{@link https://date-fns.org/docs/format}:
+ * | Token | Input examples                 |
+ * |-------|--------------------------------|
+ * | LT    | 05:30 a.m.                     |
+ * | LTS   | 05:30:15 a.m.                  |
+ * | L     | 07/02/1995                     |
+ * | l     | 7/2/1995                       |
+ * | LL    | July 2 1995                    |
+ * | ll    | Jul 2 1995                     |
+ * | LLL   | July 2 1995 05:30 a.m.         |
+ * | lll   | Jul 2 1995 05:30 a.m.          |
+ * | LLLL  | Sunday, July 2 1995 05:30 a.m. |
+ * | llll  | Sun, Jul 2 1995 05:30 a.m.     |
+ *
+ * The characters wrapped in square brackets in the format string are escaped.
+ *
+ * The result may vary by locale.
+ *
+ * If `formatString` matches with `dateString` but does not provides tokens, `baseDate` will be returned.
+ *
+ * If parsing failed, `Invalid Date` will be returned.
+ * Invalid Date is a Date, whose time value is NaN.
+ * Time value of Date: http://es5.github.io/#x15.9.1.1
+ *
+ * @param {String} dateString - the string to parse
+ * @param {String} formatString - the string of tokens
+ * @param {Date|String|Number} baseDate - the date to took the missing higher priority values from
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @returns {Date} the parsed date
+ * @throws {TypeError} 3 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ * @throws {RangeError} `options.locale` must contain `match` property
+ * @throws {RangeError} `options.locale` must contain `formatLong` property
+ *
+ * @example
+ * // Parse 11 February 2014 from middle-endian format:
+ * var result = parse(
+ *   '02/11/2014',
+ *   'MM/DD/YYYY',
+ *   new Date()
+ * )
+ * //=> Tue Feb 11 2014 00:00:00
+ *
+ * @example
+ * // Parse 28th of February in English locale in the context of 2010 year:
+ * import eoLocale from 'date-fns/locale/eo'
+ * var result = parse(
+ *   '28-a de februaro',
+ *   'Do [de] MMMM',
+ *   new Date(Date.UTC(2010, 0, 1))
+ *   {locale: eoLocale}
+ * )
+ * //=> Sun Feb 28 2010 00:00:00
+ */
+export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate, dirtyOptions) {
+  if (arguments.length < 3) {
+    throw new TypeError('3 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var dateString = String(dirtyDateString)
+  var options = dirtyOptions || {}
+
+  var weekStartsOn = options.weekStartsOn === undefined ? 0 : Number(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var locale = options.locale || defaultLocale
+  var localeParsers = locale.parsers || {}
+  var localeUnits = locale.units || {}
+
+  if (!locale.match) {
+    throw new RangeError('locale must contain match property')
+  }
+
+  if (!locale.formatLong) {
+    throw new RangeError('locale must contain formatLong property')
+  }
+
+  var formatString = String(dirtyFormatString)
+    .replace(longFormattingTokensRegExp, function (substring) {
+      if (substring[0] === '[') {
+        return substring
+      }
+
+      if (substring[0] === '\\') {
+        return cleanEscapedString(substring)
+      }
+
+      return locale.formatLong(substring)
+    })
+
+  if (formatString === '') {
+    if (dateString === '') {
+      return toDate(dirtyBaseDate, options)
+    } else {
+      return new Date(NaN)
+    }
+  }
+
+  var subFnOptions = cloneObject(options)
+  subFnOptions.locale = locale
+
+  var tokens = formatString.match(locale.parsingTokensRegExp || defaultParsingTokensRegExp)
+  var tokensLength = tokens.length
+
+  // If timezone isn't specified, it will be set to the system timezone
+  var setters = [{
+    priority: TIMEZONE_UNIT_PRIORITY,
+    set: dateToSystemTimezone,
+    index: 0
+  }]
+
+  var i
+  for (i = 0; i < tokensLength; i++) {
+    var token = tokens[i]
+    var parser = localeParsers[token] || parsers[token]
+    if (parser) {
+      var matchResult
+
+      if (parser.match instanceof RegExp) {
+        matchResult = parser.match.exec(dateString)
+      } else {
+        matchResult = parser.match(dateString, subFnOptions)
+      }
+
+      if (!matchResult) {
+        return new Date(NaN)
+      }
+
+      var unitName = parser.unit
+      var unit = localeUnits[unitName] || units[unitName]
+
+      setters.push({
+        priority: unit.priority,
+        set: unit.set,
+        value: parser.parse(matchResult, subFnOptions),
+        index: setters.length
+      })
+
+      var substring = matchResult[0]
+      dateString = dateString.slice(substring.length)
+    } else {
+      var head = tokens[i].match(/^\[.*]$/) ? tokens[i].replace(/^\[|]$/g, '') : tokens[i]
+      if (dateString.indexOf(head) === 0) {
+        dateString = dateString.slice(head.length)
+      } else {
+        return new Date(NaN)
+      }
+    }
+  }
+
+  var uniquePrioritySetters = setters
+    .map(function (setter) {
+      return setter.priority
+    })
+    .sort(function (a, b) {
+      return a - b
+    })
+    .filter(function (priority, index, array) {
+      return array.indexOf(priority) === index
+    })
+    .map(function (priority) {
+      return setters
+        .filter(function (setter) {
+          return setter.priority === priority
+        })
+        .reverse()
+    })
+    .map(function (setterArray) {
+      return setterArray[0]
+    })
+
+  var date = toDate(dirtyBaseDate, options)
+
+  if (isNaN(date)) {
+    return new Date(NaN)
+  }
+
+  // Convert the date in system timezone to the same date in UTC+00:00 timezone.
+  // This ensures that when UTC functions will be implemented, locales will be compatible with them.
+  // See an issue about UTC functions: https://github.com/date-fns/date-fns/issues/37
+  var utcDate = subMinutes(date, date.getTimezoneOffset())
+
+  var dateValues = {date: utcDate}
+
+  var settersLength = uniquePrioritySetters.length
+  for (i = 0; i < settersLength; i++) {
+    var setter = uniquePrioritySetters[i]
+    dateValues = setter.set(dateValues, setter.value, subFnOptions)
+  }
+
+  return dateValues.date
+}
+
+function dateToSystemTimezone (dateValues) {
+  var date = dateValues.date
+  var time = date.getTime()
+
+  // Get the system timezone offset at (moment of time - offset)
+  var offset = date.getTimezoneOffset()
+
+  // Get the system timezone offset at the exact moment of time
+  offset = new Date(time + offset * MILLISECONDS_IN_MINUTE).getTimezoneOffset()
+
+  // Convert date in timezone "UTC+00:00" to the system timezone
+  dateValues.date = new Date(time + offset * MILLISECONDS_IN_MINUTE)
+
+  return dateValues
+}
+
+function cleanEscapedString (input) {
+  if (input.match(/\[[\s\S]/)) {
+    return input.replace(/^\[|]$/g, '')
+  }
+  return input.replace(/\\/g, '')
+}

--- a/src/utc/parse/test.js
+++ b/src/utc/parse/test.js
@@ -1,0 +1,941 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import parse from '.'
+
+describe('utc/parse', function () {
+  var baseDate = new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 0, 900))
+
+  describe('years', function () {
+    it('YY', function () {
+      var result = parse('16', 'YY', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1916, 0 /* Jan */, 1)))
+    })
+
+    it('gets the century from `baseDate`', function () {
+      var result = parse('16', 'YY', new Date(Date.UTC(2345, 3 /* Apr */, 4, 10, 32, 0, 900)))
+      assert.deepEqual(result, new Date(Date.UTC(2316, 0 /* Jan */, 1)))
+    })
+
+    it('YYYY', function () {
+      var result = parse('2014', 'YYYY', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 1)))
+    })
+
+    it('years less than 100', function () {
+      var result = parse('0001', 'YYYY', baseDate)
+      var expectedResult = new Date(Date.UTC(1, 0 /* Jan */, 1))
+      expectedResult.setUTCFullYear(1)
+      assert.deepEqual(result, expectedResult)
+    })
+  })
+
+  describe('ISO week-numbering years', function () {
+    it('GG', function () {
+      var result = parse('50', 'GG', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1950, 0 /* Jan */, 2)))
+    })
+
+    it('GGGG', function () {
+      var result = parse('2008', 'GGGG', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2007, 11 /* Dec */, 31)))
+    })
+  })
+
+  describe('quarters', function () {
+    it('Q', function () {
+      var result = parse('1995 3', 'YYYY Q', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1995, 6 /* Jul */, 1)))
+    })
+
+    it('Qo', function () {
+      var result = parse('2000 2nd', 'YYYY Qo', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2000, 3 /* Apr */, 1)))
+    })
+
+    it('returns a correct quarter', function () {
+      var result = []
+      for (var i = 1; i <= 4; i++) {
+        result.push(parse('2014 ' + i, 'YYYY Q', baseDate))
+      }
+      var expectedResult = [
+        new Date(Date.UTC(2014, 0 /* Jan */, 1)),
+        new Date(Date.UTC(2014, 3 /* Apr */, 1)),
+        new Date(Date.UTC(2014, 6 /* Jul */, 1)),
+        new Date(Date.UTC(2014, 9 /* Oct */, 1))
+      ]
+      assert.deepEqual(result, expectedResult)
+    })
+  })
+
+  describe('months', function () {
+    it('M', function () {
+      var result = parse('1995 7', 'YYYY M', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1995, 6 /* Jul */, 1)))
+    })
+
+    it('Mo', function () {
+      var result = parse('2014 12th', 'YYYY Mo', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1)))
+    })
+
+    it('MM', function () {
+      var result = parse('2014 02', 'YYYY MM', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 1)))
+    })
+
+    it('MMM', function () {
+      var result = parse('2016 Nov', 'YYYY MMM', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 1)))
+    })
+
+    it('MMMM', function () {
+      var result = parse('2016 December', 'YYYY MMMM', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 11 /* Dec */, 1)))
+    })
+  })
+
+  describe('ISO weeks', function () {
+    it('W', function () {
+      var result = parse('2016 4', 'GGGG W', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 25)))
+    })
+
+    it('Wo', function () {
+      var result = parse('2016 3rd', 'GGGG Wo', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 18)))
+    })
+
+    it('WW', function () {
+      var result = parse('2016 09', 'GGGG WW', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 1 /* Feb */, 29)))
+    })
+  })
+
+  describe('days of a week', function () {
+    it('d', function () {
+      var result = parse('2016 4 0', 'GGGG W d', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 24)))
+    })
+
+    it('do', function () {
+      var result = parse('2016 4 0th', 'GGGG W do', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 24)))
+    })
+
+    it('dd', function () {
+      var result = parse('2016 4 Mo', 'GGGG W dd', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 25)))
+    })
+
+    it('ddd', function () {
+      var result = parse('2016 4 Wed', 'GGGG W ddd', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 27)))
+    })
+
+    it('dddd', function () {
+      var result = parse('2016 4 Friday', 'GGGG W dddd', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 29)))
+    })
+  })
+
+  describe('days of an ISO week', function () {
+    it('E', function () {
+      var result = parse('2016 4 7', 'GGGG W E', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0 /* Jan */, 31)))
+    })
+  })
+
+  describe('days of a month', function () {
+    it('D', function () {
+      var result = parse('11/2/2016', 'M/D/YYYY', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 2)))
+    })
+
+    it('Do', function () {
+      var result = parse('2016 11 15th', 'YYYY MM Do', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 15)))
+    })
+
+    it('DD', function () {
+      var result = parse('2016 11 05', 'YYYY MM DD', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 5)))
+    })
+  })
+
+  describe('days of a year', function () {
+    it('DDD', function () {
+      var result = parse('2016 50', 'YYYY DDD', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 1 /* Feb */, 19)))
+    })
+
+    it('DDDo', function () {
+      var result = parse('2016 100th', 'YYYY DDDo', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 3 /* Apr */, 9)))
+    })
+
+    it('DDDD', function () {
+      var result = parse('2016 366', 'YYYY DDDD', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 11 /* Dec */, 31)))
+    })
+  })
+
+  describe('hours', function () {
+    it('H', function () {
+      var result = parse('2016-11-25 4 o\'clock', 'YYYY-MM-DD H [o\'clock]', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+
+    it('HH', function () {
+      var result = parse('2016-11-25T04', 'YYYY-MM-DDTHH', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+
+    it('h', function () {
+      var result = parse('4 hours 2016-11-25', 'h [hours] YYYY-MM-DD', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+
+    it('hh', function () {
+      var result = parse('2016-11-25 04', 'YYYY-MM-DD hh', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+  })
+
+  describe('a.m./p.m.', function () {
+    it('AM', function () {
+      var result = parse('2016-11-25 04 AM', 'YYYY-MM-DD hh A', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+
+    it('PM', function () {
+      var result = parse('2016-11-25 04 PM', 'YYYY-MM-DD hh A', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 0, 0, 0)))
+    })
+
+    it('am', function () {
+      var result = parse('2016-11-25 04 am', 'YYYY-MM-DD hh a', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+
+    it('pm', function () {
+      var result = parse('2016-11-25 04 pm', 'YYYY-MM-DD hh a', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 0, 0, 0)))
+    })
+
+    it('a.m.', function () {
+      var result = parse('2016-11-25 04 a.m.', 'YYYY-MM-DD hh aa', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 0, 0, 0)))
+    })
+
+    it('p.m.', function () {
+      var result = parse('2016-11-25 04 p.m.', 'YYYY-MM-DD hh aa', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 0, 0, 0)))
+    })
+
+    it('12 a.m.', function () {
+      var result = parse('2016-11-25 12 a.m.', 'YYYY-MM-DD hh aa', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 0, 0, 0, 0)))
+    })
+
+    it('12 p.m.', function () {
+      var result = parse('2016-11-25 12 p.m.', 'YYYY-MM-DD hh aa', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 12, 0, 0, 0)))
+    })
+  })
+
+  describe('minutes', function () {
+    it('m', function () {
+      var result = parse('2016-11-25 4:5', 'YYYY-MM-DD H:m', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 5, 0, 0)))
+    })
+
+    it('mm', function () {
+      var result = parse('20161125T0405', 'YYYYMMDDTHHmm', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 5, 0, 0)))
+    })
+  })
+
+  describe('seconds', function () {
+    it('s', function () {
+      var dateString = '4 hours 30 minutes 5 seconds 2016-11-25'
+      var formatString = 'H [hours] m [minutes] s [seconds] YYYY-MM-DD'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 4, 30, 5, 0)))
+    })
+
+    it('ss', function () {
+      var result = parse('2016-11-25T16:38:38', 'YYYY-MM-DDTHH:mm:ss', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 38, 38, 0)))
+    })
+  })
+
+  describe('fractions of a second', function () {
+    it('S', function () {
+      var result = parse('2016-11-25T16:38:38.1', 'YYYY-MM-DDTHH:mm:ss.S', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 38, 38, 100)))
+    })
+
+    it('SS', function () {
+      var result = parse('2016-11-25T16:38:38.12', 'YYYY-MM-DDTHH:mm:ss.SS', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 38, 38, 120)))
+    })
+
+    it('SSS', function () {
+      var result = parse('2016-11-25T16:38:38.123', 'YYYY-MM-DDTHH:mm:ss.SSS', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25, 16, 38, 38, 123)))
+    })
+  })
+
+  describe('timezones', function () {
+    it('Z', function () {
+      var dateString = '2016-11-25T16:38:38.123-01:30'
+      var resultString = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+      var result = parse(dateString, resultString, baseDate)
+      assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-01:30'))
+    })
+
+    it('ZZ', function () {
+      var dateString = '2016-11-25T16:38:38.123-0130'
+      var resultString = 'YYYY-MM-DDTHH:mm:ss.SSSZZ'
+      var result = parse(dateString, resultString, baseDate)
+      assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-01:30'))
+    })
+  })
+
+  describe('timestamps', function () {
+    it('X', function () {
+      var result = parse('512969520', 'X', baseDate)
+      assert.deepEqual(result, new Date('1986-04-04T03:32:00.000Z'))
+    })
+
+    it('x', function () {
+      var result = parse('512969520900', 'x', baseDate)
+      assert.deepEqual(result, new Date('1986-04-04T03:32:00.900Z'))
+    })
+  })
+
+  describe('common formats', function () {
+    it('ISO date', function () {
+      var result = parse('20161105T040404', 'YYYYMMDDTHHmmss', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 5, 4, 4, 4, 0)))
+    })
+
+    it('ISO week-numbering date', function () {
+      var result = parse('2016W474T153005', 'GGGG[W]WWETHHmmss', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 24, 15, 30, 5, 0)))
+    })
+
+    it('ISO day of year date', function () {
+      var result = parse('2010123T235959', 'YYYYDDDDTHHmmss', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2010, 4 /* May */, 3, 23, 59, 59, 0)))
+    })
+
+    it('Date.prototype.toString()', function () {
+      var dateString = 'Wed Jul 02 2014 05:30:15 GMT+0600'
+      var formatString = 'ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, new Date(dateString))
+    })
+
+    it('Date.prototype.toISOString()', function () {
+      var dateString = '2014-07-02T05:30:15.123+06:00'
+      var formatString = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, new Date(dateString))
+    })
+
+    it('middle-endian', function () {
+      var result = parse('5 a.m. 07/02/2016', 'h aa MM/DD/YYYY', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 6 /* Jul */, 2, 5, 0, 0, 0)))
+    })
+
+    it('little-endian', function () {
+      var result = parse('02.07.1995', 'DD.MM.YYYY', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1995, 6 /* Jul */, 2, 0, 0, 0, 0)))
+    })
+  })
+
+  describe('priority', function () {
+    it('units of lower priority don\'t overwrite values of higher priority', function () {
+      var dateString = '+06:00 123 15 30 05 02 07 2014'
+      var formatString = 'Z SSS ss mm HH DD MM YYYY'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, new Date('2014-07-02T05:30:15.123+06:00'))
+    })
+
+    it('units of equal priority overwrite each other in order of appearance', function () {
+      var dateString = '25 1950 75 2000 January Feb 03 4 1 123 12'
+      var formatString = 'GG GGGG YY YYYY MMMM MMM MM M d DDD DD'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2000, 3 /* Apr */, 12)))
+    })
+
+    it('timestamp overwrites everything', function () {
+      var dateString = '512969520900 512969520 2014-07-02T05:30:15.123+06:00'
+      var formatString = 'x X YYYY-MM-DDTHH:mm:ss.SSSZ'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, new Date(512969520000))
+    })
+  })
+
+  context('only one value is provided', function () {
+    describe('quarter', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '2'
+        var formatString = 'Q'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 1)))
+      })
+    })
+
+    describe('month', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '12'
+        var formatString = 'M'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 11 /* Dec */, 1)))
+      })
+    })
+
+    describe('ISO week', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '49'
+        var formatString = 'W'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 11 /* Dec */, 1)))
+      })
+    })
+
+    describe('day of week', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '1'
+        var formatString = 'd'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 2 /* Mar */, 31)))
+      })
+
+      it('allows to specify which day is the first day of the week', function () {
+        var dateString = '0'
+        var formatString = 'd'
+        var result = parse(dateString, formatString, baseDate, {weekStartsOn: 1})
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 6)))
+      })
+
+      it('allows to specify which day is the first day of the week in locale', function () {
+        var dateString = '0'
+        var formatString = 'd'
+        var result = parse(
+          dateString,
+          formatString,
+          baseDate,
+          {
+            // $ExpectedMistake
+            locale: {
+              // $ExpectedMistake
+              match: {},
+              formatLong: function () {},
+              options: {weekStartsOn: 1}
+            }
+          }
+        )
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 6)))
+      })
+
+      it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+        var dateString = '0'
+        var formatString = 'd'
+        var result = parse(
+          dateString,
+          formatString,
+          baseDate,
+          {
+            weekStartsOn: 1,
+            // $ExpectedMistake
+            locale: {
+              // $ExpectedMistake
+              match: {},
+              formatLong: function () {},
+              options: {weekStartsOn: 0}
+            }
+          }
+        )
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 6)))
+      })
+    })
+
+    describe('day of ISO week', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '7'
+        var formatString = 'E'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 6)))
+      })
+    })
+
+    describe('day of month', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '15'
+        var formatString = 'D'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 15)))
+      })
+    })
+
+    describe('day of year', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '200'
+        var formatString = 'DDD'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 6 /* Jul */, 19)))
+      })
+    })
+
+    describe('hour', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '19'
+        var formatString = 'H'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 19)))
+      })
+    })
+
+    describe('12-hour clock', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '6 p.m.'
+        var formatString = 'h aa'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 18)))
+      })
+    })
+
+    describe('minute', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '12'
+        var formatString = 'm'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 12)))
+      })
+    })
+
+    describe('second', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '34'
+        var formatString = 's'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 34)))
+      })
+    })
+
+    describe('1/10 of second', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '5'
+        var formatString = 'S'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 0, 500)))
+      })
+    })
+
+    describe('1/100 of second', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '67'
+        var formatString = 'SS'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 0, 670)))
+      })
+    })
+
+    describe('millisecond', function () {
+      it('takes the values of higher priority from baseDate', function () {
+        var dateString = '891'
+        var formatString = 'SSS'
+        var result = parse(dateString, formatString, baseDate)
+        assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32, 0, 891)))
+      })
+    })
+  })
+
+  describe('long formats', function () {
+    it('LT', function () {
+      var result = parse('10:32 a.m.', 'LT', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32)))
+    })
+
+    it('LTS', function () {
+      var result = parse('10:32:00 a.m.', 'LTS', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 10, 32)))
+    })
+
+    it('L', function () {
+      var result = parse('04/04/1987', 'L', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4)))
+    })
+
+    it('l', function () {
+      var result = parse('4/4/1987', 'l', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4)))
+    })
+
+    it('LL', function () {
+      var result = parse('April 4 1987', 'LL', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4)))
+    })
+
+    it('ll', function () {
+      var result = parse('Apr 4 1987', 'll', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4)))
+    })
+
+    it('LLL', function () {
+      var result = parse('April 4 1987 10:32 a.m.', 'LLL', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4, 10, 32)))
+    })
+
+    it('lll', function () {
+      var result = parse('Apr 4 1987 10:32 a.m.', 'lll', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4, 10, 32)))
+    })
+
+    it('LLLL', function () {
+      var result = parse('Friday, April 4 1987 10:32 a.m.', 'LLLL', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4, 10, 32)))
+    })
+
+    it('llll', function () {
+      var result = parse('Fri, Apr 4 1987 10:32 a.m.', 'llll', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(1987, 3 /* Apr */, 4, 10, 32)))
+    })
+  })
+
+  describe('implicit conversion of options', function () {
+    it('`dateString`', function () {
+      // eslint-disable-next-line no-new-wrappers
+      var dateString = new String('20161105T040404')
+      // $ExpectedMistake
+      var result = parse(dateString, 'YYYYMMDDTHHmmss', baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 5, 4, 4, 4, 0)))
+    })
+
+    it('`formatString`', function () {
+      // eslint-disable-next-line no-new-wrappers
+      var formatString = new String('YYYYMMDDTHHmmss')
+      // $ExpectedMistake
+      var result = parse('20161105T040404', formatString, baseDate)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 5, 4, 4, 4, 0)))
+    })
+
+    it('`options.weekStartsOn`', function () {
+      var dateString = '0'
+      var formatString = 'd'
+      // $ExpectedMistake
+      var result = parse(dateString, formatString, baseDate, {weekStartsOn: '1'})
+      assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 6)))
+    })
+  })
+
+  describe('custom locale', function () {
+    it('can be passed to the function', function () {
+      var units = {
+        qwe: {
+          priority: 12,
+          set: function (dateValues, value) {
+            dateValues.date.setUTCDate(value + 2)
+            dateValues.date.setUTCHours(0, 0, 0, 0)
+            return dateValues
+          }
+        },
+
+        rty: {
+          priority: 11,
+          set: function (dateValues, value) {
+            dateValues.date.setUTCMonth(value + 2, 1)
+            dateValues.date.setUTCHours(0, 0, 0, 0)
+            return dateValues
+          }
+        }
+      }
+
+      var parsers = {
+        abc: {
+          unit: 'qwe',
+          match: /^(It|This)/,
+          parse: function (matchResult) {
+            var word = matchResult[1]
+
+            if (word === 'It') {
+              return 7
+            } else {
+              return 6
+            }
+          }
+        },
+
+        efg: {
+          unit: 'rty',
+          match: /^(works|doesn't work)/,
+          parse: function (matchResult) {
+            var word = matchResult[1]
+
+            if (word === 'works') {
+              return 3
+            } else {
+              return 2
+            }
+          }
+        }
+      }
+
+      var parsingTokensRegExp = /(\[[^[]*])|(\\)?(YYYY|abc|efg|.)/g
+
+      var formatLong = function () {
+        return 'efg'
+      }
+
+      var customLocale = {
+        // $ExpectedMistake
+        match: {},
+        formatLong: formatLong,
+        units: units,
+        parsers: parsers,
+        parsingTokensRegExp: parsingTokensRegExp
+      }
+
+      // $ExpectedMistake
+      var result = parse('2017 It works correctly!', 'YYYY abc LTS [correctly!]', baseDate, {locale: customLocale})
+      assert.deepEqual(result, new Date(Date.UTC(2017, 5, 9)))
+    })
+
+    context('does not contain `match` property', function () {
+      it('throws `RangeError`', function () {
+        var customLocale = {formatLong: function () {}}
+        // $ExpectedMistake
+        var block = parse.bind(null, '2016-11-25 04 AM', 'YYYY-MM-DD hh A', baseDate, {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `formatLong` property', function () {
+      it('throws `RangeError`', function () {
+        // $ExpectedMistake
+        var customLocale = {match: {}}
+        // $ExpectedMistake
+        var block = parse.bind(null, '2016-11-25 04 AM', 'YYYY-MM-DD hh A', baseDate, {locale: customLocale})
+        assert.throws(block, RangeError)
+      })
+    })
+
+    context('does not contain `parsingTokensRegExp` property', function () {
+      it('uses `parse.parsingTokensRegExp` of default locale', function () {
+        var units = {
+          date: {
+            priority: 12,
+            set: function (dateValues, value) {
+              dateValues.date.setUTCDate(value + 2)
+              dateValues.date.setUTCHours(0, 0, 0, 0)
+              return dateValues
+            }
+          },
+
+          month: {
+            priority: 11,
+            set: function (dateValues, value) {
+              dateValues.date.setUTCMonth(value + 2, 1)
+              dateValues.date.setUTCHours(0, 0, 0, 0)
+              return dateValues
+            }
+          }
+        }
+
+        var parsers = {
+          Do: {
+            unit: 'date',
+            match: /^(It|This)/,
+            parse: function (matchResult) {
+              var word = matchResult[1]
+
+              if (word === 'It') {
+                return 7
+              } else {
+                return 6
+              }
+            }
+          },
+
+          MMMM: {
+            unit: 'month',
+            match: /^(works|doesn't work)/,
+            parse: function (matchResult) {
+              var word = matchResult[1]
+
+              if (word === 'works') {
+                return 3
+              } else {
+                return 2
+              }
+            }
+          }
+        }
+
+        var customLocale = {
+          // $ExpectedMistake
+          match: {},
+          formatLong: function () {},
+          units: units,
+          parsers: parsers
+        }
+
+        // $ExpectedMistake
+        var result = parse('2017 It works correctly!', 'YYYY Do MMMM [correctly!]', baseDate, {locale: customLocale})
+        assert.deepEqual(result, new Date(Date.UTC(2017, 5, 9)))
+      })
+    })
+
+    context('does not contain `parsers` property', function () {
+      it('works correctly', function () {
+        // $ExpectedMistake
+        var customLocale = {match: {}, formatLong: function () {}}
+        // $ExpectedMistake
+        var result = parse('2016-11-25', 'YYYY-MM-DD', baseDate, {locale: customLocale})
+        assert.deepEqual(result, new Date(Date.UTC(2016, 10 /* Nov */, 25)))
+      })
+    })
+
+    context('does not contain `units` property', function () {
+      it('works correctly', function () {
+        var parsers = {
+          abc: {
+            unit: 'dayOfMonth',
+            match: /^(It|This)/,
+            parse: function (matchResult) {
+              var word = matchResult[1]
+
+              if (word === 'It') {
+                return 7
+              } else {
+                return 6
+              }
+            }
+          },
+
+          efg: {
+            unit: 'month',
+            match: /^(works|doesn't work)/,
+            parse: function (matchResult) {
+              var word = matchResult[1]
+
+              if (word === 'works') {
+                return 3
+              } else {
+                return 2
+              }
+            }
+          }
+        }
+
+        var parsingTokensRegExp = /(\[[^[]*])|(\\)?(YYYY|abc|efg|.)/g
+
+        var customLocale = {
+          // $ExpectedMistake
+          match: {},
+          formatLong: function () {},
+          parsers: parsers,
+          parsingTokensRegExp: parsingTokensRegExp
+        }
+
+        // $ExpectedMistake
+        var result = parse('2017 It works correctly!', 'YYYY abc efg [correctly!]', baseDate, {locale: customLocale})
+        assert.deepEqual(result, new Date(Date.UTC(2017, 3, 7)))
+      })
+    })
+  })
+
+  it('accepts a string as `baseDate`', function () {
+    var dateString = '6 p.m.'
+    var formatString = 'h aa'
+    var result = parse(dateString, formatString, baseDate.toISOString())
+    assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 18)))
+  })
+
+  it('accepts a timestamp as `baseDate`', function () {
+    var dateString = '6 p.m.'
+    var formatString = 'h aa'
+    var result = parse(dateString, formatString, baseDate.getTime())
+    assert.deepEqual(result, new Date(Date.UTC(1986, 3 /* Apr */, 4, 18)))
+  })
+
+  it('does not mutate `baseDate`', function () {
+    var baseDateClone1 = new Date(baseDate.getTime())
+    var baseDateClone2 = new Date(baseDate.getTime())
+    var dateString = '6 p.m.'
+    var formatString = 'h aa'
+    parse(dateString, formatString, baseDateClone1)
+    assert.deepEqual(baseDateClone1, baseDateClone2)
+  })
+
+  describe('failure', function () {
+    it('returns `baseDate` if `dateString` and `formatString` are empty strings', function () {
+      var dateString = ''
+      var formatString = ''
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, baseDate)
+    })
+
+    it('returns `baseDate` if no tokens in `formatString` are provided', function () {
+      var dateString = 'not a token'
+      var formatString = '[not a token]'
+      var result = parse(dateString, formatString, baseDate)
+      assert.deepEqual(result, baseDate)
+    })
+
+    it('returns `Invalid Date`  if `formatString` doesn\'t match with `dateString`', function () {
+      var dateString = '2017-01-01'
+      var formatString = 'YYYY/MM/DD'
+      var result = parse(dateString, formatString, baseDate)
+      assert(result instanceof Date && isNaN(result))
+    })
+
+    it('returns `Invalid Date`  if `formatString` tokens failed to parse a value', function () {
+      var dateString = '2017-01-01'
+      var formatString = 'MMMM Do YYYY'
+      var result = parse(dateString, formatString, baseDate)
+      assert(result instanceof Date && isNaN(result))
+    })
+
+    it('returns `Invalid Date` if `formatString` is empty string but `dateString` is not', function () {
+      var dateString = '2017-01-01'
+      var formatString = ''
+      var result = parse(dateString, formatString, baseDate)
+      assert(result instanceof Date && isNaN(result))
+    })
+
+    it('returns `Invalid Date` if `baseDate` is `Invalid Date`', function () {
+      var dateString = '2014-07-02T05:30:15.123+06:00'
+      var formatString = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+      var result = parse(dateString, formatString, new Date(NaN))
+      assert(result instanceof Date && isNaN(result))
+    })
+
+    it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+      var dateString = '2014-07-02T05:30:15.123+06:00'
+      var formatString = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+      // $ExpectedMistake
+      var block = parse.bind(null, dateString, formatString, baseDate, {weekStartsOn: NaN})
+      assert.throws(block, RangeError)
+    })
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = parse.bind(null, '16', 'YY', baseDate, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 3 arguments', function () {
+    assert.throws(parse.bind(null), TypeError)
+    // $ExpectedMistake
+    assert.throws(parse.bind(null, 1), TypeError)
+    // $ExpectedMistake
+    assert.throws(parse.bind(null, 1, 2), TypeError)
+  })
+})

--- a/src/utc/setDate/index.js
+++ b/src/utc/setDate/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setDate
+ * @category Day Helpers
+ * @summary Set the day of the month to the given date.
+ *
+ * @description
+ * Set the day of the month to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} dayOfMonth - the day of the month of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the day of the month setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set the 30th day of the month to 1 September 2014:
+ * var result = setDate(new Date(Date.UTC(2014, 8, 1)), 30)
+ * //=> Tue Sep 30 2014 00:00:00
+ */
+export default function setDate (dirtyDate, dirtyDayOfMonth, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var dayOfMonth = Number(dirtyDayOfMonth)
+  date.setUTCDate(dayOfMonth)
+  return date
+}

--- a/src/utc/setDate/test.js
+++ b/src/utc/setDate/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setDate from '.'
+
+describe('utc/setDate', function () {
+  it('sets the day of the month', function () {
+    var result = setDate(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 30)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30)))
+  })
+
+  it('accepts a string', function () {
+    var result = setDate(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 18)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 18)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setDate(Date.UTC(2014, 8 /* Sep */, 1), 25)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 25)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setDate(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '30')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    setDate(date, 20)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setDate(new Date(NaN), 30)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setDate(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setDate.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 30, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setDate.bind(null), TypeError)
+    assert.throws(setDate.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setDay/index.js
+++ b/src/utc/setDay/index.js
@@ -1,0 +1,58 @@
+import toDate from '../toDate/index.js'
+import addDays from '../addDays/index.js'
+
+/**
+ * @name setDay
+ * @category Weekday Helpers
+ * @summary Set the day of the week to the given date.
+ *
+ * @description
+ * Set the day of the week to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} day - the day of the week of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Date} the new date with the day of the week setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // Set Sunday to 1 September 2014:
+ * var result = setDay(new Date(Date.UTC(2014, 8, 1)), 0)
+ * //=> Sun Aug 31 2014 00:00:00
+ *
+ * @example
+ * // If week starts with Monday, set Sunday to 1 September 2014:
+ * var result = setDay(new Date(Date.UTC(2014, 8, 1)), 0, {weekStartsOn: 1})
+ * //=> Sun Sep 07 2014 00:00:00
+ */
+export default function setDay (dirtyDate, dirtyDay, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var date = toDate(dirtyDate, options)
+  var day = Number(dirtyDay)
+  var currentDay = date.getUTCDay()
+
+  var remainder = day % 7
+  var dayIndex = (remainder + 7) % 7
+
+  var diff = (dayIndex < weekStartsOn ? 7 : 0) + day - currentDay
+  return addDays(date, diff, options)
+}

--- a/src/utc/setDay/test.js
+++ b/src/utc/setDay/test.js
@@ -1,0 +1,135 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setDay from '.'
+
+describe('utc/setDay', function () {
+  it('sets the day of the week', function () {
+    var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0, {weekStartsOn: 1})
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 7)))
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var result = setDay(
+      new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+      0,
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 7)))
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var result = setDay(
+      new Date(Date.UTC(2014, 8 /* Sep */, 1)),
+      0,
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 7)))
+  })
+
+  it('implicitly converts options', function () {
+    // $ExpectedMistake
+    var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0, {weekStartsOn: '1'})
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 7)))
+  })
+
+  context('the day index is more than 6', function () {
+    it('sets the day of the next week', function () {
+      var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 8)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 8)))
+    })
+
+    it('allows to specify which day is the first day of the week', function () {
+      var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 7, {weekStartsOn: 1})
+      assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 14)))
+    })
+
+    it('sets the day of another week in the future', function () {
+      var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 14, {weekStartsOn: 1})
+      assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 21)))
+    })
+  })
+
+  context('the day index is less than 0', function () {
+    it('sets the day of the last week', function () {
+      var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), -6)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 25)))
+    })
+
+    it('allows to specify which day is the first day of the week', function () {
+      var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), -7, {weekStartsOn: 1})
+      assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+    })
+
+    it('set the day of another week in the past', function () {
+      var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), -14, {weekStartsOn: 1})
+      assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 24)))
+    })
+  })
+
+  it('accepts a string', function () {
+    var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 5)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setDay(Date.UTC(2014, 8 /* Sep */, 1), 3)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 5)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    setDay(date, 3)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setDay(new Date(NaN), 0)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // $ExpectedMistake
+    var block = setDay.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0, {weekStartsOn: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setDay.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setDay.bind(null), TypeError)
+    assert.throws(setDay.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setDayOfYear/index.js
+++ b/src/utc/setDayOfYear/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setDayOfYear
+ * @category Day Helpers
+ * @summary Set the day of the year to the given date.
+ *
+ * @description
+ * Set the day of the year to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} dayOfYear - the day of the year of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the day of the year setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set the 2nd day of the year to 2 July 2014:
+ * var result = setDayOfYear(new Date(Date.UTC(2014, 6, 2)), 2)
+ * //=> Thu Jan 02 2014 00:00:00
+ */
+export default function setDayOfYear (dirtyDate, dirtyDayOfYear, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var dayOfYear = Number(dirtyDayOfYear)
+  date.setUTCMonth(0)
+  date.setUTCDate(dayOfYear)
+  return date
+}

--- a/src/utc/setDayOfYear/test.js
+++ b/src/utc/setDayOfYear/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setDayOfYear from '.'
+
+describe('utc/setDayOfYear', function () {
+  it('sets the day of the year', function () {
+    var result = setDayOfYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)), 2)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 2)))
+  })
+
+  it('accepts a string', function () {
+    var result = setDayOfYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)).toISOString(), 60)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 2 /* Mar */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setDayOfYear(Date.UTC(2014, 6 /* Jul */, 2), 60)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 2 /* Mar */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setDayOfYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)), '2')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 2)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    setDayOfYear(date, 365)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setDayOfYear(new Date(NaN), 2)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setDayOfYear(new Date(Date.UTC(2014, 6 /* Jul */, 2)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setDayOfYear.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 2)), 2, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setDayOfYear.bind(null), TypeError)
+    assert.throws(setDayOfYear.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setHours/index.js
+++ b/src/utc/setHours/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setHours
+ * @category Hour Helpers
+ * @summary Set the hours to the given date.
+ *
+ * @description
+ * Set the hours to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} hours - the hours of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the hours setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set 4 hours to 1 September 2014 11:30:00:
+ * var result = setHours(new Date(Date.UTC(2014, 8, 1, 11, 30)), 4)
+ * //=> Mon Sep 01 2014 04:30:00
+ */
+export default function setHours (dirtyDate, dirtyHours, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var hours = Number(dirtyHours)
+  date.setUTCHours(hours)
+  return date
+}

--- a/src/utc/setHours/test.js
+++ b/src/utc/setHours/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setHours from '.'
+
+describe('utc/setHours', function () {
+  it('sets the amount of hours', function () {
+    var result = setHours(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30)), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 4, 30)))
+  })
+
+  it('accepts a string', function () {
+    var result = setHours(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)).toISOString(), 18)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 18)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setHours(Date.UTC(2014, 8 /* Sep */, 1, 11), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 5)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setHours(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30)), '4')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 4, 30)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1, 11))
+    setHours(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setHours(new Date(NaN), 4)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setHours(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setHours.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30)), 4, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setHours.bind(null), TypeError)
+    assert.throws(setHours.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setISODay/index.js
+++ b/src/utc/setISODay/index.js
@@ -1,0 +1,38 @@
+import toDate from '../toDate/index.js'
+import addDays from '../addDays/index.js'
+import getISODay from '../getISODay/index.js'
+
+/**
+ * @name setISODay
+ * @category Weekday Helpers
+ * @summary Set the day of the ISO week to the given date.
+ *
+ * @description
+ * Set the day of the ISO week to the given date.
+ * ISO week starts with Monday.
+ * 7 is the index of Sunday, 1 is the index of Monday etc.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} day - the day of the ISO week of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the day of the ISO week setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set Sunday to 1 September 2014:
+ * var result = setISODay(new Date(Date.UTC(2014, 8, 1)), 7)
+ * //=> Sun Sep 07 2014 00:00:00
+ */
+export default function setISODay (dirtyDate, dirtyDay, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var day = Number(dirtyDay)
+  var currentDay = getISODay(date, dirtyOptions)
+  var diff = day - currentDay
+  return addDays(date, diff, dirtyOptions)
+}

--- a/src/utc/setISODay/test.js
+++ b/src/utc/setISODay/test.js
@@ -1,0 +1,84 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setISODay from '.'
+
+describe('utc/setISODay', function () {
+  it('sets the day of the ISO week', function () {
+    var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 3)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
+  })
+
+  it('sets the day to Sunday of this ISO week if the index is 7', function () {
+    var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 7)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 7)))
+  })
+
+  context('the day index is more than 7', function () {
+    it('sets the day of the next ISO week', function () {
+      var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 8)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 8)))
+    })
+
+    it('sets the day of another ISO week in the future', function () {
+      var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 21)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 21)))
+    })
+  })
+
+  context('the day index is less than 1', function () {
+    it('sets the day of the last ISO week', function () {
+      var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+    })
+
+    it('set the day of another ISO week in the past', function () {
+      var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), -13)
+      assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 18)))
+    })
+  })
+
+  it('accepts a string', function () {
+    var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 5)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setISODay(Date.UTC(2014, 8 /* Sep */, 1), 3)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '3')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    setISODay(date, 3)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setISODay(new Date(NaN), 3)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setISODay.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 3, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setISODay.bind(null), TypeError)
+    assert.throws(setISODay.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setISOWeek/index.js
+++ b/src/utc/setISOWeek/index.js
@@ -1,0 +1,37 @@
+import toDate from '../toDate/index.js'
+import getISOWeek from '../getISOWeek/index.js'
+
+/**
+ * @name setISOWeek
+ * @category ISO Week Helpers
+ * @summary Set the ISO week to the given date.
+ *
+ * @description
+ * Set the ISO week to the given date, saving the weekday number.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} isoWeek - the ISO week of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the ISO week setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set the 53rd ISO week to 7 August 2004:
+ * var result = setISOWeek(new Date(Date.UTC(2004, 7, 7)), 53)
+ * //=> Sat Jan 01 2005 00:00:00
+ */
+export default function setISOWeek (dirtyDate, dirtyISOWeek, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var isoWeek = Number(dirtyISOWeek)
+  var diff = getISOWeek(date, dirtyOptions) - isoWeek
+  date.setUTCDate(date.getUTCDate() - diff * 7)
+  return date
+}

--- a/src/utc/setISOWeek/test.js
+++ b/src/utc/setISOWeek/test.js
@@ -1,0 +1,66 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setISOWeek from '.'
+
+describe('utc/setISOWeek', function () {
+  it('sets the ISO week', function () {
+    var result = setISOWeek(new Date(Date.UTC(2004, 7 /* Aug */, 7)), 53)
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = setISOWeek(new Date(Date.UTC(2009, 11 /* Dec */, 2)).toISOString(), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 31)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setISOWeek(Date.UTC(2009, 11 /* Dec */, 2), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 31)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setISOWeek(new Date(Date.UTC(2004, 7 /* Aug */, 7)), '53')
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    setISOWeek(date, 52)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(4, 0 /* Jan */, 4)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(4, 11 /* Dec */, 26)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = setISOWeek(initialDate, 52)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setISOWeek(new Date(NaN), 53)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setISOWeek(new Date(Date.UTC(2004, 7 /* Aug */, 7)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setISOWeek.bind(null, new Date(Date.UTC(2004, 7 /* Aug */, 7)), 53, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setISOWeek.bind(null), TypeError)
+    assert.throws(setISOWeek.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setISOWeekYear/index.js
+++ b/src/utc/setISOWeekYear/index.js
@@ -1,0 +1,43 @@
+import toDate from '../toDate/index.js'
+import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
+import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+
+/**
+ * @name setISOWeekYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Set the ISO week-numbering year to the given date.
+ *
+ * @description
+ * Set the ISO week-numbering year to the given date,
+ * saving the week number and the weekday number.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} isoWeekYear - the ISO week-numbering year of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the ISO week-numbering year setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set ISO week-numbering year 2007 to 29 December 2008:
+ * var result = setISOWeekYear(new Date(Date.UTC(2008, 11, 29)), 2007)
+ * //=> Mon Jan 01 2007 00:00:00
+ */
+export default function setISOWeekYear (dirtyDate, dirtyISOWeekYear, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var isoWeekYear = Number(dirtyISOWeekYear)
+  var diff = differenceInCalendarDays(date, startOfISOWeekYear(date, dirtyOptions), dirtyOptions)
+  var fourthOfJanuary = new Date(0)
+  fourthOfJanuary.setUTCFullYear(isoWeekYear, 0, 4)
+  fourthOfJanuary.setUTCHours(0, 0, 0, 0)
+  date = startOfISOWeekYear(fourthOfJanuary, dirtyOptions)
+  date.setUTCDate(date.getUTCDate() + diff)
+  return date
+}

--- a/src/utc/setISOWeekYear/test.js
+++ b/src/utc/setISOWeekYear/test.js
@@ -1,0 +1,75 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setISOWeekYear from '.'
+
+describe('utc/setISOWeekYear', function () {
+  it('sets the ISO week-numbering year, saving the ISO week and the day of the week', function () {
+    var result = setISOWeekYear(new Date(Date.UTC(2008, 11 /* Dec */, 29)), 2007)
+    assert.deepEqual(result, new Date(Date.UTC(2007, 0 /* Jan */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = setISOWeekYear(new Date(Date.UTC(2010, 0 /* Jan */, 2)).toISOString(), 2004)
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setISOWeekYear(Date.UTC(2010, 0 /* Jan */, 2), 2004)
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setISOWeekYear(new Date(Date.UTC(2008, 11 /* Dec */, 29)), '2007')
+    assert.deepEqual(result, new Date(Date.UTC(2007, 0 /* Jan */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2008, 11 /* Dec */, 29))
+    setISOWeekYear(date, 2000)
+    assert.deepEqual(date, new Date(Date.UTC(2008, 11 /* Dec */, 29)))
+  })
+
+  it('sets ISO week-numbering years less than 100', function () {
+    var initialDate = new Date(Date.UTC(2008, 11 /* Dec */, 29))
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(7, 0 /* Jan */, 1)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = setISOWeekYear(initialDate, 7)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(8, 11 /* Dec */, 29)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(7, 0 /* Jan */, 1)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = setISOWeekYear(initialDate, 7)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setISOWeekYear(new Date(NaN), 2007)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setISOWeekYear(new Date(Date.UTC(2008, 11 /* Dec */, 29)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setISOWeekYear.bind(null, new Date(Date.UTC(2008, 11 /* Dec */, 29)), 2007, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setISOWeekYear.bind(null), TypeError)
+    assert.throws(setISOWeekYear.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setMilliseconds/index.js
+++ b/src/utc/setMilliseconds/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setMilliseconds
+ * @category Millisecond Helpers
+ * @summary Set the milliseconds to the given date.
+ *
+ * @description
+ * Set the milliseconds to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} milliseconds - the milliseconds of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the milliseconds setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set 300 milliseconds to 1 September 2014 11:30:40.500:
+ * var result = setMilliseconds(new Date(Date.UTC(2014, 8, 1, 11, 30, 40, 500)), 300)
+ * //=> Mon Sep 01 2014 11:30:40.300
+ */
+export default function setMilliseconds (dirtyDate, dirtyMilliseconds, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var milliseconds = Number(dirtyMilliseconds)
+  date.setUTCMilliseconds(milliseconds)
+  return date
+}

--- a/src/utc/setMilliseconds/test.js
+++ b/src/utc/setMilliseconds/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setMilliseconds from '.'
+
+describe('utc/setMilliseconds', function () {
+  it('sets the milliseconds', function () {
+    var result = setMilliseconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), 300)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 300)))
+  })
+
+  it('accepts a string', function () {
+    var result = setMilliseconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)).toISOString(), 123)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 0, 0, 123)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setMilliseconds(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 15, 750), 755)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 15, 755)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setMilliseconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), '300')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 300)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500))
+    setMilliseconds(date, 137)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setMilliseconds(new Date(NaN), 300)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setMilliseconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setMilliseconds.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), 300, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setMilliseconds.bind(null), TypeError)
+    assert.throws(setMilliseconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setMinutes/index.js
+++ b/src/utc/setMinutes/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setMinutes
+ * @category Minute Helpers
+ * @summary Set the minutes to the given date.
+ *
+ * @description
+ * Set the minutes to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} minutes - the minutes of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the minutes setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set 45 minutes to 1 September 2014 11:30:40:
+ * var result = setMinutes(new Date(Date.UTC(2014, 8, 1, 11, 30, 40)), 45)
+ * //=> Mon Sep 01 2014 11:45:40
+ */
+export default function setMinutes (dirtyDate, dirtyMinutes, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var minutes = Number(dirtyMinutes)
+  date.setUTCMinutes(minutes)
+  return date
+}

--- a/src/utc/setMinutes/test.js
+++ b/src/utc/setMinutes/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setMinutes from '.'
+
+describe('utc/setMinutes', function () {
+  it('sets the minutes', function () {
+    var result = setMinutes(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40)), 45)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 45, 40)))
+  })
+
+  it('accepts a string', function () {
+    var result = setMinutes(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)).toISOString(), 18)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 18)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setMinutes(Date.UTC(2014, 8 /* Sep */, 1, 11, 30), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 5)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setMinutes(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40)), '45')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 45, 40)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30))
+    setMinutes(date, 15)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setMinutes(new Date(NaN), 45)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setMinutes(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setMinutes.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40)), 45, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setMinutes.bind(null), TypeError)
+    assert.throws(setMinutes.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setMonth/index.js
+++ b/src/utc/setMonth/index.js
@@ -1,0 +1,43 @@
+import toDate from '../toDate/index.js'
+import getDaysInMonth from '../getDaysInMonth/index.js'
+
+/**
+ * @name setMonth
+ * @category Month Helpers
+ * @summary Set the month to the given date.
+ *
+ * @description
+ * Set the month to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} month - the month of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the month setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set February to 1 September 2014:
+ * var result = setMonth(new Date(Date.UTC(2014, 8, 1)), 1)
+ * //=> Sat Feb 01 2014 00:00:00
+ */
+export default function setMonth (dirtyDate, dirtyMonth, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var month = Number(dirtyMonth)
+  var year = date.getUTCFullYear()
+  var day = date.getUTCDate()
+
+  var dateWithDesiredMonth = new Date(0)
+  dateWithDesiredMonth.setUTCFullYear(year, month, 15)
+  dateWithDesiredMonth.setUTCHours(0, 0, 0, 0)
+  var daysInMonth = getDaysInMonth(dateWithDesiredMonth, dirtyOptions)
+  // Set the last day of the new month
+  // if the original date was the last day of the longer month
+  date.setUTCMonth(month, Math.min(day, daysInMonth))
+  return date
+}

--- a/src/utc/setMonth/test.js
+++ b/src/utc/setMonth/test.js
@@ -1,0 +1,71 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setMonth from '.'
+
+describe('utc/setMonth', function () {
+  it('sets the month', function () {
+    var result = setMonth(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 1)))
+  })
+
+  it('sets the last day of the month if the original date was the last day of a longer month', function () {
+    var result = setMonth(new Date(Date.UTC(2014, 11 /* Dec */, 31)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 28)))
+  })
+
+  it('accepts a string', function () {
+    var result = setMonth(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 11)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setMonth(Date.UTC(2014, 8 /* Sep */, 1), 11)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setMonth(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '1')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    setMonth(date, 5)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 11 /* Dec */, 31)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(0, 1 /* Feb */, 29)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = setMonth(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setMonth(new Date(NaN), 1)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setMonth(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setMonth.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 1, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setMonth.bind(null), TypeError)
+    assert.throws(setMonth.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setQuarter/index.js
+++ b/src/utc/setQuarter/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+import setMonth from '../setMonth/index.js'
+
+/**
+ * @name setQuarter
+ * @category Quarter Helpers
+ * @summary Set the year quarter to the given date.
+ *
+ * @description
+ * Set the year quarter to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} quarter - the quarter of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the quarter setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set the 2nd quarter to 2 July 2014:
+ * var result = setQuarter(new Date(Date.UTC(2014, 6, 2)), 2)
+ * //=> Wed Apr 02 2014 00:00:00
+ */
+export default function setQuarter (dirtyDate, dirtyQuarter, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var quarter = Number(dirtyQuarter)
+  var oldQuarter = Math.floor(date.getUTCMonth() / 3) + 1
+  var diff = quarter - oldQuarter
+  return setMonth(date, date.getUTCMonth() + diff * 3, dirtyOptions)
+}

--- a/src/utc/setQuarter/test.js
+++ b/src/utc/setQuarter/test.js
@@ -1,0 +1,71 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setQuarter from '.'
+
+describe('utc/setQuarter', function () {
+  it('sets the quarter of the year', function () {
+    var result = setQuarter(new Date(Date.UTC(2014, 6 /* Jul */, 2)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 2)))
+  })
+
+  it('sets the last day of the month if the original date was the last day of a longer month', function () {
+    var result = setQuarter(new Date(Date.UTC(2014, 10 /* Nov */, 30)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 28)))
+  })
+
+  it('accepts a string', function () {
+    var result = setQuarter(new Date(Date.UTC(2014, 6 /* Jul */, 1)).toISOString(), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setQuarter(Date.UTC(2014, 6 /* Jul */, 1), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setQuarter(new Date(Date.UTC(2014, 6 /* Jul */, 2)), '1')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 2)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 1))
+    setQuarter(date, 2)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 1)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 10 /* Nov */, 30)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(0, 1 /* Feb */, 29)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = setQuarter(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setQuarter(new Date(NaN), 1)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setQuarter(new Date(Date.UTC(2014, 6 /* Jul */, 2)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setQuarter.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 2)), 1, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setQuarter.bind(null), TypeError)
+    assert.throws(setQuarter.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setSeconds/index.js
+++ b/src/utc/setSeconds/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setSeconds
+ * @category Second Helpers
+ * @summary Set the seconds to the given date.
+ *
+ * @description
+ * Set the seconds to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} seconds - the seconds of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the seconds setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set 45 seconds to 1 September 2014 11:30:40:
+ * var result = setSeconds(new Date(Date.UTC(2014, 8, 1, 11, 30, 40)), 45)
+ * //=> Mon Sep 01 2014 11:30:45
+ */
+export default function setSeconds (dirtyDate, dirtySeconds, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var seconds = Number(dirtySeconds)
+  date.setUTCSeconds(seconds)
+  return date
+}

--- a/src/utc/setSeconds/test.js
+++ b/src/utc/setSeconds/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setSeconds from '.'
+
+describe('utc/setSeconds', function () {
+  it('sets the seconds', function () {
+    var result = setSeconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), 45)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 45, 500)))
+  })
+
+  it('accepts a string', function () {
+    var result = setSeconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)).toISOString(), 18)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 0, 18)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setSeconds(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 15), 45)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 45)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setSeconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), '45')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 45, 500)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40))
+    setSeconds(date, 15)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setSeconds(new Date(NaN), 45)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setSeconds(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setSeconds.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11, 30, 40, 500)), 45, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setSeconds.bind(null), TypeError)
+    assert.throws(setSeconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/setYear/index.js
+++ b/src/utc/setYear/index.js
@@ -1,0 +1,39 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name setYear
+ * @category Year Helpers
+ * @summary Set the year to the given date.
+ *
+ * @description
+ * Set the year to the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} year - the year of the new date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the year setted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Set year 2013 to 1 September 2014:
+ * var result = setYear(new Date(Date.UTC(2014, 8, 1)), 2013)
+ * //=> Sun Sep 01 2013 00:00:00
+ */
+export default function setYear (dirtyDate, dirtyYear, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var year = Number(dirtyYear)
+
+  // Check if date is Invalid Date because Date.prototype.setUTCFullYear ignores the value of Invalid Date
+  if (isNaN(date)) {
+    return new Date(NaN)
+  }
+
+  date.setUTCFullYear(year)
+  return date
+}

--- a/src/utc/setYear/test.js
+++ b/src/utc/setYear/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import setYear from '.'
+
+describe('utc/setYear', function () {
+  it('sets the year', function () {
+    var result = setYear(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 2013)
+    assert.deepEqual(result, new Date(Date.UTC(2013, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = setYear(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 2016)
+    assert.deepEqual(result, new Date(Date.UTC(2016, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = setYear(Date.UTC(2014, 8 /* Sep */, 1), 2016)
+    assert.deepEqual(result, new Date(Date.UTC(2016, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = setYear(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '2013')
+    assert.deepEqual(result, new Date(Date.UTC(2013, 8 /* Sep */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    setYear(date, 2011)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = setYear(new Date(NaN), 2013)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = setYear(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = setYear.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 2013, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(setYear.bind(null), TypeError)
+    assert.throws(setYear.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/startOfDay/index.js
+++ b/src/utc/startOfDay/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfDay
+ * @category Day Helpers
+ * @summary Return the start of a day for the given date.
+ *
+ * @description
+ * Return the start of a day for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of a day
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of a day for 2 September 2014 11:55:00:
+ * var result = startOfDay(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Sep 02 2014 00:00:00
+ */
+export default function startOfDay (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/startOfDay/test.js
+++ b/src/utc/startOfDay/test.js
@@ -1,0 +1,53 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfDay from '.'
+
+describe('utc/startOfDay', function () {
+  it('returns the date with the time setted to 00:00:00', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfDay(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2, 0, 0, 0, 0))
+    )
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = startOfDay(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2, 0, 0, 0, 0))
+    )
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = startOfDay(date)
+    assert.deepEqual(result,
+      new Date(Date.UTC(2014, 8 /* Sep */, 2, 0, 0, 0, 0))
+    )
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    startOfDay(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfDay(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = startOfDay.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfDay.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfHour/index.js
+++ b/src/utc/startOfHour/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfHour
+ * @category Hour Helpers
+ * @summary Return the start of an hour for the given date.
+ *
+ * @description
+ * Return the start of an hour for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of an hour
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of an hour for 2 September 2014 11:55:00:
+ * var result = startOfHour(new Date(Date.UTC(2014, 8, 2, 11, 55)))
+ * //=> Tue Sep 02 2014 11:00:00
+ */
+export default function startOfHour (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCMinutes(0, 0, 0)
+  return date
+}

--- a/src/utc/startOfHour/test.js
+++ b/src/utc/startOfHour/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfHour from '.'
+
+describe('utc/startOfHour', function () {
+  it('returns the date with the time setted to the first millisecond of an hour', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55))
+    var result = startOfHour(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55))
+    startOfHour(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55)
+    var result = startOfHour(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 12, 45)).toISOString()
+    var result = startOfHour(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11, 1, 12, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfHour(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55))
+    // $ExpectedMistake
+    var block = startOfHour.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfHour.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfISOWeek/index.js
+++ b/src/utc/startOfISOWeek/index.js
@@ -1,0 +1,35 @@
+import startOfWeek from '../startOfWeek/index.js'
+import cloneObject from '../../_lib/cloneObject/index.js'
+
+/**
+ * @name startOfISOWeek
+ * @category ISO Week Helpers
+ * @summary Return the start of an ISO week for the given date.
+ *
+ * @description
+ * Return the start of an ISO week for the given date.
+ * The result will be in the local timezone.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of an ISO week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of an ISO week for 2 September 2014 11:55:00:
+ * var result = startOfISOWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Mon Sep 01 2014 00:00:00
+ */
+export default function startOfISOWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var startOfWeekOptions = cloneObject(dirtyOptions)
+  startOfWeekOptions.weekStartsOn = 1
+  return startOfWeek(dirtyDate, startOfWeekOptions)
+}

--- a/src/utc/startOfISOWeek/test.js
+++ b/src/utc/startOfISOWeek/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfISOWeek from '.'
+
+describe('utc/startOfISOWeek', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the first day of an ISO week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfISOWeek(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2, 11, 55, 0)).toISOString()
+    var result = startOfISOWeek(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 5 /* Jun */, 30)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 1 /* Feb */, 11, 11, 55, 0)
+    var result = startOfISOWeek(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 10)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    startOfISOWeek(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfISOWeek(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = startOfISOWeek.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfISOWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfISOWeekYear/index.js
+++ b/src/utc/startOfISOWeekYear/index.js
@@ -1,0 +1,39 @@
+import getISOWeekYear from '../getISOWeekYear/index.js'
+import startOfISOWeek from '../startOfISOWeek/index.js'
+
+/**
+ * @name startOfISOWeekYear
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Return the start of an ISO week-numbering year for the given date.
+ *
+ * @description
+ * Return the start of an ISO week-numbering year,
+ * which always starts 3 days before the year's first Thursday.
+ * The result will be in the local timezone.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of an ISO week-numbering year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of an ISO week-numbering year for 2 July 2005:
+ * var result = startOfISOWeekYear(new Date(Date.UTC(2005, 6, 2)))
+ * //=> Mon Jan 03 2005 00:00:00
+ */
+export default function startOfISOWeekYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var year = getISOWeekYear(dirtyDate, dirtyOptions)
+  var fourthOfJanuary = new Date(0)
+  fourthOfJanuary.setUTCFullYear(year, 0, 4)
+  fourthOfJanuary.setUTCHours(0, 0, 0, 0)
+  var date = startOfISOWeek(fourthOfJanuary, dirtyOptions)
+  return date
+}

--- a/src/utc/startOfISOWeekYear/test.js
+++ b/src/utc/startOfISOWeekYear/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfISOWeekYear from '.'
+
+describe('utc/startOfISOWeekYear', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the first day of an ISO year', function () {
+    var result = startOfISOWeekYear(new Date(Date.UTC(2009, 0 /* Jan */, 1, 16, 0)))
+    assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 29, 0, 0, 0, 0)))
+  })
+
+  it('accepts a string', function () {
+    var result = startOfISOWeekYear(new Date(Date.UTC(2005, 0 /* Jan */, 1, 6, 0)).toISOString())
+    assert.deepEqual(result, new Date(Date.UTC(2003, 11 /* Dec */, 29, 0, 0, 0, 0)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = startOfISOWeekYear(Date.UTC(2005, 0 /* Jan */, 1, 6, 0))
+    assert.deepEqual(result, new Date(Date.UTC(2003, 11 /* Dec */, 29, 0, 0, 0, 0)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 2))
+    startOfISOWeekYear(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 2)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(9, 0 /* Jan */, 1, 16, 0)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(8, 11 /* Dec */, 29)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = startOfISOWeekYear(initialDate)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('correctly handles years in which 4 January is Sunday', function () {
+    var result = startOfISOWeekYear(new Date(Date.UTC(2009, 6 /* Jul */, 2)))
+    assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 29)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfISOWeekYear(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = startOfISOWeekYear.bind(null, new Date(Date.UTC(2009, 0 /* Jan */, 1, 16, 0)), {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfISOWeekYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfMinute/index.js
+++ b/src/utc/startOfMinute/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfMinute
+ * @category Minute Helpers
+ * @summary Return the start of a minute for the given date.
+ *
+ * @description
+ * Return the start of a minute for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of a minute
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of a minute for 1 December 2014 22:15:45.400:
+ * var result = startOfMinute(new Date(Date.UTC(2014, 11, 1, 22, 15, 45, 400)))
+ * //=> Mon Dec 01 2014 22:15:00
+ */
+export default function startOfMinute (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCSeconds(0, 0)
+  return date
+}

--- a/src/utc/startOfMinute/test.js
+++ b/src/utc/startOfMinute/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfMinute from '.'
+
+describe('utc/startOfMinute', function () {
+  it('returns the date with the time setted to the first millisecond of a minute', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400))
+    var result = startOfMinute(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 13, 20)).toISOString()
+    var result = startOfMinute(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1, 13, 20)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 11 /* Dec */, 1, 22, 15)
+    var result = startOfMinute(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400))
+    startOfMinute(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfMinute(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400))
+    // $ExpectedMistake
+    var block = startOfMinute.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfMinute.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfMonth/index.js
+++ b/src/utc/startOfMonth/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfMonth
+ * @category Month Helpers
+ * @summary Return the start of a month for the given date.
+ *
+ * @description
+ * Return the start of a month for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of a month
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of a month for 2 September 2014 11:55:00:
+ * var result = startOfMonth(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Mon Sep 01 2014 00:00:00
+ */
+export default function startOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCDate(1)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/startOfMonth/test.js
+++ b/src/utc/startOfMonth/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfMonth from '.'
+
+describe('utc/startOfMonth', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the first day of a month', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfMonth(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = startOfMonth(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = startOfMonth(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    startOfMonth(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfMonth(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = startOfMonth.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfMonth.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfQuarter/index.js
+++ b/src/utc/startOfQuarter/index.js
@@ -1,0 +1,35 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfQuarter
+ * @category Quarter Helpers
+ * @summary Return the start of a year quarter for the given date.
+ *
+ * @description
+ * Return the start of a year quarter for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of a quarter
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of a quarter for 2 September 2014 11:55:00:
+ * var result = startOfQuarter(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Tue Jul 01 2014 00:00:00
+ */
+export default function startOfQuarter (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  var currentMonth = date.getUTCMonth()
+  var month = currentMonth - currentMonth % 3
+  date.setUTCMonth(month, 1)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/startOfQuarter/test.js
+++ b/src/utc/startOfQuarter/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfQuarter from '.'
+
+describe('utc/startOfQuarter', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the first day of a quarter', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 2 /* Mar */, 2, 11, 55, 0)).toISOString()
+    var result = startOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = startOfQuarter(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    startOfQuarter(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfQuarter(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = startOfQuarter.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfQuarter.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfSecond/index.js
+++ b/src/utc/startOfSecond/index.js
@@ -1,0 +1,32 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfSecond
+ * @category Second Helpers
+ * @summary Return the start of a second for the given date.
+ *
+ * @description
+ * Return the start of a second for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of a second
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of a second for 1 December 2014 22:15:45.400:
+ * var result = startOfSecond(new Date(Date.UTC(2014, 11, 1, 22, 15, 45, 400)))
+ * //=> Mon Dec 01 2014 22:15:45.000
+ */
+export default function startOfSecond (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var date = toDate(dirtyDate, dirtyOptions)
+  date.setUTCMilliseconds(0)
+  return date
+}

--- a/src/utc/startOfSecond/test.js
+++ b/src/utc/startOfSecond/test.js
@@ -1,0 +1,47 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfSecond from '.'
+
+describe('utc/startOfSecond', function () {
+  it('returns the date with the time setted to the first millisecond of a second', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400))
+    var result = startOfSecond(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 13, 20, 30, 456)).toISOString()
+    var result = startOfSecond(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1, 13, 20, 30)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400)
+    var result = startOfSecond(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400))
+    startOfSecond(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfSecond(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 1, 22, 15, 45, 400))
+    // $ExpectedMistake
+    var block = startOfSecond.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfSecond.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfWeek/index.js
+++ b/src/utc/startOfWeek/index.js
@@ -1,0 +1,55 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfWeek
+ * @category Week Helpers
+ * @summary Return the start of a week for the given date.
+ *
+ * @description
+ * Return the start of a week for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Date} the start of a week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
+ *
+ * @example
+ * // The start of a week for 2 September 2014 11:55:00:
+ * var result = startOfWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)))
+ * //=> Sun Aug 31 2014 00:00:00
+ *
+ * @example
+ * // If the week starts on Monday, the start of the week for 2 September 2014 11:55:00:
+ * var result = startOfWeek(new Date(Date.UTC(2014, 8, 2, 11, 55, 0)), {weekStartsOn: 1})
+ * //=> Mon Sep 01 2014 00:00:00
+ */
+export default function startOfWeek (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var date = toDate(dirtyDate, options)
+  var day = date.getUTCDay()
+  var diff = (day < weekStartsOn ? 7 : 0) + day - weekStartsOn
+
+  date.setUTCDate(date.getUTCDate() - diff)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/startOfWeek/test.js
+++ b/src/utc/startOfWeek/test.js
@@ -1,0 +1,127 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfWeek from '.'
+
+describe('utc/startOfWeek', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the first day of a week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfWeek(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+  })
+
+  it('allows to specify which day is the first day of the week', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfWeek(date, {weekStartsOn: 1})
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfWeek(
+      date,
+      {
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 1}
+        }
+      }
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfWeek(
+      date,
+      {
+        weekStartsOn: 1,
+        // $ExpectedMistake
+        locale: {
+          options: {weekStartsOn: 0}
+        }
+      }
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts options', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var result = startOfWeek(date, {weekStartsOn: '1'})
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = startOfWeek(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = startOfWeek(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    startOfWeek(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  describe('edge cases', function () {
+    context('when the given day is before the start of a week', function () {
+      it('it returns the start of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 6))
+        var result = startOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 1)))
+      })
+    })
+
+    context('when the given day is the start of a week', function () {
+      it('it returns the start of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 8))
+        var result = startOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 8)))
+      })
+    })
+
+    context('when the given day is after the start of a week', function () {
+      it('it returns the start of a week', function () {
+        var date = new Date(Date.UTC(2014, 9 /* Oct */, 10))
+        var result = startOfWeek(date, {weekStartsOn: 3})
+        assert.deepEqual(result, new Date(Date.UTC(2014, 9 /* Oct */, 8)))
+      })
+    })
+
+    it('handles the week at the start of a year', function () {
+      var date = new Date(Date.UTC(2014, 0 /* Jan */, 1))
+      var result = startOfWeek(date)
+      assert.deepEqual(result, new Date(Date.UTC(2013, 11 /* Dec */, 29)))
+    })
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfWeek(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // $ExpectedMistake
+    var block = startOfWeek.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)), {weekStartsOn: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = startOfWeek.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfWeek.bind(null), TypeError)
+  })
+})

--- a/src/utc/startOfYear/index.js
+++ b/src/utc/startOfYear/index.js
@@ -1,0 +1,34 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name startOfYear
+ * @category Year Helpers
+ * @summary Return the start of a year for the given date.
+ *
+ * @description
+ * Return the start of a year for the given date.
+ * The result will be in the local timezone.
+ *
+ * @param {Date|String|Number} date - the original date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the start of a year
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // The start of a year for 2 September 2014 11:55:00:
+ * var result = startOfYear(new Date(Date.UTC(2014, 8, 2, 11, 55, 00)))
+ * //=> Wed Jan 01 2014 00:00:00
+ */
+export default function startOfYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var cleanDate = toDate(dirtyDate, dirtyOptions)
+  var date = new Date(0)
+  date.setUTCFullYear(cleanDate.getUTCFullYear(), 0, 1)
+  date.setUTCHours(0, 0, 0, 0)
+  return date
+}

--- a/src/utc/startOfYear/test.js
+++ b/src/utc/startOfYear/test.js
@@ -1,0 +1,58 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import startOfYear from '.'
+
+describe('utc/startOfYear', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the first day of a year', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    var result = startOfYear(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 1, 0, 0, 0, 0)))
+  })
+
+  it('accepts a string', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)).toISOString()
+    var result = startOfYear(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 1, 0, 0, 0, 0)))
+  })
+
+  it('accepts a timestamp', function () {
+    var date = Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)
+    var result = startOfYear(date)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Dec */, 1, 0, 0, 0, 0)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    startOfYear(date)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(9, 0 /* Jan */, 5)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(9, 0 /* Jan */, 1)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = startOfYear(initialDate)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = startOfYear(new Date(NaN))
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 2, 11, 55, 0))
+    // $ExpectedMistake
+    var block = startOfYear.bind(null, date, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(startOfYear.bind(null), TypeError)
+  })
+})

--- a/src/utc/subDays/index.js
+++ b/src/utc/subDays/index.js
@@ -1,0 +1,31 @@
+import addDays from '../addDays/index.js'
+
+/**
+ * @name subDays
+ * @category Day Helpers
+ * @summary Subtract the specified number of days from the given date.
+ *
+ * @description
+ * Subtract the specified number of days from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of days to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the days subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 10 days from 1 September 2014:
+ * var result = subDays(new Date(Date.UTC(2014, 8, 1)), 10)
+ * //=> Fri Aug 22 2014 00:00:00
+ */
+export default function subDays (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addDays(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subDays/test.js
+++ b/src/utc/subDays/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subDays from '.'
+
+describe('utc/subDays', function () {
+  it('subtracts the given number of days', function () {
+    var result = subDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 10)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 22)))
+  })
+
+  it('accepts a string', function () {
+    var result = subDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 10)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 22)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subDays(Date.UTC(2014, 8 /* Sep */, 1), 10)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 22)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '10')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 22)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    subDays(date, 11)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subDays(new Date(NaN), 10)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subDays(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subDays.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 10, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subDays.bind(null), TypeError)
+    assert.throws(subDays.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subHours/index.js
+++ b/src/utc/subHours/index.js
@@ -1,0 +1,31 @@
+import addHours from '../addHours/index.js'
+
+/**
+ * @name subHours
+ * @category Hour Helpers
+ * @summary Subtract the specified number of hours from the given date.
+ *
+ * @description
+ * Subtract the specified number of hours from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of hours to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the hours subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 2 hours from 11 July 2014 01:00:00:
+ * var result = subHours(new Date(Date.UTC(2014, 6, 11, 1, 0)), 2)
+ * //=> Thu Jul 10 2014 23:00:00
+ */
+export default function subHours (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addHours(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subHours/test.js
+++ b/src/utc/subHours/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subHours from '.'
+
+describe('utc/subHours', function () {
+  it('subtracts the given numbers of hours', function () {
+    var result = subHours(new Date(Date.UTC(2014, 6 /* Jul */, 11, 1, 0)), 2)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)))
+  })
+
+  it('accepts a string', function () {
+    var result = subHours(
+      new Date(Date.UTC(2014, 6 /* Jul */, 12, 1, 0)).toISOString(), 26
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subHours(
+      Date.UTC(2014, 6 /* Jul */, 12, 1, 0), 26
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subHours(new Date(Date.UTC(2014, 6 /* Jul */, 11, 1, 0)), '2')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0))
+    subHours(date, 10)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 23, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subHours(new Date(NaN), 2)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subHours(new Date(Date.UTC(2014, 6 /* Jul */, 11, 1, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subHours.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 11, 1, 0)), 2, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subHours.bind(null), TypeError)
+    assert.throws(subHours.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subISOWeekYears/index.js
+++ b/src/utc/subISOWeekYears/index.js
@@ -1,0 +1,33 @@
+import addISOWeekYears from '../addISOWeekYears/index.js'
+
+/**
+ * @name subISOWeekYears
+ * @category ISO Week-Numbering Year Helpers
+ * @summary Subtract the specified number of ISO week-numbering years from the given date.
+ *
+ * @description
+ * Subtract the specified number of ISO week-numbering years from the given date.
+ *
+ * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of ISO week-numbering years to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the ISO week-numbering years subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 5 ISO week-numbering years from 1 September 2014:
+ * var result = subISOWeekYears(new Date(Date.UTC(2014, 8, 1)), 5)
+ * //=> Mon Aug 31 2009 00:00:00
+ */
+export default function subISOWeekYears (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addISOWeekYears(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subISOWeekYears/test.js
+++ b/src/utc/subISOWeekYears/test.js
@@ -1,0 +1,66 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subISOWeekYears from '.'
+
+describe('utc/subISOWeekYears', function () {
+  it('subtracts the given number of ISO week-numbering years', function () {
+    var result = subISOWeekYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2009, 7 /* Aug */, 31)))
+  })
+
+  it('accepts a string', function () {
+    var result = subISOWeekYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2002, 8 /* Sep */, 2)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subISOWeekYears(Date.UTC(2014, 8 /* Sep */, 1), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2002, 8 /* Sep */, 2)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subISOWeekYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2009, 7 /* Aug */, 31)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    subISOWeekYears(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(15, 5 /* Jun */, 26)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(10, 6 /* Jul */, 2)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = subISOWeekYears(initialDate, 5)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subISOWeekYears(new Date(NaN), 5)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subISOWeekYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subISOWeekYears.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subISOWeekYears.bind(null), TypeError)
+    assert.throws(subISOWeekYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subMilliseconds/index.js
+++ b/src/utc/subMilliseconds/index.js
@@ -1,0 +1,31 @@
+import addMilliseconds from '../addMilliseconds/index.js'
+
+/**
+ * @name subMilliseconds
+ * @category Millisecond Helpers
+ * @summary Subtract the specified number of milliseconds from the given date.
+ *
+ * @description
+ * Subtract the specified number of milliseconds from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of milliseconds to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the milliseconds subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 750 milliseconds from 10 July 2014 12:45:30.000:
+ * var result = subMilliseconds(new Date(Date.UTC(2014, 6, 10, 12, 45, 30, 0)), 750)
+ * //=> Thu Jul 10 2014 12:45:29.250
+ */
+export default function subMilliseconds (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMilliseconds(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subMilliseconds/test.js
+++ b/src/utc/subMilliseconds/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subMilliseconds from '.'
+
+describe('utc/subMilliseconds', function () {
+  it('subtracts the given number of milliseconds', function () {
+    var result = subMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), 750)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 29, 250)))
+  })
+
+  it('accepts a string', function () {
+    var result = subMilliseconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)).toISOString(), 500
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 29, 500)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subMilliseconds(
+      Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 500
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 29, 500)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), '750')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 29, 250)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0))
+    subMilliseconds(date, 250)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subMilliseconds(new Date(NaN), 750)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subMilliseconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subMilliseconds.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 30, 0)), 750, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subMilliseconds.bind(null), TypeError)
+    assert.throws(subMilliseconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subMinutes/index.js
+++ b/src/utc/subMinutes/index.js
@@ -1,0 +1,31 @@
+import addMinutes from '../addMinutes/index.js'
+
+/**
+ * @name subMinutes
+ * @category Minute Helpers
+ * @summary Subtract the specified number of minutes from the given date.
+ *
+ * @description
+ * Subtract the specified number of minutes from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of minutes to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the mintues subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 30 minutes from 10 July 2014 12:00:00:
+ * var result = subMinutes(new Date(Date.UTC(2014, 6, 10, 12, 0)), 30)
+ * //=> Thu Jul 10 2014 11:30:00
+ */
+export default function subMinutes (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMinutes(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subMinutes/test.js
+++ b/src/utc/subMinutes/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subMinutes from '.'
+
+describe('utc/subMinutes', function () {
+  it('subtracts the given number of minutes', function () {
+    var result = subMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), 30)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 11, 30)))
+  })
+
+  it('accepts a string', function () {
+    var result = subMinutes(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)).toISOString(), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 11, 40)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subMinutes(
+      Date.UTC(2014, 6 /* Jul */, 10, 12, 0), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 11, 40)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), '30')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 11, 30)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0))
+    subMinutes(date, 25)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subMinutes(new Date(NaN), 30)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subMinutes.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), 30, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subMinutes.bind(null), TypeError)
+    assert.throws(subMinutes.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subMonths/index.js
+++ b/src/utc/subMonths/index.js
@@ -1,0 +1,31 @@
+import addMonths from '../addMonths/index.js'
+
+/**
+ * @name subMonths
+ * @category Month Helpers
+ * @summary Subtract the specified number of months from the given date.
+ *
+ * @description
+ * Subtract the specified number of months from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of months to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the months subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 5 months from 1 February 2015:
+ * var result = subMonths(new Date(Date.UTC(2015, 1, 1)), 5)
+ * //=> Mon Sep 01 2014 00:00:00
+ */
+export default function subMonths (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addMonths(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subMonths/test.js
+++ b/src/utc/subMonths/test.js
@@ -1,0 +1,72 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subMonths from '.'
+
+describe('utc/subMonths', function () {
+  it('subtracts the given number of months', function () {
+    var result = subMonths(new Date(Date.UTC(2015, 1 /* Feb */, 1)), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = subMonths(new Date(Date.UTC(2015, 8 /* Sep */, 1)).toISOString(), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subMonths(Date.UTC(2015, 8 /* Sep */, 1), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subMonths(new Date(Date.UTC(2015, 1 /* Feb */, 1)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    subMonths(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('works well if the desired month has fewer days and the provided date is in the last day of a month', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    var result = subMonths(date, 3)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(1, 2 /* Mar */, 31)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(1, 1 /* Feb */, 28)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = subMonths(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subMonths(new Date(NaN), 5)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subMonths(new Date(Date.UTC(2015, 1 /* Feb */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subMonths.bind(null, new Date(Date.UTC(2015, 1 /* Feb */, 1)), 5, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subMonths.bind(null), TypeError)
+    assert.throws(subMonths.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subQuarters/index.js
+++ b/src/utc/subQuarters/index.js
@@ -1,0 +1,31 @@
+import addQuarters from '../addQuarters/index.js'
+
+/**
+ * @name subQuarters
+ * @category Quarter Helpers
+ * @summary Subtract the specified number of year quarters from the given date.
+ *
+ * @description
+ * Subtract the specified number of year quarters from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of quarters to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the quarters subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 3 quarters from 1 September 2014:
+ * var result = subQuarters(new Date(Date.UTC(2014, 8, 1)), 3)
+ * //=> Sun Dec 01 2013 00:00:00
+ */
+export default function subQuarters (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addQuarters(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subQuarters/test.js
+++ b/src/utc/subQuarters/test.js
@@ -1,0 +1,72 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subQuarters from '.'
+
+describe('utc/subQuarters', function () {
+  it('subtracts the given number of quarters', function () {
+    var result = subQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 3)
+    assert.deepEqual(result, new Date(Date.UTC(2013, 11 /* Dec */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = subQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2013, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subQuarters(Date.UTC(2014, 8 /* Sep */, 1), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2013, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '3')
+    assert.deepEqual(result, new Date(Date.UTC(2013, 11 /* Dec */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    subQuarters(date, 3)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('works well if the desired month has fewer days and the provided date is in the last day of a month', function () {
+    var date = new Date(Date.UTC(2014, 11 /* Dec */, 31))
+    var result = subQuarters(date, 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 30)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 10 /* Nov */, 30)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(0, 1 /* Feb */, 29)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = subQuarters(initialDate, 3)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subQuarters(new Date(NaN), 3)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subQuarters(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subQuarters.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 3, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subQuarters.bind(null), TypeError)
+    assert.throws(subQuarters.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subSeconds/index.js
+++ b/src/utc/subSeconds/index.js
@@ -1,0 +1,31 @@
+import addSeconds from '../addSeconds/index.js'
+
+/**
+ * @name subSeconds
+ * @category Second Helpers
+ * @summary Subtract the specified number of seconds from the given date.
+ *
+ * @description
+ * Subtract the specified number of seconds from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of seconds to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the seconds subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 30 seconds from 10 July 2014 12:45:00:
+ * var result = subSeconds(new Date(Date.UTC(2014, 6, 10, 12, 45, 0)), 30)
+ * //=> Thu Jul 10 2014 12:44:30
+ */
+export default function subSeconds (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addSeconds(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subSeconds/test.js
+++ b/src/utc/subSeconds/test.js
@@ -1,0 +1,59 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subSeconds from '.'
+
+describe('utc/subSeconds', function () {
+  it('subtracts the given number of seconds', function () {
+    var result = subSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), 30)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 44, 30)))
+  })
+
+  it('accepts a string', function () {
+    var result = subSeconds(
+      new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)).toISOString(), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 44, 40)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subSeconds(
+      Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0), 20
+    )
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 44, 40)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), '30')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 44, 30)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0))
+    subSeconds(date, 15)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subSeconds(new Date(NaN), 30)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subSeconds(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subSeconds.bind(null, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 45, 0)), 30, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subSeconds.bind(null), TypeError)
+    assert.throws(subSeconds.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subWeeks/index.js
+++ b/src/utc/subWeeks/index.js
@@ -1,0 +1,31 @@
+import addWeeks from '../addWeeks/index.js'
+
+/**
+ * @name subWeeks
+ * @category Week Helpers
+ * @summary Subtract the specified number of weeks from the given date.
+ *
+ * @description
+ * Subtract the specified number of weeks from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of weeks to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the weeks subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 4 weeks from 1 September 2014:
+ * var result = subWeeks(new Date(Date.UTC(2014, 8, 1)), 4)
+ * //=> Mon Aug 04 2014 00:00:00
+ */
+export default function subWeeks (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addWeeks(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subWeeks/test.js
+++ b/src/utc/subWeeks/test.js
@@ -1,0 +1,55 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subWeeks from '.'
+
+describe('utc/subWeeks', function () {
+  it('subtracts the given number of weeks', function () {
+    var result = subWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 4)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 4)))
+  })
+
+  it('accepts a string', function () {
+    var result = subWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 2)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 18)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subWeeks(Date.UTC(2014, 8 /* Sep */, 1), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 25)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '4')
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 4)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    subWeeks(date, 2)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subWeeks(new Date(NaN), 4)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subWeeks(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subWeeks.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 4, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subWeeks.bind(null), TypeError)
+    assert.throws(subWeeks.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/subYears/index.js
+++ b/src/utc/subYears/index.js
@@ -1,0 +1,31 @@
+import addYears from '../addYears/index.js'
+
+/**
+ * @name subYears
+ * @category Year Helpers
+ * @summary Subtract the specified number of years from the given date.
+ *
+ * @description
+ * Subtract the specified number of years from the given date.
+ *
+ * @param {Date|String|Number} date - the date to be changed
+ * @param {Number} amount - the amount of years to be subtracted
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Date} the new date with the years subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Subtract 5 years from 1 September 2014:
+ * var result = subYears(new Date(Date.UTC(2014, 8, 1)), 5)
+ * //=> Tue Sep 01 2009 00:00:00
+ */
+export default function subYears (dirtyDate, dirtyAmount, dirtyOptions) {
+  if (arguments.length < 2) {
+    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+  }
+
+  var amount = Number(dirtyAmount)
+  return addYears(dirtyDate, -amount, dirtyOptions)
+}

--- a/src/utc/subYears/test.js
+++ b/src/utc/subYears/test.js
@@ -1,0 +1,71 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import subYears from '.'
+
+describe('utc/subYears', function () {
+  it('subtracts the given number of years', function () {
+    var result = subYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5)
+    assert.deepEqual(result, new Date(Date.UTC(2009, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a string', function () {
+    var result = subYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)).toISOString(), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2002, 8 /* Sep */, 1)))
+  })
+
+  it('accepts a timestamp', function () {
+    var result = subYears(Date.UTC(2014, 8 /* Sep */, 1), 12)
+    assert.deepEqual(result, new Date(Date.UTC(2002, 8 /* Sep */, 1)))
+  })
+
+  it('implicitly converts number arguments', function () {
+    // $ExpectedMistake
+    var result = subYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '5')
+    assert.deepEqual(result, new Date(Date.UTC(2009, 8 /* Sep */, 1)))
+  })
+
+  it('does not mutate the original date', function () {
+    var date = new Date(Date.UTC(2014, 8 /* Sep */, 1))
+    subYears(date, 12)
+    assert.deepEqual(date, new Date(Date.UTC(2014, 8 /* Sep */, 1)))
+  })
+
+  it('handles the leap years properly', function () {
+    var result = subYears(new Date(Date.UTC(2016, 1 /* Feb */, 29)), 1)
+    assert.deepEqual(result, new Date(Date.UTC(2015, 1 /* Feb */, 28)))
+  })
+
+  it('handles dates before 100 AD', function () {
+    var initialDate = new Date(0)
+    initialDate.setUTCFullYear(0, 1 /* Feb */, 29)
+    initialDate.setUTCHours(0, 0, 0, 0)
+    var expectedResult = new Date(0)
+    expectedResult.setUTCFullYear(-1, 1 /* Feb */, 28)
+    expectedResult.setUTCHours(0, 0, 0, 0)
+    var result = subYears(initialDate, 1)
+    assert.deepEqual(result, expectedResult)
+  })
+
+  it('returns `Invalid Date` if the given date is invalid', function () {
+    var result = subYears(new Date(NaN), 5)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('returns `Invalid Date` if the given amount is NaN', function () {
+    var result = subYears(new Date(Date.UTC(2014, 8 /* Sep */, 1)), NaN)
+    assert(result instanceof Date && isNaN(result))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = subYears.bind(null, new Date(Date.UTC(2014, 8 /* Sep */, 1)), 5, {additionalDigits: NaN})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    assert.throws(subYears.bind(null), TypeError)
+    assert.throws(subYears.bind(null, 1), TypeError)
+  })
+})

--- a/src/utc/toDate/index.js
+++ b/src/utc/toDate/index.js
@@ -1,0 +1,332 @@
+var MILLISECONDS_IN_HOUR = 3600000
+var MILLISECONDS_IN_MINUTE = 60000
+var DEFAULT_ADDITIONAL_DIGITS = 2
+
+var patterns = {
+  dateTimeDelimeter: /[T ]/,
+  plainTime: /:/,
+
+  // year tokens
+  YY: /^(\d{2})$/,
+  YYY: [
+    /^([+-]\d{2})$/, // 0 additional digits
+    /^([+-]\d{3})$/, // 1 additional digit
+    /^([+-]\d{4})$/ // 2 additional digits
+  ],
+  YYYY: /^(\d{4})/,
+  YYYYY: [
+    /^([+-]\d{4})/, // 0 additional digits
+    /^([+-]\d{5})/, // 1 additional digit
+    /^([+-]\d{6})/ // 2 additional digits
+  ],
+
+  // date tokens
+  MM: /^-(\d{2})$/,
+  DDD: /^-?(\d{3})$/,
+  MMDD: /^-?(\d{2})-?(\d{2})$/,
+  Www: /^-?W(\d{2})$/,
+  WwwD: /^-?W(\d{2})-?(\d{1})$/,
+
+  HH: /^(\d{2}([.,]\d*)?)$/,
+  HHMM: /^(\d{2}):?(\d{2}([.,]\d*)?)$/,
+  HHMMSS: /^(\d{2}):?(\d{2}):?(\d{2}([.,]\d*)?)$/,
+
+  // timezone tokens
+  timezone: /([Z+-].*)$/,
+  timezoneZ: /^(Z)$/,
+  timezoneHH: /^([+-])(\d{2})$/,
+  timezoneHHMM: /^([+-])(\d{2}):?(\d{2})$/
+}
+
+/**
+ * @name toDate
+ * @category Common Helpers
+ * @summary Convert the given argument to an instance of Date.
+ *
+ * @description
+ * Convert the given argument to an instance of Date.
+ *
+ * If the argument is an instance of Date, the function returns its clone.
+ *
+ * If the argument is a number, it is treated as a timestamp.
+ *
+ * If an argument is a string, the function tries to parse it.
+ * Function accepts complete ISO 8601 formats as well as partial implementations.
+ * ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
+ *
+ * If the argument is null, it is treated as an invalid date.
+ *
+ * If all above fails, the function passes the given argument to Date constructor.
+ *
+ * **Note**: *all* Date arguments passed to any *date-fns* function is processed by `toDate`.
+ * All *date-fns* functions will throw `RangeError` if `options.additionalDigits` is not 0, 1, 2 or undefined.
+ *
+ * @param {*} argument - the value to convert
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - the additional number of digits in the extended year format
+ * @returns {Date} the parsed date in the local time zone
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
+ *
+ * @example
+ * // Convert string '2014-02-11T11:30:30' to date:
+ * var result = toDate('2014-02-11T11:30:30')
+ * //=> Tue Feb 11 2014 11:30:30
+ *
+ * @example
+ * // Convert string '+02014101' to date,
+ * // if the additional number of digits in the extended year format is 1:
+ * var result = toDate('+02014101', {additionalDigits: 1})
+ * //=> Fri Apr 11 2014 00:00:00
+ */
+export default function toDate (argument, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  if (argument === null) {
+    return new Date(NaN)
+  }
+
+  var options = dirtyOptions || {}
+
+  var additionalDigits = options.additionalDigits === undefined ? DEFAULT_ADDITIONAL_DIGITS : Number(options.additionalDigits)
+  if (additionalDigits !== 2 && additionalDigits !== 1 && additionalDigits !== 0) {
+    throw new RangeError('additionalDigits must be 0, 1 or 2')
+  }
+
+  // Clone the date
+  if (argument instanceof Date) {
+    // Prevent the date to lose the milliseconds when passed to new Date() in IE10
+    return new Date(argument.getTime())
+  } else if (typeof argument !== 'string') {
+    return new Date(argument)
+  }
+
+  var dateStrings = splitDateString(argument)
+
+  var parseYearResult = parseYear(dateStrings.date, additionalDigits)
+  var year = parseYearResult.year
+  var restDateString = parseYearResult.restDateString
+
+  var date = parseDate(restDateString, year)
+
+  if (date) {
+    var timestamp = date.getTime()
+    var time = 0
+    var offset
+
+    if (dateStrings.time) {
+      time = parseTime(dateStrings.time)
+    }
+
+    if (dateStrings.timezone) {
+      offset = parseTimezone(dateStrings.timezone)
+    } else {
+      // get offset accurate to hour in timezones that change offset
+      offset = new Date(timestamp + time).getTimezoneOffset()
+      offset = new Date(timestamp + time + offset * MILLISECONDS_IN_MINUTE).getTimezoneOffset()
+    }
+
+    return new Date(timestamp + time + offset * MILLISECONDS_IN_MINUTE)
+  } else {
+    return new Date(argument)
+  }
+}
+
+function splitDateString (dateString) {
+  var dateStrings = {}
+  var array = dateString.split(patterns.dateTimeDelimeter)
+  var timeString
+
+  if (patterns.plainTime.test(array[0])) {
+    dateStrings.date = null
+    timeString = array[0]
+  } else {
+    dateStrings.date = array[0]
+    timeString = array[1]
+  }
+
+  if (timeString) {
+    var token = patterns.timezone.exec(timeString)
+    if (token) {
+      dateStrings.time = timeString.replace(token[1], '')
+      dateStrings.timezone = token[1]
+    } else {
+      dateStrings.time = timeString
+    }
+  }
+
+  return dateStrings
+}
+
+function parseYear (dateString, additionalDigits) {
+  var patternYYY = patterns.YYY[additionalDigits]
+  var patternYYYYY = patterns.YYYYY[additionalDigits]
+
+  var token
+
+  // YYYY or ±YYYYY
+  token = patterns.YYYY.exec(dateString) || patternYYYYY.exec(dateString)
+  if (token) {
+    var yearString = token[1]
+    return {
+      year: parseInt(yearString, 10),
+      restDateString: dateString.slice(yearString.length)
+    }
+  }
+
+  // YY or ±YYY
+  token = patterns.YY.exec(dateString) || patternYYY.exec(dateString)
+  if (token) {
+    var centuryString = token[1]
+    return {
+      year: parseInt(centuryString, 10) * 100,
+      restDateString: dateString.slice(centuryString.length)
+    }
+  }
+
+  // Invalid ISO-formatted year
+  return {
+    year: null
+  }
+}
+
+function parseDate (dateString, year) {
+  // Invalid ISO-formatted year
+  if (year === null) {
+    return null
+  }
+
+  var token
+  var date
+  var month
+  var week
+
+  // YYYY
+  if (dateString.length === 0) {
+    date = new Date(0)
+    date.setUTCFullYear(year)
+    return date
+  }
+
+  // YYYY-MM
+  token = patterns.MM.exec(dateString)
+  if (token) {
+    date = new Date(0)
+    month = parseInt(token[1], 10) - 1
+    date.setUTCFullYear(year, month)
+    return date
+  }
+
+  // YYYY-DDD or YYYYDDD
+  token = patterns.DDD.exec(dateString)
+  if (token) {
+    date = new Date(0)
+    var dayOfYear = parseInt(token[1], 10)
+    date.setUTCFullYear(year, 0, dayOfYear)
+    return date
+  }
+
+  // YYYY-MM-DD or YYYYMMDD
+  token = patterns.MMDD.exec(dateString)
+  if (token) {
+    date = new Date(0)
+    month = parseInt(token[1], 10) - 1
+    var day = parseInt(token[2], 10)
+    date.setUTCFullYear(year, month, day)
+    return date
+  }
+
+  // YYYY-Www or YYYYWww
+  token = patterns.Www.exec(dateString)
+  if (token) {
+    week = parseInt(token[1], 10) - 1
+    return dayOfISOWeekYear(year, week)
+  }
+
+  // YYYY-Www-D or YYYYWwwD
+  token = patterns.WwwD.exec(dateString)
+  if (token) {
+    week = parseInt(token[1], 10) - 1
+    var dayOfWeek = parseInt(token[2], 10) - 1
+    return dayOfISOWeekYear(year, week, dayOfWeek)
+  }
+
+  // Invalid ISO-formatted date
+  return null
+}
+
+function parseTime (timeString) {
+  var token
+  var hours
+  var minutes
+
+  // hh
+  token = patterns.HH.exec(timeString)
+  if (token) {
+    hours = parseFloat(token[1].replace(',', '.'))
+    return (hours % 24) * MILLISECONDS_IN_HOUR
+  }
+
+  // hh:mm or hhmm
+  token = patterns.HHMM.exec(timeString)
+  if (token) {
+    hours = parseInt(token[1], 10)
+    minutes = parseFloat(token[2].replace(',', '.'))
+    return (hours % 24) * MILLISECONDS_IN_HOUR +
+      minutes * MILLISECONDS_IN_MINUTE
+  }
+
+  // hh:mm:ss or hhmmss
+  token = patterns.HHMMSS.exec(timeString)
+  if (token) {
+    hours = parseInt(token[1], 10)
+    minutes = parseInt(token[2], 10)
+    var seconds = parseFloat(token[3].replace(',', '.'))
+    return (hours % 24) * MILLISECONDS_IN_HOUR +
+      minutes * MILLISECONDS_IN_MINUTE +
+      seconds * 1000
+  }
+
+  // Invalid ISO-formatted time
+  return null
+}
+
+function parseTimezone (timezoneString) {
+  var token
+  var absoluteOffset
+
+  // Z
+  token = patterns.timezoneZ.exec(timezoneString)
+  if (token) {
+    return 0
+  }
+
+  // ±hh
+  token = patterns.timezoneHH.exec(timezoneString)
+  if (token) {
+    absoluteOffset = parseInt(token[2], 10) * 60
+    return (token[1] === '+') ? -absoluteOffset : absoluteOffset
+  }
+
+  // ±hh:mm or ±hhmm
+  token = patterns.timezoneHHMM.exec(timezoneString)
+  if (token) {
+    absoluteOffset = parseInt(token[2], 10) * 60 + parseInt(token[3], 10)
+    return (token[1] === '+') ? -absoluteOffset : absoluteOffset
+  }
+
+  return 0
+}
+
+function dayOfISOWeekYear (isoWeekYear, week, day) {
+  week = week || 0
+  day = day || 0
+  var date = new Date(0)
+  date.setUTCFullYear(isoWeekYear, 0, 4)
+  var fourthOfJanuaryDay = date.getUTCDay() || 7
+  var diff = week * 7 + day + 1 - fourthOfJanuaryDay
+  date.setUTCDate(date.getUTCDate() + diff)
+  return date
+}

--- a/src/utc/toDate/index.js
+++ b/src/utc/toDate/index.js
@@ -114,7 +114,7 @@ export default function toDate (argument, dirtyOptions) {
   if (date) {
     var timestamp = date.getTime()
     var time = 0
-    var offset
+    var offset = 0
 
     if (dateStrings.time) {
       time = parseTime(dateStrings.time)
@@ -122,10 +122,6 @@ export default function toDate (argument, dirtyOptions) {
 
     if (dateStrings.timezone) {
       offset = parseTimezone(dateStrings.timezone)
-    } else {
-      // get offset accurate to hour in timezones that change offset
-      offset = new Date(timestamp + time).getTimezoneOffset()
-      offset = new Date(timestamp + time + offset * MILLISECONDS_IN_MINUTE).getTimezoneOffset()
     }
 
     return new Date(timestamp + time + offset * MILLISECONDS_IN_MINUTE)

--- a/src/utc/toDate/test.js
+++ b/src/utc/toDate/test.js
@@ -117,7 +117,7 @@ describe('utc/toDate', function () {
     describe('extended century representation', function () {
       it('parses century 101 BC - 2 BC', function () {
         var result = toDate('-0001')
-        var date = new Date(-100, 0 /* Jan */, 1)
+        var date = new Date(Date.UTC(-100, 0 /* Jan */, 1))
         date.setUTCFullYear(-100)
         assert.deepEqual(result, date)
       })
@@ -136,7 +136,7 @@ describe('utc/toDate', function () {
 
       it('allows to specify the number of additional digits', function () {
         var result = toDate('-20', {additionalDigits: 0})
-        var date = new Date(-2000, 0 /* Jan */, 1)
+        var date = new Date(Date.UTC(-2000, 0 /* Jan */, 1))
         date.setUTCFullYear(-2000)
         assert.deepEqual(result, date)
       })

--- a/src/utc/toDate/test.js
+++ b/src/utc/toDate/test.js
@@ -1,0 +1,273 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import toDate from '.'
+
+describe('utc/toDate', function () {
+  describe('date argument', function () {
+    it('returns a clone of the given date', function () {
+      var date = new Date(Date.UTC(2016, 0, 1))
+      var dateClone = toDate(date)
+      dateClone.setUTCFullYear(2015)
+      assert.deepEqual(date, new Date(Date.UTC(2016, 0, 1)))
+    })
+  })
+
+  describe('timestamp argument', function () {
+    it('creates a date from the timestamp', function () {
+      var timestamp = Date.UTC(2016, 0, 1, 23, 30, 45, 123)
+      var result = toDate(timestamp)
+      assert.deepEqual(result, new Date(Date.UTC(2016, 0, 1, 23, 30, 45, 123)))
+    })
+  })
+
+  describe('string argument', function () {
+    describe('centuries', function () {
+      it('parses YY', function () {
+        var result = toDate('20')
+        assert.deepEqual(result, new Date(Date.UTC(2000, 0 /* Jan */, 1)))
+      })
+    })
+
+    describe('years', function () {
+      it('parses YYYY', function () {
+        var result = toDate('2014')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 1)))
+      })
+    })
+
+    describe('months', function () {
+      it('parses YYYY-MM', function () {
+        var result = toDate('2014-02')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 1)))
+      })
+    })
+
+    describe('weeks', function () {
+      it('parses YYYY-Www', function () {
+        var result = toDate('2014-W02')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 6)))
+      })
+
+      it('parses YYYYWww', function () {
+        var result = toDate('2014W02')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 6)))
+      })
+    })
+
+    describe('calendar dates', function () {
+      it('parses YYYY-MM-DD', function () {
+        var result = toDate('2014-02-11')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1, /* Feb */ 11)))
+      })
+
+      it('parses YYYYMMDD', function () {
+        var result = toDate('20140211')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11)))
+      })
+    })
+
+    describe('week dates', function () {
+      it('parses YYYY-Www-D', function () {
+        var result = toDate('2014-W02-7')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 12)))
+      })
+
+      it('parses YYYYWwwD', function () {
+        var result = toDate('2014W027')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 12)))
+      })
+
+      it('correctly handles years in which 4 January is Sunday', function () {
+        var result = toDate('2009-W01-1')
+        assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 29)))
+      })
+    })
+
+    describe('ordinal dates', function () {
+      it('parses YYYY-DDD', function () {
+        var result = toDate('2014-026')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 26)))
+      })
+
+      it('parses YYYYDDD', function () {
+        var result = toDate('2014026')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 0 /* Jan */, 26)))
+      })
+    })
+
+    describe('date and time combined', function () {
+      it('parses YYYY-MM-DDThh:mm', function () {
+        var result = toDate('2014-02-11T11:30')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 30)))
+      })
+
+      it('parses YYYY-MM-DDThhmm', function () {
+        var result = toDate('2014-02-11T1130')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 30)))
+      })
+
+      it('parses 24:00 as midnight', function () {
+        var result = toDate('2014-02-11T2400')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 0, 0)))
+      })
+    })
+
+    describe('extended century representation', function () {
+      it('parses century 101 BC - 2 BC', function () {
+        var result = toDate('-0001')
+        var date = new Date(-100, 0 /* Jan */, 1)
+        date.setUTCFullYear(-100)
+        assert.deepEqual(result, date)
+      })
+
+      it('parses century 1 BC - 99 AD', function () {
+        var result = toDate('00')
+        var date = new Date(Date.UTC(0, 0 /* Jan */, 1))
+        date.setUTCFullYear(0)
+        assert.deepEqual(result, date)
+      })
+
+      it('parses centruries after 9999 AD', function () {
+        var result = toDate('+0123')
+        assert.deepEqual(result, new Date(Date.UTC(12300, 0 /* Jan */, 1)))
+      })
+
+      it('allows to specify the number of additional digits', function () {
+        var result = toDate('-20', {additionalDigits: 0})
+        var date = new Date(-2000, 0 /* Jan */, 1)
+        date.setUTCFullYear(-2000)
+        assert.deepEqual(result, date)
+      })
+    })
+
+    describe('extended year representation', function () {
+      it('correctly parses years from 1 AD to 99 AD', function () {
+        var result = toDate('0095-07-02')
+        var date = new Date(Date.UTC(0, 6 /* Jul */, 2))
+        date.setUTCFullYear(95)
+        assert.deepEqual(result, date)
+      })
+
+      it('parses years after 9999 AD', function () {
+        var result = toDate('+012345-07-02')
+        assert.deepEqual(result, new Date(Date.UTC(12345, 6 /* Jul */, 2)))
+      })
+
+      it('allows to specify the number of additional digits', function () {
+        var result = toDate('+12340702', {additionalDigits: 0})
+        assert.deepEqual(result, new Date(Date.UTC(1234, 6 /* Jul */, 2)))
+      })
+
+      it('parses year 1 BC', function () {
+        var result = toDate('0000-07-02')
+        var date = new Date(Date.UTC(0, 6 /* Jul */, 2))
+        date.setUTCFullYear(0)
+        assert.deepEqual(result, date)
+      })
+
+      it('parses years less than 1 BC', function () {
+        var result = toDate('-000001-07-02')
+        var date = new Date(Date.UTC(0, 6 /* Jul */, 2))
+        date.setUTCFullYear(-1)
+        assert.deepEqual(result, date)
+      })
+    })
+
+    describe('float time', function () {
+      it('parses float hours', function () {
+        var result = toDate('2014-02-11T11.5')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 30)))
+      })
+
+      it('parses float minutes', function () {
+        var result = toDate('2014-02-11T11:30.5')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 30, 30)))
+      })
+
+      it('parses float seconds', function () {
+        var result = toDate('2014-02-11T11:30:30.768')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 30, 30, 768)))
+      })
+
+      it('parses , as decimal mark', function () {
+        var result = toDate('2014-02-11T11,5')
+        assert.deepEqual(result, new Date(Date.UTC(2014, 1 /* Feb */, 11, 11, 30)))
+      })
+    })
+
+    describe('timezones', function () {
+      context('when the date and the time are specified', function () {
+        it('parses Z', function () {
+          var result = toDate('2014-10-25T06:46:20Z')
+          assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
+        })
+
+        it('parses ±hh:mm', function () {
+          var result = toDate('2014-10-25T13:46:20+07:00')
+          assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
+        })
+
+        it('parses ±hhmm', function () {
+          var result = toDate('2014-10-25T03:46:20-0300')
+          assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
+        })
+
+        it('parses ±hh', function () {
+          var result = toDate('2014-10-25T13:46:20+07')
+          assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
+        })
+      })
+    })
+
+    describe('failure', function () {
+      it('fallbacks to `new Date` if the string is not an ISO formatted date', function () {
+        var result = toDate(new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)).toString())
+        assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 1, 11)))
+      })
+    })
+  })
+
+  describe('invalid argument', function () {
+    it('returns Invalid Date if argument is non-date string', function () {
+      var result = toDate('abc')
+      assert(result instanceof Date)
+      assert(isNaN(result))
+    })
+
+    it('returns Invalid Date if argument is NaN', function () {
+      var result = toDate(NaN)
+      assert(result instanceof Date)
+      assert(isNaN(result))
+    })
+
+    it('returns Invalid Date if argument is Invalid Date', function () {
+      var result = toDate(new Date(NaN))
+      assert(result instanceof Date)
+      assert(isNaN(result))
+    })
+
+    it('returns Invalid Date if argument is null', function () {
+      var result = toDate(null)
+      assert(result instanceof Date)
+      assert(isNaN(result))
+    })
+  })
+
+  it('implicitly converts options', function () {
+    // $ExpectedMistake
+    var result = toDate('+12340702', {additionalDigits: '0'})
+    assert.deepEqual(result, new Date(Date.UTC(1234, 6 /* Jul */, 2)))
+  })
+
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+    // $ExpectedMistake
+    var block = toDate.bind(null, '+12340702', {additionalDigits: 3})
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(toDate.bind(null), TypeError)
+  })
+})


### PR DESCRIPTION
For this PR:
- [x] Add tests for UTC functions
- [x] Add UTC functions
- [ ] Make `format` timezones always output UTC timezone (and add private option `options._timezone` to modify this behaviour)
- [ ] Add indices
- [ ] Add typings
- [ ] Add FP tests
- [ ] Add FP fns
- [ ] Add documentation

In future:
- [ ] Add to-UTC and from-UTC helper functions to src/_lib
- [ ] Convert all non-UTC functions to UTC wrappers