### PR TITLE
[V2] Add TH locale

### DIFF
--- a/src/locale/th/_lib/formatLong/index.js
+++ b/src/locale/th/_lib/formatLong/index.js
@@ -1,12 +1,41 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
-var formatLong = buildFormatLongFn({
-  LT: 'h:mm aa',
-  LTS: 'h:mm:ss aa',
-  L: 'MM/DD/YYYY',
-  LL: 'MMMM D YYYY',
-  LLL: 'MMMM D YYYY h:mm aa',
-  LLLL: 'dddd, MMMM D YYYY h:mm aa'
-})
+var dateFormats = {
+  full: 'วันEEEEที่ do MMMM y',
+  long: 'do MMMM y',
+  medium: 'd MMM y',
+  short: 'dd/MM/yyyy'
+}
+
+var timeFormats = {
+  full: 'h:mm:ss a zzzz',
+  long: 'h:mm:ss a z',
+  medium: 'h:mm:ss a',
+  short: 'h:mm a'
+}
+
+var dateTimeFormats = {
+  full: "{{date}} 'เวลา' {{time}}",
+  long: "{{date}} 'เวลา' {{time}}",
+  medium: '{{date}}, {{time}}',
+  short: '{{date}}, {{time}}'
+}
+
+var formatLong = {
+  date: buildFormatLongFn({
+    formats: dateFormats,
+    defaultWidth: 'full'
+  }),
+
+  time: buildFormatLongFn({
+    formats: timeFormats,
+    defaultWidth: 'full'
+  }),
+
+  dateTime: buildFormatLongFn({
+    formats: dateTimeFormats,
+    defaultWidth: 'full'
+  })
+}
 
 export default formatLong

