### PR TITLE
Truncate all number arguments (closes #746); review usage of === undefined (closes #767); review handling of arguments of wrong type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,7 +579,7 @@ for the list of changes made since `v2.0.0-alpha.1`.
 
 - **BREAKING**: all functions now handle arguments by following rules:
 
-  | exp. type | date          | number | string      | boolean |
+  |           | date          | number | string      | boolean |
   |-----------|---------------|--------|-------------|---------|
   | 0         | new Date(0)   | 0      | '0'         | false   |
   | '0'       | Invalid Date  | 0      | '0'         | false   |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,20 +579,27 @@ for the list of changes made since `v2.0.0-alpha.1`.
 
 - **BREAKING**: all functions now handle arguments by following rules:
 
+  | exp. type | date          | number | string      | boolean |
+  |-----------|---------------|--------|-------------|---------|
+  | 0         | new Date(0)   | 0      | '0'         | false   |
+  | '0'       | Invalid Date  | 0      | '0'         | false   |
+  | 1         | new Date(1)   | 1      | '1'         | true    |
+  | '1'       | Invalid Date  | 1      | '1'         | true    |
+  | true      | Invalid Date  | NaN    | 'true'      | true    |
+  | false     | Invalid Date  | NaN    | 'false'     | false   |
+  | null      | Invalid Date  | NaN    | 'null'      | false   |
+  | undefined | Invalid Date  | NaN    | 'undefined' | false   |
+  | NaN       | Invalid Date  | NaN    | 'NaN'       | false   |
+
+  Notes:
   - as before, arguments expected to be `Date` are converted to `Date` using *date-fns'* `toDate` function;
   - arguments expected to be numbers are converted to integer numbers using our custom `toInteger` implementation
     (see [#765](https://github.com/date-fns/date-fns/pull/765));
-  - arguments expected to be strings arguments are converted to strings using JavaScript's `String` function.
+  - arguments expected to be strings arguments are converted to strings using JavaScript's `String` function;
+  - arguments expected to be booleans are converted to strings using JavaScript's `Boolean` function.
 
-  In `toDate` and `toInteger` arguments are converted using the following strategy:
-
-  - `null` becomes `NaN` or `Invalid Date`
-  - `undefined` becomes `NaN` or `Invalid Date`
-  - `false` becomes `0` or `new Date(0)`
-  - `true` becomes `1` or `new Date(1)`
-
-  `null` and `undefined` passes to optional arguments (i.e. properties of `options` argument)
-  are ignored.
+  `null` and `undefined` passed to optional arguments (i.e. properties of `options` argument)
+  are ignored as if no argument was passed.
 
   If any of resulting arguments is invalid (i.e. `NaN` for numbers and `Invalid Date` for dates),
   an invalid value will be returned:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,7 +577,7 @@ for the list of changes made since `v2.0.0-alpha.1`.
   This change is introduced for consistency with ECMAScript standard library which does the same.
   See [docs/Options.js](https://github.com/date-fns/date-fns/blob/master/docs/Options.js)
 
-- **BREAKING**: all functions now handle arguments by following rules:
+- **BREAKING**: all functions now implicitly convert arguments by following rules:
 
   |           | date          | number | string      | boolean |
   |-----------|---------------|--------|-------------|---------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,8 +580,19 @@ for the list of changes made since `v2.0.0-alpha.1`.
 - **BREAKING**: all functions now handle arguments by following rules:
 
   - as before, arguments expected to be `Date` are converted to `Date` using *date-fns'* `toDate` function;
-  - arguments expected to be numbers are converted to numbers using JavaScript's `Number` function;
+  - arguments expected to be numbers are converted to integer numbers using our custom `toInteger` implementation
+    (see [#765](https://github.com/date-fns/date-fns/pull/765));
   - arguments expected to be strings arguments are converted to strings using JavaScript's `String` function.
+
+  In `toDate` and `toInteger` arguments are converted using the following strategy:
+
+  - `null` becomes `NaN` or `Invalid Date`
+  - `undefined` becomes `NaN` or `Invalid Date`
+  - `false` becomes `0` or `new Date(0)`
+  - `true` becomes `1` or `new Date(1)`
+
+  `null` and `undefined` passes to optional arguments (i.e. properties of `options` argument)
+  are ignored.
 
   If any of resulting arguments is invalid (i.e. `NaN` for numbers and `Invalid Date` for dates),
   an invalid value will be returned:
@@ -591,7 +602,8 @@ for the list of changes made since `v2.0.0-alpha.1`.
   - `NaN` for functions that return numbers;
   - and `String('Invalid Date')` for functions that return strings.
 
-  See tests and PR [#460](https://github.com/date-fns/date-fns/pull/460) for exact behavior.
+  See tests and PRs [#460](https://github.com/date-fns/date-fns/pull/460) and
+  [#765](https://github.com/date-fns/date-fns/pull/765) for exact behavior.
 
 - **BREAKING**: all functions now check if the passed number of arguments is less
   than the number of required arguments and throw `TypeError` exception if so.

--- a/src/_lib/addUTCMinutes/index.js
+++ b/src/_lib/addUTCMinutes/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
@@ -8,7 +9,7 @@ export default function addUTCMinutes (dirtyDate, dirtyAmount, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   date.setUTCMinutes(date.getUTCMinutes() + amount)
   return date
 }

--- a/src/_lib/addUTCMinutes/test.js
+++ b/src/_lib/addUTCMinutes/test.js
@@ -24,6 +24,11 @@ describe('addUTCMinutes', function () {
     assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 20)))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addUTCMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), 30.5)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 30)))
+  })
+
   it('implicitly converts number arguments', function () {
     var result = addUTCMinutes(new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 0)), '30')
     assert.deepEqual(result, new Date(Date.UTC(2014, 6 /* Jul */, 10, 12, 30)))

--- a/src/_lib/getUTCWeekYear/index.js
+++ b/src/_lib/getUTCWeekYear/index.js
@@ -18,11 +18,11 @@ export default function getUTCWeekYear (dirtyDate, dirtyOptions) {
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 

--- a/src/_lib/getUTCWeekYear/index.js
+++ b/src/_lib/getUTCWeekYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 import startOfUTCWeek from '../startOfUTCWeek/index.js'
 
@@ -19,11 +20,11 @@ export default function getUTCWeekYear (dirtyDate, dirtyOptions) {
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {

--- a/src/_lib/setUTCDay/index.js
+++ b/src/_lib/setUTCDay/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
@@ -10,8 +11,8 @@ export default function setUTCDay (dirtyDate, dirtyDay, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
@@ -19,7 +20,7 @@ export default function setUTCDay (dirtyDate, dirtyDay, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var day = Number(dirtyDay)
+  var day = toInteger(dirtyDay)
 
   var currentDay = date.getUTCDay()
 

--- a/src/_lib/setUTCDay/index.js
+++ b/src/_lib/setUTCDay/index.js
@@ -11,8 +11,8 @@ export default function setUTCDay (dirtyDate, dirtyDay, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/_lib/setUTCDay/test.js
+++ b/src/_lib/setUTCDay/test.js
@@ -86,6 +86,11 @@ describe('setUTCDay', function () {
     assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setUTCDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 0.9)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))
+  })
+
   it('implicitly converts number arguments', function () {
     var result = setUTCDay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '0')
     assert.deepEqual(result, new Date(Date.UTC(2014, 7 /* Aug */, 31)))

--- a/src/_lib/setUTCISODay/index.js
+++ b/src/_lib/setUTCISODay/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
@@ -7,7 +8,7 @@ export default function setUTCISODay (dirtyDate, dirtyDay, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var day = Number(dirtyDay)
+  var day = toInteger(dirtyDay)
 
   if (day % 7 === 0) {
     day = day - 7

--- a/src/_lib/setUTCISODay/test.js
+++ b/src/_lib/setUTCISODay/test.js
@@ -49,6 +49,11 @@ describe('setUTCISODay', function () {
     assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setUTCISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), 3.33)
+    assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))
+  })
+
   it('implicitly converts number arguments', function () {
     var result = setUTCISODay(new Date(Date.UTC(2014, 8 /* Sep */, 1)), '3')
     assert.deepEqual(result, new Date(Date.UTC(2014, 8 /* Sep */, 3)))

--- a/src/_lib/setUTCISOWeek/index.js
+++ b/src/_lib/setUTCISOWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 import getUTCISOWeek from '../getUTCISOWeek/index.js'
 
@@ -9,7 +10,7 @@ export default function setUTCISOWeek (dirtyDate, dirtyISOWeek, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var isoWeek = Number(dirtyISOWeek)
+  var isoWeek = toInteger(dirtyISOWeek)
   var diff = getUTCISOWeek(date, dirtyOptions) - isoWeek
   date.setUTCDate(date.getUTCDate() - diff * 7)
   return date

--- a/src/_lib/setUTCISOWeek/test.js
+++ b/src/_lib/setUTCISOWeek/test.js
@@ -20,6 +20,11 @@ describe('setUTCISOWeek', function () {
     assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 31)))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setUTCISOWeek(new Date(Date.UTC(2004, 7 /* Aug */, 7)), 53.53)
+    assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))
+  })
+
   it('implicitly converts number arguments', function () {
     var result = setUTCISOWeek(new Date(Date.UTC(2004, 7 /* Aug */, 7)), '53')
     assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))

--- a/src/_lib/setUTCWeek/index.js
+++ b/src/_lib/setUTCWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 import getUTCWeek from '../getUTCWeek/index.js'
 
@@ -9,7 +10,7 @@ export default function setUTCWeek (dirtyDate, dirtyWeek, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var week = Number(dirtyWeek)
+  var week = toInteger(dirtyWeek)
   var diff = getUTCWeek(date, dirtyOptions) - week
   date.setUTCDate(date.getUTCDate() - diff * 7)
   return date

--- a/src/_lib/setUTCWeek/test.js
+++ b/src/_lib/setUTCWeek/test.js
@@ -20,6 +20,11 @@ describe('setUTCWeek', function () {
     assert.deepEqual(result, new Date(Date.UTC(2008, 11 /* Dec */, 31)))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setUTCWeek(new Date(Date.UTC(2005, 0 /* Jan */, 2)), 1.1)
+    assert.deepEqual(result, new Date(Date.UTC(2004, 11 /* Dec */, 26)))
+  })
+
   it('implicitly converts number arguments', function () {
     var result = setUTCWeek(new Date(Date.UTC(2004, 7 /* Aug */, 7)), '53')
     assert.deepEqual(result, new Date(Date.UTC(2005, 0 /* Jan */, 1)))

--- a/src/_lib/startOfUTCWeek/index.js
+++ b/src/_lib/startOfUTCWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
@@ -10,8 +11,8 @@ export default function startOfUTCWeek (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/_lib/startOfUTCWeek/index.js
+++ b/src/_lib/startOfUTCWeek/index.js
@@ -11,8 +11,8 @@ export default function startOfUTCWeek (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/_lib/startOfUTCWeekYear/index.js
+++ b/src/_lib/startOfUTCWeekYear/index.js
@@ -15,11 +15,11 @@ export default function startOfUTCWeekYear (dirtyDate, dirtyOptions) {
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 

--- a/src/_lib/startOfUTCWeekYear/index.js
+++ b/src/_lib/startOfUTCWeekYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../toInteger/index.js'
 import getUTCWeekYear from '../getUTCWeekYear/index.js'
 import startOfUTCWeek from '../startOfUTCWeek/index.js'
 
@@ -16,11 +17,11 @@ export default function startOfUTCWeekYear (dirtyDate, dirtyOptions) {
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   var year = getUTCWeekYear(dirtyDate, dirtyOptions)
   var firstWeek = new Date(0)

--- a/src/_lib/toInteger/index.js
+++ b/src/_lib/toInteger/index.js
@@ -1,5 +1,5 @@
 export default function toInteger (dirtyNumber) {
-  if (dirtyNumber === null) {
+  if (dirtyNumber === null || dirtyNumber === true || dirtyNumber === false) {
     return NaN
   }
 

--- a/src/_lib/toInteger/index.js
+++ b/src/_lib/toInteger/index.js
@@ -1,0 +1,9 @@
+export default function toInteger (dirtyNumber) {
+  var number = Number(dirtyNumber)
+
+  if (isNaN(number)) {
+    return number
+  }
+
+  return number < 0 ? Math.ceil(number) : Math.floor(number)
+}

--- a/src/_lib/toInteger/index.js
+++ b/src/_lib/toInteger/index.js
@@ -1,4 +1,8 @@
 export default function toInteger (dirtyNumber) {
+  if (dirtyNumber === null) {
+    return NaN
+  }
+
   var number = Number(dirtyNumber)
 
   if (isNaN(number)) {

--- a/src/_lib/toInteger/test.js
+++ b/src/_lib/toInteger/test.js
@@ -25,14 +25,14 @@ describe('toInteger', function () {
     assert(typeof result === 'number' && isNaN(result))
   })
 
-  it('converts false to 0', function () {
+  it('returns NaN for false', function () {
     var result = toInteger(false)
-    assert(result === 0)
+    assert(typeof result === 'number' && isNaN(result))
   })
 
-  it('converts true to 1', function () {
+  it('returns NaN for true', function () {
     var result = toInteger(true)
-    assert(result === 1)
+    assert(typeof result === 'number' && isNaN(result))
   })
 
   it('returns NaN for null', function () {
@@ -41,6 +41,11 @@ describe('toInteger', function () {
   })
 
   it('returns NaN for undefined', function () {
+    var result = toInteger(undefined)
+    assert(typeof result === 'number' && isNaN(result))
+  })
+
+  it('returns NaN for NaN', function () {
     var result = toInteger(undefined)
     assert(typeof result === 'number' && isNaN(result))
   })

--- a/src/_lib/toInteger/test.js
+++ b/src/_lib/toInteger/test.js
@@ -46,7 +46,7 @@ describe('toInteger', function () {
   })
 
   it('returns NaN for NaN', function () {
-    var result = toInteger(undefined)
+    var result = toInteger(NaN)
     assert(typeof result === 'number' && isNaN(result))
   })
 

--- a/src/_lib/toInteger/test.js
+++ b/src/_lib/toInteger/test.js
@@ -15,13 +15,45 @@ describe('toInteger', function () {
     assert(result === -5)
   })
 
-  it('converts convertable arguments', function () {
+  it('converts convertable strings', function () {
     var result = toInteger('-10.75')
     assert(result === -10)
   })
 
-  it('returns NaN for non-convertable arguments', function () {
+  it('returns NaN for non-convertable strings', function () {
     var result = toInteger('Foobar')
+    assert(typeof result === 'number' && isNaN(result))
+  })
+
+  it('converts false to 0', function () {
+    var result = toInteger(false)
+    assert(result === 0)
+  })
+
+  it('converts true to 1', function () {
+    var result = toInteger(true)
+    assert(result === 1)
+  })
+
+  it('returns NaN for null', function () {
+    var result = toInteger(null)
+    assert(typeof result === 'number' && isNaN(result))
+  })
+
+  it('returns NaN for undefined', function () {
+    var result = toInteger(undefined)
+    assert(typeof result === 'number' && isNaN(result))
+  })
+
+  it('converts convertable objects', function () {
+    // eslint-disable-next-line no-new-wrappers
+    var result = toInteger(new Number(123))
+    assert(result === 123)
+  })
+
+  it('returns NaN for non-convertable objects', function () {
+    // eslint-disable-next-line no-new-wrappers
+    var result = toInteger({})
     assert(typeof result === 'number' && isNaN(result))
   })
 })

--- a/src/_lib/toInteger/test.js
+++ b/src/_lib/toInteger/test.js
@@ -1,0 +1,27 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import toInteger from '.'
+
+describe('toInteger', function () {
+  it('truncates positive numbers', function () {
+    var result = toInteger(10.99)
+    assert(result === 10)
+  })
+
+  it('truncates negative numbers', function () {
+    var result = toInteger(-5.5)
+    assert(result === -5)
+  })
+
+  it('converts convertable arguments', function () {
+    var result = toInteger('-10.75')
+    assert(result === -10)
+  })
+
+  it('returns NaN for non-convertable arguments', function () {
+    var result = toInteger('Foobar')
+    assert(typeof result === 'number' && isNaN(result))
+  })
+})

--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function addDays (dirtyDate, dirtyAmount, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   date.setDate(date.getDate() + amount)
   return date
 }

--- a/src/addDays/test.js
+++ b/src/addDays/test.js
@@ -20,6 +20,11 @@ describe('addDays', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 11))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addDays(new Date(2014, 8 /* Sep */, 1), 10.5)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 11))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addDays(new Date(2014, 8 /* Sep */, 1), '10')

--- a/src/addHours/index.js
+++ b/src/addHours/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
 
 var MILLISECONDS_IN_HOUR = 3600000
@@ -28,6 +29,6 @@ export default function addHours (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, amount * MILLISECONDS_IN_HOUR, dirtyOptions)
 }

--- a/src/addHours/test.js
+++ b/src/addHours/test.js
@@ -24,6 +24,11 @@ describe('addHours', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 12, 1, 0))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addHours(new Date(2014, 6 /* Jul */, 10, 23, 0), 2.5)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 11, 1, 0))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addHours(new Date(2014, 6 /* Jul */, 10, 23, 0), '2')

--- a/src/addISOWeekYears/index.js
+++ b/src/addISOWeekYears/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import getISOWeekYear from '../getISOWeekYear/index.js'
 import setISOWeekYear from '../setISOWeekYear/index.js'
 
@@ -29,6 +30,6 @@ export default function addISOWeekYears (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return setISOWeekYear(dirtyDate, getISOWeekYear(dirtyDate, dirtyOptions) + amount, dirtyOptions)
 }

--- a/src/addISOWeekYears/test.js
+++ b/src/addISOWeekYears/test.js
@@ -20,6 +20,11 @@ describe('addISOWeekYears', function () {
     assert.deepEqual(result, new Date(2026, 7 /* Aug */, 31))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addISOWeekYears(new Date(2010, 6 /* Jul */, 2), 5.6)
+    assert.deepEqual(result, new Date(2015, 5 /* Jun */, 26))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addISOWeekYears(new Date(2010, 6 /* Jul */, 2), '5')

--- a/src/addMilliseconds/index.js
+++ b/src/addMilliseconds/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,6 +28,6 @@ export default function addMilliseconds (dirtyDate, dirtyAmount, dirtyOptions) {
   }
 
   var timestamp = toDate(dirtyDate, dirtyOptions).getTime()
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return new Date(timestamp + amount)
 }

--- a/src/addMilliseconds/test.js
+++ b/src/addMilliseconds/test.js
@@ -24,6 +24,11 @@ describe('addMilliseconds', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 500))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addMilliseconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 750.750)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 750))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addMilliseconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 5), '750')

--- a/src/addMinutes/index.js
+++ b/src/addMinutes/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
 
 var MILLISECONDS_IN_MINUTE = 60000
@@ -28,6 +29,6 @@ export default function addMinutes (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, amount * MILLISECONDS_IN_MINUTE, dirtyOptions)
 }

--- a/src/addMinutes/test.js
+++ b/src/addMinutes/test.js
@@ -24,6 +24,11 @@ describe('addMinutes', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 20))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), 30.99)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 30))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addMinutes(new Date(2014, 6 /* Jul */, 10, 12, 5), '30')

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getDaysInMonth from '../getDaysInMonth/index.js'
 
@@ -28,7 +29,7 @@ export default function addMonths (dirtyDate, dirtyAmount, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   var desiredMonth = date.getMonth() + amount
   var dateWithDesiredMonth = new Date(0)
   dateWithDesiredMonth.setFullYear(date.getFullYear(), desiredMonth, 1)

--- a/src/addMonths/test.js
+++ b/src/addMonths/test.js
@@ -20,6 +20,11 @@ describe('addMonths', function () {
     assert.deepEqual(result, new Date(2015, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addMonths(new Date(2014, 8 /* Sep */, 1), 5.75)
+    assert.deepEqual(result, new Date(2015, 1 /* Feb */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addMonths(new Date(2014, 8 /* Sep */, 1), '5')

--- a/src/addQuarters/index.js
+++ b/src/addQuarters/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMonths from '../addMonths/index.js'
 
 /**
@@ -26,7 +27,7 @@ export default function addQuarters (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   var months = amount * 3
   return addMonths(dirtyDate, months, dirtyOptions)
 }

--- a/src/addQuarters/test.js
+++ b/src/addQuarters/test.js
@@ -20,6 +20,11 @@ describe('addQuarters', function () {
     assert.deepEqual(result, new Date(2015, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addQuarters(new Date(2014, 8 /* Sep */, 1), 1.91)
+    assert.deepEqual(result, new Date(2014, 11 /* Dec */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addQuarters(new Date(2014, 8 /* Sep */, 1), '1')

--- a/src/addSeconds/index.js
+++ b/src/addSeconds/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function addSeconds (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, amount * 1000, dirtyOptions)
 }

--- a/src/addSeconds/test.js
+++ b/src/addSeconds/test.js
@@ -24,6 +24,11 @@ describe('addSeconds', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 45, 20))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addSeconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 0), 30.777)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 45, 30))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addSeconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 5), '30')

--- a/src/addWeeks/index.js
+++ b/src/addWeeks/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addDays from '../addDays/index.js'
 
 /**
@@ -26,7 +27,7 @@ export default function addWeeks (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   var days = amount * 7
   return addDays(dirtyDate, days, dirtyOptions)
 }

--- a/src/addWeeks/test.js
+++ b/src/addWeeks/test.js
@@ -20,6 +20,11 @@ describe('addWeeks', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 8))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addWeeks(new Date(2014, 8 /* Sep */, 1), 4.95)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 29))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addWeeks(new Date(2014, 8 /* Sep */, 1), '4')

