### PR TITLE
Update long & relative formats for 'nl' locale

### DIFF
--- a/src/locale/nl/_lib/formatLong/index.js
+++ b/src/locale/nl/_lib/formatLong/index.js
@@ -1,12 +1,12 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
 var formatLong = buildFormatLongFn({
-  LT: 'h:mm aa',
-  LTS: 'h:mm:ss aa',
-  L: 'MM/DD/YYYY',
-  LL: 'MMMM D YYYY',
-  LLL: 'MMMM D YYYY h:mm aa',
-  LLLL: 'dddd, MMMM D YYYY h:mm aa'
+  LT: 'HH:mm',
+  LTS: 'HH:mm:ss',
+  L: 'DD/MM/YYYY',
+  LL: 'D MMMM YYYY',
+  LLL: 'D MMMM YYYY HH:mm',
+  LLLL: 'dddd, D MMMM YYYY HH:mm'
 })
 
 export default formatLong

--- a/src/locale/nl/_lib/formatRelative/index.js
+++ b/src/locale/nl/_lib/formatRelative/index.js
@@ -1,9 +1,9 @@
 var formatRelativeLocale = {
-  lastWeek: '[last] dddd [at] LT',
-  yesterday: '[yesterday at] LT',
-  today: '[today at] LT',
-  tomorrow: '[tomorrow at] LT',
-  nextWeek: 'dddd [at] LT',
+  lastWeek: '[vorige] dddd [om] LT',
+  yesterday: '[gisteren om] LT',
+  today: '[vandaag om] LT',
+  tomorrow: '[morgen om] LT',
+  nextWeek: 'dddd [om] LT',
   other: 'L'
 }
 

--- a/src/locale/nl/test.js
+++ b/src/locale/nl/test.js
@@ -131,32 +131,32 @@ describe('nl locale', function () {
     describe('long formats', function () {
       it('LT', function () {
         var result = format(date, 'LT', {locale: locale})
-        assert(result === '10:32 a.m.')
+        assert(result === '10:32')
       })
 
       it('LTS', function () {
         var result = format(date, 'LTS', {locale: locale})
-        assert(result === '10:32:00 a.m.')
+        assert(result === '10:32:00')
       })
 
       it('L', function () {
         var result = format(new Date(2017, 6 /* Jul */, 2), 'L', {locale: locale})
-        assert(result === '07/02/2017')
+        assert(result === '02/07/2017')
       })
 
       it('LL', function () {
         var result = format(date, 'LL', {locale: locale})
-        assert(result === 'april 4 1986')
+        assert(result === '4 april 1986')
       })
 
       it('LLL', function () {
         var result = format(date, 'LLL', {locale: locale})
-        assert(result === 'april 4 1986 10:32 a.m.')
+        assert(result === '4 april 1986 10:32')
       })
 
       it('LLLL', function () {
         var result = format(date, 'LLLL', {locale: locale})
-        assert(result === 'vrijdag, april 4 1986 10:32 a.m.')
+        assert(result === 'vrijdag, 4 april 1986 10:32')
       })
     })
   })
@@ -228,32 +228,32 @@ describe('nl locale', function () {
 
     it('last week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 1), baseDate, {locale: locale})
-      assert(result === 'last dinsdag at 12:00 a.m.')
+      assert(result === 'last dinsdag at 00:00')
     })
 
     it('yesterday', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 3, 22, 22), baseDate, {locale: locale})
-      assert(result === 'yesterday at 10:22 p.m.')
+      assert(result === 'yesterday at 22:22')
     })
 
     it('today', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 4, 16, 50), baseDate, {locale: locale})
-      assert(result === 'today at 4:50 p.m.')
+      assert(result === 'today at 16:50')
     })
 
     it('tomorrow', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 5, 7, 30), baseDate, {locale: locale})
-      assert(result === 'tomorrow at 7:30 a.m.')
+      assert(result === 'tomorrow at 07:30')
     })
 
     it('next week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 6, 12, 0), baseDate, {locale: locale})
-      assert(result === 'zondag at 12:00 p.m.')
+      assert(result === 'zondag at 12:00')
     })
 
     it('after the next week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 11, 16, 50), baseDate, {locale: locale})
-      assert(result === '04/11/1986')
+      assert(result === '11/04/1986')
     })
   })
 
@@ -385,7 +385,7 @@ describe('nl locale', function () {
 
     describe('long formats', function () {
       it('unfolds long formats', function () {
-        var result = parse('April 6 1987 11:32 a.m.', 'LLL', baseDate, {locale: locale})
+        var result = parse('6 April 1987 11:32', 'LLL', baseDate, {locale: locale})
         assert.deepEqual(result, new Date(1987, 3 /* Apr */, 6, 11, 32))
       })
     })

--- a/src/locale/nl/test.js
+++ b/src/locale/nl/test.js
@@ -228,27 +228,27 @@ describe('nl locale', function () {
 
     it('last week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 1), baseDate, {locale: locale})
-      assert(result === 'last dinsdag at 00:00')
+      assert(result === 'vorige dinsdag om 00:00')
     })
 
     it('yesterday', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 3, 22, 22), baseDate, {locale: locale})
-      assert(result === 'yesterday at 22:22')
+      assert(result === 'gisteren om 22:22')
     })
 
     it('today', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 4, 16, 50), baseDate, {locale: locale})
-      assert(result === 'today at 16:50')
+      assert(result === 'vandaag om 16:50')
     })
 
     it('tomorrow', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 5, 7, 30), baseDate, {locale: locale})
-      assert(result === 'tomorrow at 07:30')
+      assert(result === 'morgen om 07:30')
     })
 
     it('next week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 6, 12, 0), baseDate, {locale: locale})
-      assert(result === 'zondag at 12:00')
+      assert(result === 'zondag om 12:00')
     })
 
     it('after the next week', function () {


### PR DESCRIPTION
We noticed that the `nl` locale did not yet contain the proper long format specifiers (see: https://en.wikipedia.org/wiki/Date_and_time_notation_in_the_Netherlands). Also, the relative date formatting did not use the Dutch language yet.

In this pull request I've updated both. Since this is my first contribution to this project, I'm happy to receive feedback and update the PR accordingly if that would be necessary.