--- a/src/locale/th/_lib/formatRelative/index.js
+++ b/src/locale/th/_lib/formatRelative/index.js
@@ -1,10 +1,10 @@
 var formatRelativeLocale = {
-  lastWeek: '[last] dddd [at] LT',
-  yesterday: '[yesterday at] LT',
-  today: '[today at] LT',
-  tomorrow: '[tomorrow at] LT',
-  nextWeek: 'dddd [at] LT',
-  other: 'L'
+  lastWeek: "eeee'ที่แล้วเวลา' p",
+  yesterday: "'เมื่อวานนี้เวลา' p",
+  today: "'วันนี้เวลา' p",
+  tomorrow: "'พรุ่งนี้เวลา' p",
+  nextWeek: "eeee 'เวลา' p",
+  other: 'P'
 }
 
 export default function formatRelative (token, date, baseDate, options) {

--- a/src/locale/th/_lib/localize/index.js
+++ b/src/locale/th/_lib/localize/index.js
@@ -1,21 +1,94 @@
 import buildLocalizeFn from '../../../_lib/buildLocalizeFn/index.js'
-import buildLocalizeArrayFn from '../../../_lib/buildLocalizeArrayFn/index.js'
 
-var weekdayValues = {
+var eraValues = {
+  narrow: ['B', 'คศ'],
+  abbreviated: ['BC', 'ค.ศ.'],
+  wide: ['ปีก่อนคริสตกาล', 'คริสต์ศักราช']
+}
+
+var quarterValues = {
+  narrow: ['1', '2', '3', '4'],
+  abbreviated: ['Q1', 'Q2', 'Q3', 'Q4'],
+  wide: ['ไตรมาสแรก', 'ไตรมาสที่สอง', 'ไตรมาสที่สาม', 'ไตรมาสที่สี่']
+}
+
+var dayValues = {
   narrow: ['อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'],
   short: ['อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'],
-  long: ['อาทิตย์', 'จันทร์', 'อังคาร', 'พุธ', 'พฤหัสบดี', 'ศุกร์', 'เสาร์']
+  abbreviated: ['อา.', 'จ.', 'อ.', 'พ.', 'พฤ.', 'ศ.', 'ส.'],
+  wide: ['อาทิตย์', 'จันทร์', 'อังคาร', 'พุธ', 'พฤหัสบดี', 'ศุกร์', 'เสาร์']
 }
 
 var monthValues = {
-  short: ['ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.'],
-  long: ['มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม']
+  narrow: ['ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.'],
+  abbreviated: ['ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.'],
+  wide: ['มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม']
 }
 
-var timeOfDayValues = {
-  uppercase: ['น.'],
-  lowercase: ['น.'],
-  long: ['นาฬิกา']
+var dayPeriodValues = {
+  narrow: {
+    am: 'น',
+    pm: 'น',
+    midnight: 'เที่ยงคืน',
+    noon: 'เที่ยง',
+    morning: 'เช้า',
+    afternoon: 'บ่าย',
+    evening: 'เย็น',
+    night: 'กลางคืน'
+  },
+  abbreviated: {
+    am: 'น.',
+    pm: 'น.',
+    midnight: 'เที่ยงคืน',
+    noon: 'เที่ยง',
+    morning: 'เช้า',
+    afternoon: 'บ่าย',
+    evening: 'เย็น',
+    night: 'กลางคืน'
+  },
+  wide: {
+    am: 'น.',
+    pm: 'น.',
+    midnight: 'เที่ยงคืน',
+    noon: 'เที่ยง',
+    morning: 'เช้า',
+    afternoon: 'บ่าย',
+    evening: 'เย็น',
+    night: 'กลางคืน'
+  }
+}
+
+var formattingDayPeriodValues = {
+  narrow: {
+    am: 'น',
+    pm: 'น',
+    midnight: 'เที่ยงคืน',
+    noon: 'เที่ยง',
+    morning: 'ตอนเช้า',
+    afternoon: 'ตอนกลางวัน',
+    evening: 'ตอนเย็น',
+    night: 'ตอนกลางคืน'
+  },
+  abbreviated: {
+    am: 'น.',
+    pm: 'น.',
+    midnight: 'เที่ยงคืน',
+    noon: 'เที่ยง',
+    morning: 'ตอนเช้า',
+    afternoon: 'ตอนกลางวัน',
+    evening: 'ตอนเย็น',
+    night: 'ตอนกลางคืน'
+  },
+  wide: {
+    am: 'น.',
+    pm: 'น.',
+    midnight: 'เที่ยงคืน',
+    noon: 'เที่ยง',
+    morning: 'ตอนเช้า',
+    afternoon: 'ตอนกลางวัน',
+    evening: 'ตอนเย็น',
+    night: 'ตอนกลางคืน'
+  }
 }
 
 function ordinalNumber (dirtyNumber) {
@@ -25,14 +98,36 @@ function ordinalNumber (dirtyNumber) {
 
 var localize = {
   ordinalNumber: ordinalNumber,
-  weekday: buildLocalizeFn(weekdayValues, 'long'),
-  weekdays: buildLocalizeArrayFn(weekdayValues, 'long'),
-  month: buildLocalizeFn(monthValues, 'long'),
-  months: buildLocalizeArrayFn(monthValues, 'long'),
-  timeOfDay: buildLocalizeFn(timeOfDayValues, 'long', function (hours) {
-    return (hours / 12) >= 1 ? 1 : 0
+
+  era: buildLocalizeFn({
+    values: eraValues,
+    defaultWidth: 'wide'
   }),
-  timesOfDay: buildLocalizeArrayFn(timeOfDayValues, 'long')
+
+  quarter: buildLocalizeFn({
+    values: quarterValues,
+    defaultWidth: 'wide',
+    argumentCallback: function (quarter) {
+      return Number(quarter) - 1
+    }
+  }),
+
+  month: buildLocalizeFn({
+    values: monthValues,
+    defaultWidth: 'wide'
+  }),
+
+  day: buildLocalizeFn({
+    values: dayValues,
+    defaultWidth: 'wide'
+  }),
+
+  dayPeriod: buildLocalizeFn({
+    values: dayPeriodValues,
+    defaultWidth: 'wide',
+    formattingValues: formattingDayPeriodValues,
+    defaulFormattingWidth: 'wide'
+  })
 }
 
 export default localize

--- a/src/locale/th/_lib/match/index.js
+++ b/src/locale/th/_lib/match/index.js
@@ -1,47 +1,116 @@
-import buildMatchFn from '../../../_lib/buildMatchFn/index.js'
-import buildParseFn from '../../../_lib/buildParseFn/index.js'
 import buildMatchPatternFn from '../../../_lib/buildMatchPatternFn/index.js'
-import parseDecimal from '../../../_lib/parseDecimal/index.js'
+import buildMatchFn from '../../../_lib/buildMatchFn/index.js'
 
-var matchOrdinalNumbersPattern = /^(\d+)(th|st|nd|rd)?/i
+/*
+ * Copy from en-US/_lib/match
+ * I decided to not support this feature because of rarly usages.
+ * Thus, this feature still need the contributions for parse thai date and time.
+ */
+var matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i
+var parseOrdinalNumberPattern = /\d+/i
 
-var matchWeekdaysPatterns = {
-  narrow: /^(su|mo|tu|we|th|fr|sa)/i,
-  short: /^(sun|mon|tue|wed|thu|fri|sat)/i,
-  long: /^(sunday|monday|tuesday|wednesday|thursday|friday|saturday)/i
+var matchEraPatterns = {
+  narrow: /^(b|a)/i,
+  abbreviated: /^(b\.?\s?c\.?|b\.?\s?c\.?\s?e\.?|a\.?\s?d\.?|c\.?\s?e\.?)/i,
+  wide: /^(before christ|before common era|anno domini|common era)/i
+}
+var parseEraPatterns = {
+  any: [/^b/i, /^(a|c)/i]
 }
 
-var parseWeekdayPatterns = {
-  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i]
+var matchQuarterPatterns = {
+  narrow: /^[1234]/i,
+  abbreviated: /^q[1234]/i,
+  wide: /^[1234](th|st|nd|rd)? quarter/i
+}
+var parseQuarterPatterns = {
+  any: [/1/i, /2/i, /3/i, /4/i]
 }
 
-var matchMonthsPatterns = {
-  short: /^(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/i,
-  long: /^(january|february|march|april|may|june|july|august|september|october|november|december)/i
+var matchMonthPatterns = {
+  narrow: /^[jfmasond]/i,
+  abbreviated: /^(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/i,
+  wide: /^(january|february|march|april|may|june|july|august|september|october|november|december)/i
 }
-
 var parseMonthPatterns = {
+  narrow: [/^j/i, /^f/i, /^m/i, /^a/i, /^m/i, /^j/i, /^j/i, /^a/i, /^s/i, /^o/i, /^n/i, /^d/i],
   any: [/^ja/i, /^f/i, /^mar/i, /^ap/i, /^may/i, /^jun/i, /^jul/i, /^au/i, /^s/i, /^o/i, /^n/i, /^d/i]
 }
 
-var matchTimesOfDayPatterns = {
-  short: /^(am|pm)/i,
-  long: /^([ap]\.?\s?m\.?)/i
+var matchDayPatterns = {
+  narrow: /^[smtwf]/i,
+  short: /^(su|mo|tu|we|th|fr|sa)/i,
+  abbreviated: /^(sun|mon|tue|wed|thu|fri|sat)/i,
+  wide: /^(sunday|monday|tuesday|wednesday|thursday|friday|saturday)/i
+}
+var parseDayPatterns = {
+  narrow: [/^s/i, /^m/i, /^t/i, /^w/i, /^t/i, /^f/i, /^s/i],
+  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i]
 }
 
-var parseTimeOfDayPatterns = {
-  any: [/^a/i, /^p/i]
+var matchDayPeriodPatterns = {
+  narrow: /^(a|p|mi|n|(in the|at) (morning|afternoon|evening|night))/i,
+  any: /^([ap]\.?\s?m\.?|midnight|noon|(in the|at) (morning|afternoon|evening|night))/i
+}
+var parseDayPeriodPatterns = {
+  any: {
+    am: /^a/i,
+    pm: /^p/i,
+    midnight: /^mi/i,
+    noon: /^no/i,
+    morning: /morning/i,
+    afternoon: /afternoon/i,
+    evening: /evening/i,
+    night: /night/i
+  }
 }
 
 var match = {
-  ordinalNumbers: buildMatchPatternFn(matchOrdinalNumbersPattern),
-  ordinalNumber: parseDecimal,
-  weekdays: buildMatchFn(matchWeekdaysPatterns, 'long'),
-  weekday: buildParseFn(parseWeekdayPatterns, 'any'),
-  months: buildMatchFn(matchMonthsPatterns, 'long'),
-  month: buildParseFn(parseMonthPatterns, 'any'),
-  timesOfDay: buildMatchFn(matchTimesOfDayPatterns, 'long'),
-  timeOfDay: buildParseFn(parseTimeOfDayPatterns, 'any')
+  ordinalNumber: buildMatchPatternFn({
+    matchPattern: matchOrdinalNumberPattern,
+    parsePattern: parseOrdinalNumberPattern,
+    valueCallback: function (value) {
+      return parseInt(value, 10)
+    }
+  }),
+
+  era: buildMatchFn({
+    matchPatterns: matchEraPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseEraPatterns,
+    defaultParseWidth: 'any'
+  }),
+
+  quarter: buildMatchFn({
+    matchPatterns: matchQuarterPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseQuarterPatterns,
+    defaultParseWidth: 'any',
+    valueCallback: function (index) {
+      return index + 1
+    }
+  }),
+
+  month: buildMatchFn({
+    matchPatterns: matchMonthPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseMonthPatterns,
+    defaultParseWidth: 'any'
+  }),
+
+  day: buildMatchFn({
+    matchPatterns: matchDayPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseDayPatterns,
+    defaultParseWidth: 'any'
+  }),
+
+  dayPeriod: buildMatchFn({
+    matchPatterns: matchDayPeriodPatterns,
+    defaultMatchWidth: 'any',
+    parsePatterns: parseDayPeriodPatterns,
+    defaultParseWidth: 'any'
+  })
 }
 
 export default match

--- a/src/locale/th/index.js
+++ b/src/locale/th/index.js
@@ -1,8 +1,8 @@
-// import formatDistance from './_lib/formatDistance/index.js'
-// import formatLong from './_lib/formatLong/index.js'
-// import formatRelative from './_lib/formatRelative/index.js'
-// import localize from './_lib/localize/index.js'
-// import match from './_lib/match/index.js'
+import formatDistance from './_lib/formatDistance/index.js'
+import formatLong from './_lib/formatLong/index.js'
+import formatRelative from './_lib/formatRelative/index.js'
+import localize from './_lib/localize/index.js'
+import match from './_lib/match/index.js'
 
 /**
  * @type {Locale}
@@ -12,19 +12,18 @@
  * @iso-639-2 tha
  * @author Athiwat Hirunworawongkun [@athivvat]{@link https://github.com/athivvat}
  * @author [@hawkup]{@link https://github.com/hawkup}
+ * @author  Jirawat I. [@nodtem66]{@link https://github.com/nodtem66}
  */
-// var locale = {
-//   formatDistance: formatDistance,
-//   formatLong: formatLong,
-//   formatRelative: formatRelative,
-//   localize: localize,
-//   match: match,
-//   options: {
-//     weekStartsOn: 1 /* Monday */,
-//     firstWeekContainsDate: 1
-//   }
-// }
+var locale = {
+  formatDistance: formatDistance,
+  formatLong: formatLong,
+  formatRelative: formatRelative,
+  localize: localize,
+  match: match,
+  options: {
+    weekStartsOn: 1 /* Monday */,
+    firstWeekContainsDate: 1
+  }
+}
 
-// export default locale
-
-throw new Error('th locale is currently unavailable. Please check the progress of converting this locale to v2.0.0 in this issue on Github: TBA')
+export default locale

--- a/src/locale/th/test.js
+++ b/src/locale/th/test.js
@@ -1,9 +1,277 @@
 // @flow
 /* eslint-env mocha */
 
-// import assert from 'power-assert'
-// import locale from '.'
+import assert from 'power-assert'
+import locale from '.'
 
-describe.skip('th locale', function () {
+import format from '../../format'
+import formatDistance from '../../formatDistance'
+import formatDistanceStrict from '../../formatDistanceStrict'
+import formatRelative from '../../formatRelative'
 
+describe('th locale', function () {
+  context('with `format`', function () {
+    var date = new Date(1986, 3 /* Apr */, 5, 10, 32, 0, 900)
+
+    it('era', function () {
+      var result = format(date, 'G, GGGG, GGGGG', {locale: locale})
+      assert(result === 'ค.ศ., คริสต์ศักราช, คศ')
+    })
+
+    describe('year', function () {
+      it('ordinal regular year', function () {
+        var result = format(date, "yo 'year'", {locale: locale})
+        assert(result === '1986 year')
+      })
+
+      it('ordinal local week-numbering year', function () {
+        var result = format(date, "Yo 'week-numbering year'", {locale: locale})
+        assert(result === '1986 week-numbering year')
+      })
+    })
+
+    describe('quarter', function () {
+      it('formatting quarter', function () {
+        var result = format(date, 'Qo, QQQ, QQQQ, QQQQQ', {locale: locale})
+        assert(result === '2, Q2, ไตรมาสที่สอง, 2')
+      })
+
+      it('stand-alone quarter', function () {
+        var result = format(date, 'qo, qqq, qqqq, qqqqq', {locale: locale})
+        assert(result === '2, Q2, ไตรมาสที่สอง, 2')
+      })
+    })
+
+    describe('month', function () {
+      it('formatting month', function () {
+        var result = format(date, 'do MMMM', {locale: locale})
+        assert(result === '5 เมษายน')
+      })
+
+      it('stand-alone month', function () {
+        var result = format(date, "'เดือนที่' Lo, LLL, LLLL, LLLLL", {locale: locale})
+        assert(result === 'เดือนที่ 4, เม.ย., เมษายน, เม.ย.')
+      })
+    })
+
+    describe('week', function () {
+      it('ordinal local week of year', function () {
+        var date = new Date(1986, 3 /* Apr */, 6)
+        var result = format(date, 'wo', {locale: locale})
+        assert(result === '14')
+      })
+
+      it('ordinal ISO week of year', function () {
+        var date = new Date(1986, 3 /* Apr */, 6)
+        var result = format(date, "'ISO week ที่' Io", {locale: locale})
+        assert(result === 'ISO week ที่ 14')
+      })
+    })
+
+    describe('day', function () {
+      it('ordinal date', function () {
+        var result = format(date, "'วันนี้วันที่' do", {locale: locale})
+        assert(result === 'วันนี้วันที่ 5')
+      })
+
+      it('ordinal day of year', function () {
+        var result = format(date, 'Do', {locale: locale})
+        assert(result === '95')
+      })
+    })
+
+    describe('week day', function () {
+      it('day of week', function () {
+        var result = format(date, 'E, EEEE, EEEEE, EEEEEE', {locale: locale})
+        assert(result === 'ส., เสาร์, ส., ส.')
+      })
+
+      it('ordinal day of week', function () {
+        var result = format(date, 'eo', {locale: locale})
+        assert(result === '6')
+      })
+    })
+
+    describe('day period and hour', function () {
+      it('ordinal hour', function () {
+        var result = format(date, 'ho', {locale: locale})
+        assert(result === '10')
+      })
+
+      it('AM, PM', function () {
+        var result = format(date, 'h a, h aaaa, haaaaa', {locale: locale})
+        assert(result === '10 น., 10 น., 10น')
+      })
+
+      it('AM, PM, noon, midnight', function () {
+        var result = format(new Date(1986, 3 /* Apr */, 6, 0), 'b, bbbb, bbbbb', {locale: locale})
+        assert(result === 'เที่ยงคืน, เที่ยงคืน, เที่ยงคืน')
+      })
+
+      it('flexible day periods', function () {
+        it('works as expected', function () {
+          var result = format(date, 'h B', {locale: locale})
+          assert(result === '10 ตอนเช้า')
+        })
+      })
+    })
+
+    it('ordinal minute', function () {
+      var result = format(date, "'นาทีที่' mo", {locale: locale})
+      assert(result === 'นาทีที่ 32')
+    })
+
+    it('ordinal second', function () {
+      var result = format(date, 'so', {locale: locale})
+      assert(result === '0')
+    })
+
+    describe('long format', function () {
+      it('short date', function () {
+        var result = format(date, 'P', {locale: locale})
+        assert(result === '05/04/1986')
+      })
+
+      it('medium date', function () {
+        var result = format(date, 'PP', {locale: locale})
+        assert(result === '5 เม.ย. 1986')
+      })
+
+      it('long date', function () {
+        var result = format(date, 'PPP', {locale: locale})
+        assert(result === '5 เมษายน 1986')
+      })
+
+      it('full date', function () {
+        var result = format(date, 'PPPP', {locale: locale})
+        assert(result === 'วันเสาร์ที่ 5 เมษายน 1986')
+      })
+
+      it('short time', function () {
+        var result = format(date, 'p', {locale: locale})
+        assert(result === '10:32 น.')
+      })
+
+      it('medium time', function () {
+        var result = format(date, 'pp', {locale: locale})
+        assert(result === '10:32:00 น.')
+      })
+
+      it('short date + time', function () {
+        var result = format(date, 'Pp', {locale: locale})
+        assert(result === '05/04/1986, 10:32 น.')
+      })
+
+      it('medium date + time', function () {
+        var result = format(date, 'PPpp', {locale: locale})
+        assert(result === '5 เม.ย. 1986, 10:32:00 น.')
+      })
+
+      it('long date + time', function () {
+        var result = format(date, 'PPPp', {locale: locale})
+        assert(result === '5 เมษายน 1986 เวลา 10:32 น.')
+      })
+
+      it('full date + time', function () {
+        var result = format(date, 'PPPPp', {locale: locale})
+        assert(result === 'วันเสาร์ที่ 5 เมษายน 1986 เวลา 10:32 น.')
+      })
+    })
+  })
+
+  context('with `formatDistance`', function () {
+    it('works as expected', function () {
+      var result = formatDistance(
+        new Date(1986, 3, 4, 10, 32, 25),
+        new Date(1986, 3, 4, 10, 32, 0),
+        {locale: locale, includeSeconds: true}
+      )
+      assert(result === 'ครึ่งนาที')
+    })
+
+    context('when `addSuffix` option is true', function () {
+      it('adds a future suffix', function () {
+        var result = formatDistance(
+          new Date(1986, 3, 4, 10, 32, 7),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {locale: locale, includeSeconds: true, addSuffix: true}
+        )
+        assert(result === 'ใน น้อยกว่า 10 วินาที')
+      })
+
+      it('adds a past suffix', function () {
+        var result = formatDistance(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 11, 32, 0),
+          {locale: locale, addSuffix: true}
+        )
+        assert(result === 'ประมาณ 1 ชั่วโมงที่ผ่านมา')
+      })
+    })
+  })
+
+  context('with `formatDistanceStrict`', function () {
+    it('works as expected', function () {
+      var result = formatDistanceStrict(
+        new Date(1986, 3, 4, 10, 32, 0),
+        new Date(1986, 3, 4, 12, 32, 0),
+        {locale: locale, unit: 'minute'}
+      )
+      assert(result === '120 นาที')
+    })
+
+    describe('when `addSuffix` option is true', function () {
+      it('adds a future suffix', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 25),
+          new Date(1986, 3, 4, 10, 32, 0),
+          {locale: locale, addSuffix: true}
+        )
+        assert(result === 'ใน 25 วินาที')
+      })
+
+      it('adds a past suffix', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 11, 32, 0),
+          {locale: locale, addSuffix: true}
+        )
+        assert(result === '1 ชั่วโมงที่ผ่านมา')
+      })
+    })
+  })
+
+  context('with `formatRelative`', function () {
+    var baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900)
+
+    it('last week', function () {
+      var result = formatRelative(new Date(1986, 3 /* Apr */, 1), baseDate, {locale: locale})
+      assert(result === 'อังคารที่แล้วเวลา 12:00 น.')
+    })
+
+    it('yesterday', function () {
+      var result = formatRelative(new Date(1986, 3 /* Apr */, 3, 22, 22), baseDate, {locale: locale})
+      assert(result === 'เมื่อวานนี้เวลา 10:22 น.')
+    })
+
+    it('today', function () {
+      var result = formatRelative(new Date(1986, 3 /* Apr */, 4, 16, 50), baseDate, {locale: locale})
+      assert(result === 'วันนี้เวลา 4:50 น.')
+    })
+
+    it('tomorrow', function () {
+      var result = formatRelative(new Date(1986, 3 /* Apr */, 5, 7, 30), baseDate, {locale: locale})
+      assert(result === 'พรุ่งนี้เวลา 7:30 น.')
+    })
+
+    it('next week', function () {
+      var result = formatRelative(new Date(1986, 3 /* Apr */, 6, 12, 0), baseDate, {locale: locale})
+      assert(result === 'อาทิตย์ เวลา 12:00 น.')
+    })
+
+    it('after the next week', function () {
+      var result = formatRelative(new Date(1986, 3 /* Apr */, 11, 16, 50), baseDate, {locale: locale})
+      assert(result === '11/04/1986')
+    })
+  })
 })


### PR DESCRIPTION
Add Thai language support for date-fns v2.0

Parsing date strings is left unimplemented.
The code from `match/index.js` is copied from locale en-US.