--- a/src/addYears/index.js
+++ b/src/addYears/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMonths from '../addMonths/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function addYears (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMonths(dirtyDate, amount * 12, dirtyOptions)
 }

--- a/src/addYears/test.js
+++ b/src/addYears/test.js
@@ -20,6 +20,11 @@ describe('addYears', function () {
     assert.deepEqual(result, new Date(2026, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = addYears(new Date(2014, 8 /* Sep */, 1), 5.555)
+    assert.deepEqual(result, new Date(2019, 8 /* Sep */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = addYears(new Date(2014, 8 /* Sep */, 1), '5')

--- a/src/closestIndexTo/index.js
+++ b/src/closestIndexTo/index.js
@@ -66,7 +66,7 @@ export default function closestIndexTo (dirtyDateToCompare, dirtyDatesArray, dir
     }
 
     var distance = Math.abs(timeToCompare - currentDate.getTime())
-    if (result === undefined || distance < minDistance) {
+    if (result == null || distance < minDistance) {
       result = index
       minDistance = distance
     }

--- a/src/closestIndexTo/test.js
+++ b/src/closestIndexTo/test.js
@@ -45,7 +45,7 @@ describe('closestIndexTo', function () {
   it('returns undefined if the given array is empty', function () {
     var date = new Date(2014, 6 /* Jul */, 2).getTime()
     var result = closestIndexTo(date, [])
-    assert(result === undefined)
+    assert(result == null)
   })
 
   it('returns NaN if the given date is `Invalid Date`', function () {
@@ -94,14 +94,14 @@ describe('closestIndexTo', function () {
     var date = new Date(2014, 6 /* Jul */, 2).getTime()
     // $ExpectedMistake
     var result = closestIndexTo(date, undefined)
-    assert(result === undefined)
+    assert(result == null)
   })
 
   it('converts null into empty array', function () {
     var date = new Date(2014, 6 /* Jul */, 2).getTime()
     // $ExpectedMistake
     var result = closestIndexTo(date, null)
-    assert(result === undefined)
+    assert(result == null)
   })
 
   it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {

--- a/src/closestTo/index.js
+++ b/src/closestTo/index.js
@@ -64,7 +64,7 @@ export default function closestTo (dirtyDateToCompare, dirtyDatesArray, dirtyOpt
     }
 
     var distance = Math.abs(timeToCompare - currentDate.getTime())
-    if (result === undefined || distance < minDistance) {
+    if (result == null || distance < minDistance) {
       result = currentDate
       minDistance = distance
     }

--- a/src/closestTo/test.js
+++ b/src/closestTo/test.js
@@ -45,7 +45,7 @@ describe('closestTo', function () {
   it('returns undefined if the given array is empty', function () {
     var date = new Date(2014, 6 /* Jul */, 2).getTime()
     var result = closestTo(date, [])
-    assert(result === undefined)
+    assert(result == null)
   })
 
   it('returns `Invalid Date` if the given date is `Invalid Date`', function () {
@@ -104,14 +104,14 @@ describe('closestTo', function () {
     var date = new Date(2014, 6 /* Jul */, 2).getTime()
     // $ExpectedMistake
     var result = closestTo(date, undefined)
-    assert(result === undefined)
+    assert(result == null)
   })
 
   it('converts null into empty array', function () {
     var date = new Date(2014, 6 /* Jul */, 2).getTime()
     // $ExpectedMistake
     var result = closestTo(date, null)
-    assert(result === undefined)
+    assert(result == null)
   })
 
   it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {

--- a/src/endOfWeek/index.js
+++ b/src/endOfWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -38,8 +39,8 @@ export default function endOfWeek (dirtyDate, dirtyOptions) {
 
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/endOfWeek/index.js
+++ b/src/endOfWeek/index.js
@@ -39,8 +39,8 @@ export default function endOfWeek (dirtyDate, dirtyOptions) {
 
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import isValid from '../isValid/index.js'
 import defaultLocale from '../locale/en-US/index.js'
@@ -321,11 +322,11 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {
@@ -333,8 +334,8 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   }
 
   var localeWeekStartsOn = locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -320,11 +320,11 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 
@@ -334,8 +334,8 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   }
 
   var localeWeekStartsOn = locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -131,7 +131,7 @@ export default function formatDistanceStrict (dirtyDate, dirtyBaseDate, dirtyOpt
     dateRight = toDate(dirtyBaseDate, options)
   }
 
-  var roundingMethod = options.roundingMethod ? String(options.roundingMethod) : 'round'
+  var roundingMethod = options.roundingMethod == null ? 'round' : String(options.roundingMethod)
   var roundingMethodFn
 
   if (roundingMethod === 'floor') {
@@ -149,7 +149,7 @@ export default function formatDistanceStrict (dirtyDate, dirtyBaseDate, dirtyOpt
   var minutes = roundingMethodFn(seconds / 60) - offset
 
   var unit
-  if (options.unit === undefined) {
+  if (options.unit == null) {
     if (minutes < 1) {
       unit = 'second'
     } else if (minutes < 60) {

--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import getDate from '../getDate/index.js'
 import startOfMonth from '../startOfMonth/index.js'
 import getDay from '../getDay/index.js'
@@ -31,8 +32,8 @@ export default function getWeekOfMonth (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -32,8 +32,8 @@ export default function getWeekOfMonth (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/getWeekYear/index.js
+++ b/src/getWeekYear/index.js
@@ -56,11 +56,11 @@ export default function getWeekYear (dirtyDate, dirtyOptions) {
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 

--- a/src/getWeekYear/index.js
+++ b/src/getWeekYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import startOfWeek from '../startOfWeek/index.js'
 
@@ -57,11 +58,11 @@ export default function getWeekYear (dirtyDate, dirtyOptions) {
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {

--- a/src/lastDayOfWeek/index.js
+++ b/src/lastDayOfWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -37,8 +38,8 @@ export default function lastDayOfWeek (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/lastDayOfWeek/index.js
+++ b/src/lastDayOfWeek/index.js
@@ -38,8 +38,8 @@ export default function lastDayOfWeek (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import subMinutes from '../subMinutes/index.js'
 import defaultLocale from '../locale/en-US/index.js'
@@ -304,11 +305,11 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {
@@ -316,8 +317,8 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   }
 
   var localeWeekStartsOn = locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -303,11 +303,11 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 
@@ -317,8 +317,8 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   }
 
   var localeWeekStartsOn = locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/setDate/index.js
+++ b/src/setDate/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setDate (dirtyDate, dirtyDayOfMonth, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var dayOfMonth = Number(dirtyDayOfMonth)
+  var dayOfMonth = toInteger(dirtyDayOfMonth)
   date.setDate(dayOfMonth)
   return date
 }

--- a/src/setDate/test.js
+++ b/src/setDate/test.js
@@ -20,6 +20,11 @@ describe('setDate', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 25))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setDate(new Date(2014, 8 /* Sep */, 1), 30.30)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 30))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setDate(new Date(2014, 8 /* Sep */, 1), '30')

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import addDays from '../addDays/index.js'
 
@@ -38,8 +39,8 @@ export default function setDay (dirtyDate, dirtyDay, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
@@ -47,7 +48,7 @@ export default function setDay (dirtyDate, dirtyDay, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, options)
-  var day = Number(dirtyDay)
+  var day = toInteger(dirtyDay)
   var currentDay = date.getDay()
 
   var remainder = day % 7

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -39,8 +39,8 @@ export default function setDay (dirtyDate, dirtyDay, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/setDay/test.js
+++ b/src/setDay/test.js
@@ -44,6 +44,11 @@ describe('setDay', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 7))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setDay(new Date(2014, 8 /* Sep */, 1), 0.5)
+    assert.deepEqual(result, new Date(2014, 7 /* Aug */, 31))
+  })
+
   it('implicitly converts options', function () {
     // $ExpectedMistake
     var result = setDay(new Date(2014, 8 /* Sep */, 1), 0, {weekStartsOn: '1'})

--- a/src/setDayOfYear/index.js
+++ b/src/setDayOfYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setDayOfYear (dirtyDate, dirtyDayOfYear, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var dayOfYear = Number(dirtyDayOfYear)
+  var dayOfYear = toInteger(dirtyDayOfYear)
   date.setMonth(0)
   date.setDate(dayOfYear)
   return date

--- a/src/setDayOfYear/test.js
+++ b/src/setDayOfYear/test.js
@@ -20,6 +20,11 @@ describe('setDayOfYear', function () {
     assert.deepEqual(result, new Date(2014, 2 /* Mar */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setDayOfYear(new Date(2014, 6 /* Jul */, 2), 2.75)
+    assert.deepEqual(result, new Date(2014, 0 /* Jan */, 2))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setDayOfYear(new Date(2014, 6 /* Jul */, 2), '2')

--- a/src/setHours/index.js
+++ b/src/setHours/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setHours (dirtyDate, dirtyHours, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var hours = Number(dirtyHours)
+  var hours = toInteger(dirtyHours)
   date.setHours(hours)
   return date
 }

--- a/src/setHours/test.js
+++ b/src/setHours/test.js
@@ -20,6 +20,11 @@ describe('setHours', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 5))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setHours(new Date(2014, 8 /* Sep */, 1, 11, 30), 4.123)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 4, 30))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setHours(new Date(2014, 8 /* Sep */, 1, 11, 30), '4')

--- a/src/setISODay/index.js
+++ b/src/setISODay/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import addDays from '../addDays/index.js'
 import getISODay from '../getISODay/index.js'
@@ -31,7 +32,7 @@ export default function setISODay (dirtyDate, dirtyDay, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var day = Number(dirtyDay)
+  var day = toInteger(dirtyDay)
   var currentDay = getISODay(date, dirtyOptions)
   var diff = day - currentDay
   return addDays(date, diff, dirtyOptions)

--- a/src/setISODay/test.js
+++ b/src/setISODay/test.js
@@ -49,6 +49,11 @@ describe('setISODay', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 3))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setISODay(new Date(2014, 8 /* Sep */, 1), 3.33)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 3))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setISODay(new Date(2014, 8 /* Sep */, 1), '3')

--- a/src/setISOWeek/index.js
+++ b/src/setISOWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getISOWeek from '../getISOWeek/index.js'
 
@@ -30,7 +31,7 @@ export default function setISOWeek (dirtyDate, dirtyISOWeek, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var isoWeek = Number(dirtyISOWeek)
+  var isoWeek = toInteger(dirtyISOWeek)
   var diff = getISOWeek(date, dirtyOptions) - isoWeek
   date.setDate(date.getDate() - diff * 7)
   return date

--- a/src/setISOWeek/test.js
+++ b/src/setISOWeek/test.js
@@ -20,6 +20,11 @@ describe('setISOWeek', function () {
     assert.deepEqual(result, new Date(2008, 11 /* Dec */, 31))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setISOWeek(new Date(2004, 7 /* Aug */, 7), 53.53)
+    assert.deepEqual(result, new Date(2005, 0 /* Jan */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setISOWeek(new Date(2004, 7 /* Aug */, 7), '53')

--- a/src/setISOWeekYear/index.js
+++ b/src/setISOWeekYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
 import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
@@ -32,7 +33,7 @@ export default function setISOWeekYear (dirtyDate, dirtyISOWeekYear, dirtyOption
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var isoWeekYear = Number(dirtyISOWeekYear)
+  var isoWeekYear = toInteger(dirtyISOWeekYear)
   var diff = differenceInCalendarDays(date, startOfISOWeekYear(date, dirtyOptions), dirtyOptions)
   var fourthOfJanuary = new Date(0)
   fourthOfJanuary.setFullYear(isoWeekYear, 0, 4)

--- a/src/setISOWeekYear/test.js
+++ b/src/setISOWeekYear/test.js
@@ -20,6 +20,11 @@ describe('setISOWeekYear', function () {
     assert.deepEqual(result, new Date(2005, 0 /* Jan */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setISOWeekYear(new Date(2008, 11 /* Dec */, 29), 2007.7002)
+    assert.deepEqual(result, new Date(2007, 0 /* Jan */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setISOWeekYear(new Date(2008, 11 /* Dec */, 29), '2007')

--- a/src/setMilliseconds/index.js
+++ b/src/setMilliseconds/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setMilliseconds (dirtyDate, dirtyMilliseconds, dirtyOpti
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var milliseconds = Number(dirtyMilliseconds)
+  var milliseconds = toInteger(dirtyMilliseconds)
   date.setMilliseconds(milliseconds)
   return date
 }

--- a/src/setMilliseconds/test.js
+++ b/src/setMilliseconds/test.js
@@ -20,6 +20,11 @@ describe('setMilliseconds', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 11, 30, 15, 755))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setMilliseconds(new Date(2014, 8 /* Sep */, 1, 11, 30, 40, 500), 300.999)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 11, 30, 40, 300))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setMilliseconds(new Date(2014, 8 /* Sep */, 1, 11, 30, 40, 500), '300')

--- a/src/setMinutes/index.js
+++ b/src/setMinutes/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setMinutes (dirtyDate, dirtyMinutes, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var minutes = Number(dirtyMinutes)
+  var minutes = toInteger(dirtyMinutes)
   date.setMinutes(minutes)
   return date
 }

--- a/src/setMinutes/test.js
+++ b/src/setMinutes/test.js
@@ -20,6 +20,11 @@ describe('setMinutes', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 11, 5))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setMinutes(new Date(2014, 8 /* Sep */, 1, 11, 30, 40), 45.54)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 11, 45, 40))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setMinutes(new Date(2014, 8 /* Sep */, 1, 11, 30, 40), '45')

--- a/src/setMonth/index.js
+++ b/src/setMonth/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getDaysInMonth from '../getDaysInMonth/index.js'
 
@@ -28,7 +29,7 @@ export default function setMonth (dirtyDate, dirtyMonth, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var month = Number(dirtyMonth)
+  var month = toInteger(dirtyMonth)
   var year = date.getFullYear()
   var day = date.getDate()
 

--- a/src/setMonth/test.js
+++ b/src/setMonth/test.js
@@ -25,6 +25,11 @@ describe('setMonth', function () {
     assert.deepEqual(result, new Date(2014, 11 /* Dec */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setMonth(new Date(2014, 8 /* Sep */, 1), 1.5)
+    assert.deepEqual(result, new Date(2014, 1 /* Feb */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setMonth(new Date(2014, 8 /* Sep */, 1), '1')

--- a/src/setQuarter/index.js
+++ b/src/setQuarter/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import setMonth from '../setMonth/index.js'
 
@@ -28,7 +29,7 @@ export default function setQuarter (dirtyDate, dirtyQuarter, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var quarter = Number(dirtyQuarter)
+  var quarter = toInteger(dirtyQuarter)
   var oldQuarter = Math.floor(date.getMonth() / 3) + 1
   var diff = quarter - oldQuarter
   return setMonth(date, date.getMonth() + diff * 3, dirtyOptions)

--- a/src/setQuarter/test.js
+++ b/src/setQuarter/test.js
@@ -25,6 +25,11 @@ describe('setQuarter', function () {
     assert.deepEqual(result, new Date(2014, 9 /* Oct */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setQuarter(new Date(2014, 6 /* Jul */, 2), 1.951)
+    assert.deepEqual(result, new Date(2014, 0 /* Jan */, 2))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setQuarter(new Date(2014, 6 /* Jul */, 2), '1')

--- a/src/setSeconds/index.js
+++ b/src/setSeconds/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setSeconds (dirtyDate, dirtySeconds, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var seconds = Number(dirtySeconds)
+  var seconds = toInteger(dirtySeconds)
   date.setSeconds(seconds)
   return date
 }

--- a/src/setSeconds/test.js
+++ b/src/setSeconds/test.js
@@ -20,6 +20,11 @@ describe('setSeconds', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 11, 30, 45))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setSeconds(new Date(2014, 8 /* Sep */, 1, 11, 30, 40, 500), 45.54)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1, 11, 30, 45, 500))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setSeconds(new Date(2014, 8 /* Sep */, 1, 11, 30, 40, 500), '45')

--- a/src/setWeek/index.js
+++ b/src/setWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getWeek from '../getWeek/index.js'
 
@@ -45,7 +46,7 @@ export default function setWeek (dirtyDate, dirtyWeek, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var week = Number(dirtyWeek)
+  var week = toInteger(dirtyWeek)
   var diff = getWeek(date, dirtyOptions) - week
   date.setDate(date.getDate() - diff * 7)
   return date

--- a/src/setWeek/test.js
+++ b/src/setWeek/test.js
@@ -20,6 +20,11 @@ describe('setWeek', function () {
     assert.deepEqual(result, new Date(2008, 11 /* Dec */, 31))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setWeek(new Date(2005, 0 /* Jan */, 2), 1.9)
+    assert.deepEqual(result, new Date(2004, 11 /* Dec */, 26))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setWeek(new Date(2004, 7 /* Aug */, 7), '53')

--- a/src/setWeekYear/index.js
+++ b/src/setWeekYear/index.js
@@ -53,11 +53,11 @@ export default function setWeekYear (dirtyDate, dirtyWeekYear, dirtyOptions) {
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 

--- a/src/setWeekYear/index.js
+++ b/src/setWeekYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import startOfWeekYear from '../startOfWeekYear/index.js'
 import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
@@ -54,14 +55,14 @@ export default function setWeekYear (dirtyDate, dirtyWeekYear, dirtyOptions) {
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var weekYear = Number(dirtyWeekYear)
+  var weekYear = toInteger(dirtyWeekYear)
   var diff = differenceInCalendarDays(date, startOfWeekYear(date, dirtyOptions), dirtyOptions)
   var firstWeek = new Date(0)
   firstWeek.setFullYear(weekYear, 0, firstWeekContainsDate)

--- a/src/setWeekYear/test.js
+++ b/src/setWeekYear/test.js
@@ -20,6 +20,11 @@ describe('setWeekYear', function () {
     assert.deepEqual(result, new Date(2007, 0 /* Jan */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setWeekYear(new Date(2010, 0 /* Jan */, 2), 2004.2004)
+    assert.deepEqual(result, new Date(2004, 0 /* Jan */, 3))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setWeekYear(new Date(2008, 11 /* Dec */, 29), '2007')

--- a/src/setYear/index.js
+++ b/src/setYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -27,7 +28,7 @@ export default function setYear (dirtyDate, dirtyYear, dirtyOptions) {
   }
 
   var date = toDate(dirtyDate, dirtyOptions)
-  var year = Number(dirtyYear)
+  var year = toInteger(dirtyYear)
 
   // Check if date is Invalid Date because Date.prototype.setFullYear ignores the value of Invalid Date
   if (isNaN(date)) {

--- a/src/setYear/test.js
+++ b/src/setYear/test.js
@@ -20,6 +20,11 @@ describe('setYear', function () {
     assert.deepEqual(result, new Date(2016, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = setYear(new Date(2014, 8 /* Sep */, 1), 2013.987654321)
+    assert.deepEqual(result, new Date(2013, 8 /* Sep */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = setYear(new Date(2014, 8 /* Sep */, 1), '2013')

--- a/src/startOfWeek/index.js
+++ b/src/startOfWeek/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 
 /**
@@ -37,8 +38,8 @@ export default function startOfWeek (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : Number(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : Number(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/startOfWeek/index.js
+++ b/src/startOfWeek/index.js
@@ -38,8 +38,8 @@ export default function startOfWeek (dirtyDate, dirtyOptions) {
   var options = dirtyOptions || {}
   var locale = options.locale
   var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn === undefined ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn === undefined ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -50,11 +50,11 @@ export default function startOfWeekYear (dirtyDate, dirtyOptions) {
     locale.options &&
     locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
-    localeFirstWeekContainsDate === undefined
+    localeFirstWeekContainsDate == null
       ? 1
       : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
-    options.firstWeekContainsDate === undefined
+    options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
 

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import getWeekYear from '../getWeekYear/index.js'
 import startOfWeek from '../startOfWeek/index.js'
 
@@ -51,11 +52,11 @@ export default function startOfWeekYear (dirtyDate, dirtyOptions) {
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate === undefined
       ? 1
-      : Number(localeFirstWeekContainsDate)
+      : toInteger(localeFirstWeekContainsDate)
   var firstWeekContainsDate =
     options.firstWeekContainsDate === undefined
       ? defaultFirstWeekContainsDate
-      : Number(options.firstWeekContainsDate)
+      : toInteger(options.firstWeekContainsDate)
 
   var year = getWeekYear(dirtyDate, dirtyOptions)
   var firstWeek = new Date(0)

--- a/src/subDays/index.js
+++ b/src/subDays/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addDays from '../addDays/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subDays (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addDays(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subDays/test.js
+++ b/src/subDays/test.js
@@ -20,6 +20,11 @@ describe('subDays', function () {
     assert.deepEqual(result, new Date(2014, 7 /* Aug */, 22))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subDays(new Date(2014, 8 /* Sep */, 1), 10.85)
+    assert.deepEqual(result, new Date(2014, 7 /* Aug */, 22))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subDays(new Date(2014, 8 /* Sep */, 1), '10')

--- a/src/subHours/index.js
+++ b/src/subHours/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addHours from '../addHours/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subHours (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addHours(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subHours/test.js
+++ b/src/subHours/test.js
@@ -24,6 +24,11 @@ describe('subHours', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 23, 0))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subHours(new Date(2014, 6 /* Jul */, 11, 1, 0), 2.22)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 23, 0))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subHours(new Date(2014, 6 /* Jul */, 11, 1, 0), '2')

--- a/src/subISOWeekYears/index.js
+++ b/src/subISOWeekYears/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addISOWeekYears from '../addISOWeekYears/index.js'
 
 /**
@@ -28,6 +29,6 @@ export default function subISOWeekYears (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addISOWeekYears(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subISOWeekYears/test.js
+++ b/src/subISOWeekYears/test.js
@@ -20,6 +20,11 @@ describe('subISOWeekYears', function () {
     assert.deepEqual(result, new Date(2002, 8 /* Sep */, 2))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1), 5.555)
+    assert.deepEqual(result, new Date(2009, 7 /* Aug */, 31))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1), '5')

--- a/src/subMilliseconds/index.js
+++ b/src/subMilliseconds/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subMilliseconds (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subMilliseconds/test.js
+++ b/src/subMilliseconds/test.js
@@ -24,6 +24,11 @@ describe('subMilliseconds', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 45, 29, 500))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subMilliseconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 750.750)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 45, 29, 250))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subMilliseconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), '750')

--- a/src/subMinutes/index.js
+++ b/src/subMinutes/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMinutes from '../addMinutes/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subMinutes (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMinutes(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subMinutes/test.js
+++ b/src/subMinutes/test.js
@@ -24,6 +24,11 @@ describe('subMinutes', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 11, 40))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), 30.4)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 11, 30))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), '30')

--- a/src/subMonths/index.js
+++ b/src/subMonths/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addMonths from '../addMonths/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subMonths (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addMonths(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subMonths/test.js
+++ b/src/subMonths/test.js
@@ -20,6 +20,11 @@ describe('subMonths', function () {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subMonths(new Date(2015, 1 /* Feb */, 1), 5.999)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subMonths(new Date(2015, 1 /* Feb */, 1), '5')

--- a/src/subQuarters/index.js
+++ b/src/subQuarters/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addQuarters from '../addQuarters/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subQuarters (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addQuarters(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subQuarters/test.js
+++ b/src/subQuarters/test.js
@@ -20,6 +20,11 @@ describe('subQuarters', function () {
     assert.deepEqual(result, new Date(2013, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subQuarters(new Date(2014, 8 /* Sep */, 1), 3.33)
+    assert.deepEqual(result, new Date(2013, 11 /* Dec */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subQuarters(new Date(2014, 8 /* Sep */, 1), '3')

--- a/src/subSeconds/index.js
+++ b/src/subSeconds/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addSeconds from '../addSeconds/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subSeconds (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addSeconds(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subSeconds/test.js
+++ b/src/subSeconds/test.js
@@ -24,6 +24,11 @@ describe('subSeconds', function () {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 44, 40))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subSeconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 0), 30.5)
+    assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 44, 30))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subSeconds(new Date(2014, 6 /* Jul */, 10, 12, 45, 0), '30')

--- a/src/subWeeks/index.js
+++ b/src/subWeeks/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addWeeks from '../addWeeks/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subWeeks (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addWeeks(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subWeeks/test.js
+++ b/src/subWeeks/test.js
@@ -20,6 +20,11 @@ describe('subWeeks', function () {
     assert.deepEqual(result, new Date(2014, 7 /* Aug */, 25))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subWeeks(new Date(2014, 8 /* Sep */, 1), 4.2)
+    assert.deepEqual(result, new Date(2014, 7 /* Aug */, 4))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subWeeks(new Date(2014, 8 /* Sep */, 1), '4')

--- a/src/subYears/index.js
+++ b/src/subYears/index.js
@@ -1,3 +1,4 @@
+import toInteger from '../_lib/toInteger/index.js'
 import addYears from '../addYears/index.js'
 
 /**
@@ -26,6 +27,6 @@ export default function subYears (dirtyDate, dirtyAmount, dirtyOptions) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var amount = Number(dirtyAmount)
+  var amount = toInteger(dirtyAmount)
   return addYears(dirtyDate, -amount, dirtyOptions)
 }

--- a/src/subYears/test.js
+++ b/src/subYears/test.js
@@ -20,6 +20,11 @@ describe('subYears', function () {
     assert.deepEqual(result, new Date(2002, 8 /* Sep */, 1))
   })
 
+  it('converts a fractional number to an integer', function () {
+    var result = subYears(new Date(2014, 8 /* Sep */, 1), 5.1)
+    assert.deepEqual(result, new Date(2009, 8 /* Sep */, 1))
+  })
+
   it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     var result = subYears(new Date(2014, 8 /* Sep */, 1), '5')

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -101,7 +101,7 @@ export default function toDate (argument, dirtyOptions) {
   if (argument instanceof Date) {
     // Prevent the date to lose the milliseconds when passed to new Date() in IE10
     return new Date(argument.getTime())
-  } else if (typeof argument === 'number' || argument instanceof Number || argument === true || argument === false) {
+  } else if (typeof argument === 'number' || argument instanceof Number) {
     return new Date(argument)
   } else if (!(typeof argument === 'string' || argument instanceof String)) {
     return new Date(NaN)

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -92,7 +92,7 @@ export default function toDate (argument, dirtyOptions) {
 
   var options = dirtyOptions || {}
 
-  var additionalDigits = options.additionalDigits === undefined ? DEFAULT_ADDITIONAL_DIGITS : toInteger(options.additionalDigits)
+  var additionalDigits = options.additionalDigits == null ? DEFAULT_ADDITIONAL_DIGITS : toInteger(options.additionalDigits)
   if (additionalDigits !== 2 && additionalDigits !== 1 && additionalDigits !== 0) {
     throw new RangeError('additionalDigits must be 0, 1 or 2')
   }
@@ -101,7 +101,7 @@ export default function toDate (argument, dirtyOptions) {
   if (argument instanceof Date) {
     // Prevent the date to lose the milliseconds when passed to new Date() in IE10
     return new Date(argument.getTime())
-  } else if (typeof argument === 'number' || argument instanceof Number) {
+  } else if (typeof argument === 'number' || argument instanceof Number || argument === true || argument === false) {
     return new Date(argument)
   } else if (!(typeof argument === 'string' || argument instanceof String)) {
     return new Date(NaN)

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -1,3 +1,5 @@
+import toInteger from '../_lib/toInteger/index.js'
+
 var MILLISECONDS_IN_HOUR = 3600000
 var MILLISECONDS_IN_MINUTE = 60000
 var DEFAULT_ADDITIONAL_DIGITS = 2
@@ -90,7 +92,7 @@ export default function toDate (argument, dirtyOptions) {
 
   var options = dirtyOptions || {}
 
-  var additionalDigits = options.additionalDigits === undefined ? DEFAULT_ADDITIONAL_DIGITS : Number(options.additionalDigits)
+  var additionalDigits = options.additionalDigits === undefined ? DEFAULT_ADDITIONAL_DIGITS : toInteger(options.additionalDigits)
   if (additionalDigits !== 2 && additionalDigits !== 1 && additionalDigits !== 0) {
     throw new RangeError('additionalDigits must be 0, 1 or 2')
   }

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -269,16 +269,18 @@ describe('toDate', function () {
       assert(isNaN(result))
     })
 
-    it('returns new Date(0) if argument is false', function () {
+    it('returns Invalid Date if argument is false', function () {
       // $ExpectedMistake
       var result = toDate(false)
-      assert.deepEqual(result, new Date(0))
+      assert(result instanceof Date)
+      assert(isNaN(result))
     })
 
-    it('returns new Date(1) if argument is true', function () {
+    it('returns Invalid Date if argument is true', function () {
       // $ExpectedMistake
       var result = toDate(true)
-      assert.deepEqual(result, new Date(1))
+      assert(result instanceof Date)
+      assert(isNaN(result))
     })
   })
 

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -269,18 +269,16 @@ describe('toDate', function () {
       assert(isNaN(result))
     })
 
-    it('returns Invalid Date if argument is false', function () {
+    it('returns new Date(0) if argument is false', function () {
       // $ExpectedMistake
       var result = toDate(false)
-      assert(result instanceof Date)
-      assert(isNaN(result))
+      assert.deepEqual(result, new Date(0))
     })
 
-    it('returns Invalid Date if argument is true', function () {
+    it('returns new Date(1) if argument is true', function () {
       // $ExpectedMistake
       var result = toDate(true)
-      assert(result instanceof Date)
-      assert(isNaN(result))
+      assert.deepEqual(result, new Date(1))
     })
   })
 


### PR DESCRIPTION
- Convert number arguments into integer number using a custom `toInteger` implementation
- Change null/undefined/true/false implicit conversion strategy:
  - For required arguments:

  | | date          | number | string      | boolean |
  |-----------|---------------|--------|-------------|---------|
  | 0         | new Date(0)   | 0      | '0'         | false   |
  | '0'       | Invalid Date  | 0      | '0'         | false   |
  | 1         | new Date(1)   | 1      | '1'         | true    |
  | '1'       | Invalid Date  | 1      | '1'         | true    |
  | true      | Invalid Date  | NaN    | 'true'      | true    |
  | false     | Invalid Date  | NaN    | 'false'     | false   |
  | null      | Invalid Date  | NaN    | 'null'      | false   |
  | undefined | Invalid Date  | NaN    | 'undefined' | false   |
  | NaN       | Invalid Date  | NaN    | 'NaN'       | false   |

  - For optional arguments, null and undefined are treated as if argument is not provided