### PR TITLE
Feature: added function that returns date of past day of week such as `Last Monday`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ npm-debug.log*
 tmp
 dist
 .envrc
+.vscode
+.history
 /.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ for the list of changes made since `v2.0.0-alpha.1`.
 
 ### Added
 
+- `getDateOfPastWeekday` - Function that returns date of the desired past day of the week i.e. `Last Monday`, `Last Thuesday`, etc.
+
+  ```javascript
+  import getDateOfPastWeekday from 'date-fns/getDateOfPastWeekday'
+
+  const lastMonday = getDateOfPastWeekday(1)
+  // Date is Nov 23, 2017
+  //=> Mon Nov 20 2017 00:00:00
+  ```
+
 - FP functions like those in [lodash](https://github.com/lodash/lodash/wiki/FP-Guide),
   that support [currying](https://en.wikipedia.org/wiki/Currying), and, as a consequence,
   functional-style [function composing](https://medium.com/making-internets/why-using-chain-is-a-mistake-9bc1f80d51ba).

--- a/src/getDateOfPastWeekday/benchmark.js
+++ b/src/getDateOfPastWeekday/benchmark.js
@@ -11,6 +11,6 @@ suite('getDateOfPastDayOfWeek', function () {
 }, {
   setup: function () {
     this.date = new Date()
-    this.dayOfWeekIndex = 2;
+    this.dayOfWeekIndex = 2
   }
 })

--- a/src/getDateOfPastWeekday/benchmark.js
+++ b/src/getDateOfPastWeekday/benchmark.js
@@ -1,0 +1,16 @@
+// @flow
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import getDateOfPastDayOfWeek from '.'
+
+suite('getDateOfPastDayOfWeek', function () {
+  benchmark('date-fns', function () {
+    return getDateOfPastDayOfWeek(this.dayOfWeekIndex, this.date)
+  })
+}, {
+  setup: function () {
+    this.date = new Date()
+    this.dayOfWeekIndex = 2;
+  }
+})

--- a/src/getDateOfPastWeekday/index.js
+++ b/src/getDateOfPastWeekday/index.js
@@ -28,12 +28,12 @@ export default function getDateOfPastWeekday (dayOfWeekNumber, dateForTest) {
   }
   var today = new Date()
 
-  if (dateForTest !== undefined) { today = dateForTest }
+  if (dateForTest !== undefined && dateForTest instanceof Date) { today = dateForTest }
   // Take current day of week index where 0 - Sunday
   var index = today.getDay()
   // If desired day of the week in the past then take date for this week
   // Otherwise take date form the previous week
   var date = index > dayOfWeekNumber ? addDays(today, -index + dayOfWeekNumber) : addDays(today, -index + dayOfWeekNumber - 7)
   date.setHours(0, 0, 0, 0)
-  return date;
+  return date
 }

--- a/src/getDateOfPastWeekday/index.js
+++ b/src/getDateOfPastWeekday/index.js
@@ -1,0 +1,39 @@
+import addDays from '../addDays/index.js'
+
+/**
+ * @name getDateOfPastWeekday
+ * @category Weekday Helpers
+ * @summary Get date of the desired past day of the week.
+ *
+ * @description
+ * Get date of the desired past day of the week
+ *
+ * @param {Number} dayOfWeekNumber - the index of a desired day of week (0 - Sunday)
+ * @returns {Date} the date of the last day of week
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} `dayOfWeekNumber` must be >= 0 and <=6
+ * @example
+ * // What is the last Monday date?
+ * // Today is Nov 22, 2017
+ * var result = getDateOfLastDayOfWeek(1)
+ * // => Mon Nov 20 2017 00:00:00
+ */
+export default function getDateOfPastWeekday (dayOfWeekNumber, dateForTest) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  if (dayOfWeekNumber < 0 || dayOfWeekNumber > 6) {
+    throw new RangeError('The index of day of the week should be greater or equal 0 and less than 7')
+  }
+  var today = new Date()
+
+  if (dateForTest !== undefined) { today = dateForTest }
+  // Take current day of week index where 0 - Sunday
+  var index = today.getDay()
+  // If desired day of the week in the past then take date for this week
+  // Otherwise take date form the previous week
+  var date = index > dayOfWeekNumber ? addDays(today, -index + dayOfWeekNumber) : addDays(today, -index + dayOfWeekNumber - 7)
+  date.setHours(0, 0, 0, 0)
+  return date;
+}

--- a/src/getDateOfPastWeekday/test.js
+++ b/src/getDateOfPastWeekday/test.js
@@ -1,0 +1,66 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getDateOfPastWeekday from '.'
+
+describe('getDateOfPastWeekday', function () {
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Monday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(1, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 20)
+    )
+  })
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Tuesday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(2, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 21)
+    )
+  })
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Wednesday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(3, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 15)
+    )
+  })
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Thursday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(4, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 16)
+    )
+  })
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Friday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(5, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 17)
+    )
+  })
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Saturday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(6, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 18)
+    )
+  })
+  it('returns the date with the time setted to 00:00:00 and the date setted to the last Sunday', function () {
+    var date = new Date(2017, 10 /* Nov */, 22, 11, 55, 0)
+    var result = getDateOfPastWeekday(0, date)
+    assert.deepEqual(result,
+      new Date(2017, 10 /* Nov */, 19)
+    )
+  })
+  it('throws TypeError exception if the argument is not passed', function () {
+    assert.throws(getDateOfPastWeekday.bind(null), TypeError)
+  })
+  it('throws RangeError exception if passed less than 0 argument', function () {
+    assert.throws(getDateOfPastWeekday.bind(null, -1), RangeError)
+  })
+  it('throws RangeError exception if passed greater than 6 argument', function () {
+    assert.throws(getDateOfPastWeekday.bind(null, 7), RangeError)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ module.exports = {
   formatDistanceStrict: require('./formatDistanceStrict/index.js'),
   formatRelative: require('./formatRelative/index.js'),
   getDate: require('./getDate/index.js'),
+  getDateOfPastWeekday: require('./getDateOfPastWeekday/index.js'),
   getDay: require('./getDay/index.js'),
   getDayOfYear: require('./getDayOfYear/index.js'),
   getDaysInMonth: require('./getDaysInMonth/index.js'),


### PR DESCRIPTION
Added function `getDateOfPastWeekday` that returns date of the desired past day of the week i.e. `Last Monday`, `Last Thuesday`, etc. by its index.

  ```javascript
  import getDateOfPastWeekday from 'date-fns/getDateOfPastWeekday'

  const lastMonday = getDateOfPastWeekday(1)
  // Date is Nov 23, 2017
  //=> Mon Nov 20 2017 00:00:00
  ```