### PR TITLE
Fix wrong example of `getMonth`

### DIFF
--- a/src/getMonth/index.js
+++ b/src/getMonth/index.js
@@ -17,7 +17,7 @@ import toDate from '../toDate/index.js'
  *
  * @example
  * // Which month is 29 February 2012?
- * var result = getMonth(new Date(2012, 1, 29))
+ * var result = getMonth(new Date(2012, 2, 29))
  * //=> 1
  */
 export default function getMonth (dirtyDate, dirtyOptions) {


### PR DESCRIPTION
getMonth return month as a zero-based value