### PR TITLE
fix formatLong in Chinese Simplified locale

### DIFF
--- a/src/locale/zh-CN/_lib/formatLong/index.js
+++ b/src/locale/zh-CN/_lib/formatLong/index.js
@@ -1,12 +1,16 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
 var formatLong = buildFormatLongFn({
-  LT: 'h:mm aa',
-  LTS: 'h:mm:ss aa',
-  L: 'MM/DD/YYYY',
-  LL: 'MMMM D YYYY',
-  LLL: 'MMMM D YYYY h:mm aa',
-  LLLL: 'dddd, MMMM D YYYY h:mm aa'
+  LT: 'HH:mm',
+  LTS: 'HH:mm:ss',
+  L: 'YYYY/MM/DD',
+  LL: 'YYYY年M月D日',
+  LLL: 'YYYY年M月D日Ah点mm分',
+  LLLL: 'YYYY年M月D日ddddAh点mm分',
+  l: 'YYYY/M/D',
+  ll: 'YYYY年M月D日',
+  lll: 'YYYY年M月D日 HH:mm',
+  llll: 'YYYY年M月D日dddd HH:mm'
 })
 
 export default formatLong


### PR DESCRIPTION
Modified Chinese date format

```javascript
format(new Date(), 'L');    // 2018/03/07
format(new Date(), 'l');    // 2018/03/07
format(new Date(), 'LL');   // 2018年3月7日
format(new Date(), 'll');   // 2018年3月7日
format(new Date(), 'LLL');  // 2018年3月7日下午12点37分
format(new Date(), 'lll');  // 2018年3月7日 12:37
format(new Date(), 'LLLL'); // 2018年3月7日星期三下午12点37分
format(new Date(), 'llll'); // 2018年3月7日星期三 12:37
```