### PR TITLE
Add tree-shake compatible example to docs

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -23,7 +23,7 @@ as an option to a function:
 ```js
 import {formatDistance} from 'date-fns/esm'
 // Require Esperanto locale
-import {eo} from 'date-fns/esm/locale'
+import {default as eo} from 'date-fns/esm/locale/eo';
 
 const result = formatDistance(
   new Date(2016, 7, 1),


### PR DESCRIPTION
If I import a locale with the syntax `import {de} from 'date-fns/esm/locale'`, no tree-shaking is done in webpack (v4.5) and **all** locales are included in my final production bundle.

Importing a language like this `import {default as de} from 'date-fns/esm/locale/de'` works as expected and only includes the imported locale in my final bundle, which makes it about 100kb smaller.

I don't know if this is still relevant since your last (huge) beta PR (#700).

I'm currently on `v2.0.0-alpha.7`.

By the way, thanks for this awesome library! :octocat: 