### PR TITLE
Fix Markdown tables in format & parse functions' annotations (closes #751)

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -43,6 +43,7 @@ var doubleQuoteRegExp = /''/g
  * with a few additions (see note 7 below the table).
  *
  * Accepted patterns:
+ *
  * | Unit                            | Pattern | Result examples                   | Notes |
  * |---------------------------------|---------|-----------------------------------|-------|
  * | Era                             | G..GGG  | AD, BC                            |       |
@@ -194,6 +195,7 @@ var doubleQuoteRegExp = /''/g
  * |                                 | PPpp    | May 29, 1453, 12:00:00 AM         | 7     |
  * |                                 | PPPppp  | May 29th, 1453 at ...             | 7     |
  * |                                 | PPPPpppp| Sunday, May 29th, 1453 at ...     | 2,7   |
+ *
  * Notes:
  * 1. "Formatting" units (e.g. formatting quarter) in the default en-US locale
  *    are the same as "stand-alone" units, but are different in some languages.

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -38,6 +38,7 @@ var doubleQuoteRegExp = /''/g
  * with a few additions (see note 5 below the table).
  *
  * Accepted format string patterns:
+ *
  * | Unit                            |Prior| Pattern | Result examples                   | Notes |
  * |---------------------------------|-----|---------|-----------------------------------|-------|
  * | Era                             | 140 | G..GGG  | AD, BC                            |       |
@@ -173,6 +174,7 @@ var doubleQuoteRegExp = /''/g
  * |                                 |     | tt      | ...                               | 2     |
  * | Milliseconds timestamp          |  10 | T       | 512969520900                      |       |
  * |                                 |     | TT      | ...                               | 2     |
+ *
  * Notes:
  * 1. "Formatting" units (e.g. formatting quarter) in the default en-US locale
  *    are the same as "stand-alone" units, but are different in some languages.


### PR DESCRIPTION
The PR fixes Markdown tables that were broken because of lack of empty lines.