### PR TITLE
Fix short version of Norwegian day names

### DIFF
--- a/src/locale/nb/_lib/localize/index.js
+++ b/src/locale/nb/_lib/localize/index.js
@@ -3,7 +3,7 @@ import buildLocalizeArrayFn from '../../../_lib/buildLocalizeArrayFn/index.js'
 
 var weekdayValues = {
   narrow: ['sø', 'ma', 'ti', 'on', 'to', 'fr', 'lø'],
-  short: ['sø.', 'ma.', 'ti.', 'on.', 'to.', 'fr.', 'lø.'],
+  short: ['søn.', 'man.', 'tir.', 'ons.', 'tor.', 'fre.', 'lør.'],
   long: ['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag']
 }
 


### PR DESCRIPTION
In the current Norwegian locale, the short versions of the day names are the same as the narrow. The three day versions are commonly used in Norway, and having the correct ones in `date-fns` would be great.

This PR adds that.