### PR TITLE
Fixed issue when parsing ISO style dates (but not valid ISO format) with a trailing Z (Issue #510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ for the list of changes made since `v2.0.0-alpha.1`.
 - [Support for long and relative formats for Swedish locale](https://github.com/date-fns/date-fns/pull/570) (thanks to [@alexandernanberg](https://github.com/alexandernanberg)).
 
 ### Changed
+- **BREAKING**: fixed when parsing ISO style dates (but not valid ISO format) with a trailing Z (e.g 2012-01Z), it returns Invalid Date for FireFox/IE11 (Issue #510)
 
 - **BREAKING**: function submodules now use camelCase naming schema:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ for the list of changes made since `v2.0.0-alpha.1`.
 - [Support for long and relative formats for Swedish locale](https://github.com/date-fns/date-fns/pull/570) (thanks to [@alexandernanberg](https://github.com/alexandernanberg)).
 
 ### Changed
-- **BREAKING**: fixed when parsing ISO style dates (but not valid ISO format) with a trailing Z (e.g 2012-01Z), it returns Invalid Date for FireFox/IE11 (Issue #510)
+- **Fixed**: fixed when parsing ISO style dates (but not valid ISO format) with a trailing Z (e.g 2012-01Z), it returns Invalid Date for FireFox/IE11 [#510](https://github.com/date-fns/date-fns/issue/510)
 
 - **BREAKING**: function submodules now use camelCase naming schema:
 

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -5,6 +5,7 @@ var DEFAULT_ADDITIONAL_DIGITS = 2
 var patterns = {
   dateTimeDelimeter: /[T ]/,
   plainTime: /:/,
+  timeZoneDelimeter: /[Z ]/i,
 
   // year tokens
   YY: /^(\d{2})$/,
@@ -145,6 +146,10 @@ function splitDateString (dateString) {
   } else {
     dateStrings.date = array[0]
     timeString = array[1]
+    if (patterns.timeZoneDelimeter.test(dateStrings.date)) {
+      dateStrings.date = dateString.split(patterns.timeZoneDelimeter)[0]
+      timeString = dateString.substr(dateStrings.date.length, dateString.length)
+    }
   }
 
   if (timeString) {

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -219,6 +219,12 @@ describe('toDate', function () {
           assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
         })
       })
+      context('when the year and the month are specified', function () {
+        it('sets timezone correctly on yyyy-MMZ format', function () {
+          var result = toDate('2012-01Z')
+          assert.deepEqual(result, new Date('2011-12-31T18:00:00+07:00'))
+        })
+      })
     })
 
     describe('failure', function () {

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -222,7 +222,7 @@ describe('toDate', function () {
       context('when the year and the month are specified', function () {
         it('sets timezone correctly on yyyy-MMZ format', function () {
           var result = toDate('2012-01Z')
-          assert.deepEqual(result, new Date('2011-12-31T18:00:00+07:00'))
+          assert.deepEqual(result, new Date('2012-01-01T00:00:00+00:00'))
         })
       })
     })


### PR DESCRIPTION
This PR fixed the issue [https://github.com/date-fns/date-fns/issues/510](url) 