### PR TITLE
`parse` strict validation

### DIFF
--- a/src/locale/_lib/buildMatchFn/index.js
+++ b/src/locale/_lib/buildMatchFn/index.js
@@ -26,6 +26,7 @@ export default function buildMatchFn (args) {
     }
 
     value = args.valueCallback ? args.valueCallback(value) : value
+    value = options.valueCallback ? options.valueCallback(value) : value
 
     return {
       value: value,

--- a/src/locale/_lib/buildMatchPatternFn/index.js
+++ b/src/locale/_lib/buildMatchPatternFn/index.js
@@ -1,6 +1,7 @@
 export default function buildMatchPatternFn (args) {
-  return function (dirtyString) {
+  return function (dirtyString, dirtyOptions) {
     var string = String(dirtyString)
+    var options = dirtyOptions || {}
 
     var matchResult = string.match(args.matchPattern)
     if (!matchResult) {
@@ -13,6 +14,7 @@ export default function buildMatchPatternFn (args) {
       return null
     }
     var value = args.valueCallback ? args.valueCallback(parseResult[0]) : parseResult[0]
+    value = options.valueCallback ? options.valueCallback(value) : value
 
     return {
       value: value,

--- a/src/parse/_lib/parsers/index.js
+++ b/src/parse/_lib/parsers/index.js
@@ -271,6 +271,9 @@ var parsers = {
           return parseNDigits(token.length, string, valueCallback)
       }
     },
+    validate: function (date, value, options) {
+      return value.isTwoDigitYear || value.year > 0
+    },
     set: function (date, value, options) {
       var currentYear = getUTCWeekYear(date, options)
 
@@ -307,6 +310,9 @@ var parsers = {
         default:
           return parseNDigits(token.length, string, valueCallback)
       }
+    },
+    validate: function (date, value, options) {
+      return value.isTwoDigitYear || value.year > 0
     },
     set: function (date, value, options) {
       var currentYear = date.getUTCFullYear()
@@ -511,6 +517,7 @@ var parsers = {
       }
     },
     validate: function (date, value, options) {
+      console.log({value})
       return value >= 0 && value <= 11
     },
     set: function (date, value, options) {
@@ -665,7 +672,8 @@ var parsers = {
     priority: 90,
     parse: function (string, token, match, options) {
       var valueCallback = function (value) {
-        return (value + options.weekStartsOn + 6) % 7
+        var wholeWeekDays = Math.floor((value - 1) / 7) * 7
+        return (value + options.weekStartsOn + 6) % 7 + wholeWeekDays
       }
 
       switch (token) {
@@ -712,7 +720,8 @@ var parsers = {
     priority: 90,
     parse: function (string, token, match, options) {
       var valueCallback = function (value) {
-        return (value + options.weekStartsOn + 6) % 7
+        var wholeWeekDays = Math.floor((value - 1) / 7) * 7
+        return (value + options.weekStartsOn + 6) % 7 + wholeWeekDays
       }
 
       switch (token) {
@@ -758,6 +767,13 @@ var parsers = {
   i: {
     priority: 90,
     parse: function (string, token, match, options) {
+      var valueCallback = function (value) {
+        if (value === 0) {
+          return 7
+        }
+        return value
+      }
+
       switch (token) {
         // 2
         case 'i':
@@ -768,30 +784,30 @@ var parsers = {
           return match.ordinalNumber(string, {unit: 'day'})
         // Tue
         case 'iii':
-          return match.day(string, {width: 'abbreviated', context: 'formatting'}) ||
-            match.day(string, {width: 'short', context: 'formatting'}) ||
-            match.day(string, {width: 'narrow', context: 'formatting'})
+          return match.day(string, {width: 'abbreviated', context: 'formatting', valueCallback: valueCallback}) ||
+            match.day(string, {width: 'short', context: 'formatting', valueCallback: valueCallback}) ||
+            match.day(string, {width: 'narrow', context: 'formatting', valueCallback: valueCallback})
         // T
         case 'iiiii':
-          return match.day(string, {width: 'narrow', context: 'formatting'})
+          return match.day(string, {width: 'narrow', context: 'formatting', valueCallback: valueCallback})
         // Tu
         case 'iiiiii':
-          return match.day(string, {width: 'short', context: 'formatting'}) ||
-          match.day(string, {width: 'narrow', context: 'formatting'})
+          return match.day(string, {width: 'short', context: 'formatting', valueCallback: valueCallback}) ||
+          match.day(string, {width: 'narrow', context: 'formatting', valueCallback: valueCallback})
         // Tuesday
         case 'iiii':
         default:
-          return match.day(string, {width: 'wide', context: 'formatting'}) ||
-            match.day(string, {width: 'abbreviated', context: 'formatting'}) ||
-            match.day(string, {width: 'short', context: 'formatting'}) ||
-            match.day(string, {width: 'narrow', context: 'formatting'})
+          return match.day(string, {width: 'wide', context: 'formatting', valueCallback: valueCallback}) ||
+            match.day(string, {width: 'abbreviated', context: 'formatting', valueCallback: valueCallback}) ||
+            match.day(string, {width: 'short', context: 'formatting', valueCallback: valueCallback}) ||
+            match.day(string, {width: 'narrow', context: 'formatting', valueCallback: valueCallback})
       }
     },
     validate: function (date, value, options) {
-      return value >= 0 && value <= 6
+      return value >= 1 && value <= 7
     },
     set: function (date, value, options) {
-      date = setUTCISODay(date, value % 7 || 7, options)
+      date = setUTCISODay(date, value, options)
       date.setUTCHours(0, 0, 0, 0)
       return date
     }

--- a/src/parse/_lib/parsers/index.js
+++ b/src/parse/_lib/parsers/index.js
@@ -42,15 +42,17 @@ var timezonePatterns = {
   extendedOptionalSeconds: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?|Z/
 }
 
-function parseNumericPattern (pattern, string) {
+function parseNumericPattern (pattern, string, valueCallback) {
   var matchResult = string.match(pattern)
 
   if (!matchResult) {
     return null
   }
 
+  var value = parseInt(matchResult[0], 10)
+
   return {
-    value: parseInt(matchResult[0], 10),
+    value: valueCallback ? valueCallback(value) : value,
     rest: string.slice(matchResult[0].length)
   }
 }
@@ -85,37 +87,37 @@ function parseTimezonePattern (pattern, string) {
   }
 }
 
-function parseAnyDigitsSigned (string) {
-  return parseNumericPattern(numericPatterns.anyDigitsSigned, string)
+function parseAnyDigitsSigned (string, valueCallback) {
+  return parseNumericPattern(numericPatterns.anyDigitsSigned, string, valueCallback)
 }
 
-function parseNDigits (n, string) {
+function parseNDigits (n, string, valueCallback) {
   switch (n) {
     case 1:
-      return parseNumericPattern(numericPatterns.singleDigit, string)
+      return parseNumericPattern(numericPatterns.singleDigit, string, valueCallback)
     case 2:
-      return parseNumericPattern(numericPatterns.twoDigits, string)
+      return parseNumericPattern(numericPatterns.twoDigits, string, valueCallback)
     case 3:
-      return parseNumericPattern(numericPatterns.threeDigits, string)
+      return parseNumericPattern(numericPatterns.threeDigits, string, valueCallback)
     case 4:
-      return parseNumericPattern(numericPatterns.fourDigits, string)
+      return parseNumericPattern(numericPatterns.fourDigits, string, valueCallback)
     default:
-      return parseNumericPattern(new RegExp('^\\d{1,' + n + '}'), string)
+      return parseNumericPattern(new RegExp('^\\d{1,' + n + '}'), string, valueCallback)
   }
 }
 
-function parseNDigitsSigned (n, string) {
+function parseNDigitsSigned (n, string, valueCallback) {
   switch (n) {
     case 1:
-      return parseNumericPattern(numericPatterns.singleDigitSigned, string)
+      return parseNumericPattern(numericPatterns.singleDigitSigned, string, valueCallback)
     case 2:
-      return parseNumericPattern(numericPatterns.twoDigitsSigned, string)
+      return parseNumericPattern(numericPatterns.twoDigitsSigned, string, valueCallback)
     case 3:
-      return parseNumericPattern(numericPatterns.threeDigitsSigned, string)
+      return parseNumericPattern(numericPatterns.threeDigitsSigned, string, valueCallback)
     case 4:
-      return parseNumericPattern(numericPatterns.fourDigitsSigned, string)
+      return parseNumericPattern(numericPatterns.fourDigitsSigned, string, valueCallback)
     default:
-      return parseNumericPattern(new RegExp('^-?\\d{1,' + n + '}'), string)
+      return parseNumericPattern(new RegExp('^-?\\d{1,' + n + '}'), string, valueCallback)
   }
 }
 
@@ -224,7 +226,7 @@ var parsers = {
             match.era(string, {width: 'narrow'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       // Sets year 10 BC if BC, or 10 AC if AC
       date.setUTCFullYear(value === 1 ? 10 : -9, 0, 1)
       date.setUTCHours(0, 0, 0, 0)
@@ -245,26 +247,33 @@ var parsers = {
 
     priority: 130,
     parse: function (string, token, match, options) {
+      var valueCallback = function (year) {
+        return {
+          year: year,
+          isTwoDigitYear: token === 'yy'
+        }
+      }
+
       switch (token) {
         case 'y':
-          return parseNDigits(4, string)
+          return parseNDigits(4, string, valueCallback)
         case 'yo':
-          return match.ordinalNumber(string, {unit: 'year'})
+          return match.ordinalNumber(string, {unit: 'year', valueCallback: valueCallback})
         default:
-          return parseNDigits(token.length, string)
+          return parseNDigits(token.length, string, valueCallback)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       var currentYear = getUTCWeekYear(date, options)
 
-      if (token === 'yy') {
-        var normalizedTwoDigitYear = normalizeTwoDigitYear(value, currentYear)
+      if (value.isTwoDigitYear) {
+        var normalizedTwoDigitYear = normalizeTwoDigitYear(value.year, currentYear)
         date.setUTCFullYear(normalizedTwoDigitYear, 0, 1)
         date.setUTCHours(0, 0, 0, 0)
         return date
       }
 
-      var year = currentYear > 0 ? value : 1 - value
+      var year = currentYear > 0 ? value.year : 1 - value.year
       date.setUTCFullYear(year, 0, 1)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -275,26 +284,33 @@ var parsers = {
   Y: {
     priority: 130,
     parse: function (string, token, match, options) {
+      var valueCallback = function (year) {
+        return {
+          year: year,
+          isTwoDigitYear: token === 'YY'
+        }
+      }
+
       switch (token) {
         case 'Y':
-          return parseNDigits(4, string)
+          return parseNDigits(4, string, valueCallback)
         case 'Yo':
-          return match.ordinalNumber(string, {unit: 'year'})
+          return match.ordinalNumber(string, {unit: 'year', valueCallback: valueCallback})
         default:
-          return parseNDigits(token.length, string)
+          return parseNDigits(token.length, string, valueCallback)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       var currentYear = date.getUTCFullYear()
 
-      if (token === 'YY') {
-        var normalizedTwoDigitYear = normalizeTwoDigitYear(value, currentYear)
+      if (value.isTwoDigitYear) {
+        var normalizedTwoDigitYear = normalizeTwoDigitYear(value.year, currentYear)
         date.setUTCFullYear(normalizedTwoDigitYear, 0, options.firstWeekContainsDate)
         date.setUTCHours(0, 0, 0, 0)
         return startOfUTCWeek(date, options)
       }
 
-      var year = currentYear > 0 ? value : 1 - value
+      var year = currentYear > 0 ? value.year : 1 - value.year
       date.setUTCFullYear(year, 0, options.firstWeekContainsDate)
       date.setUTCHours(0, 0, 0, 0)
       return startOfUTCWeek(date, options)
@@ -311,7 +327,7 @@ var parsers = {
 
       return parseNDigitsSigned(token.length, string)
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       var firstWeekOfYear = new Date(0)
       firstWeekOfYear.setUTCFullYear(value, 0, 4)
       firstWeekOfYear.setUTCHours(0, 0, 0, 0)
@@ -329,7 +345,7 @@ var parsers = {
 
       return parseNDigitsSigned(token.length, string)
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCFullYear(value, 0, 1)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -363,7 +379,7 @@ var parsers = {
             match.quarter(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCMonth((value - 1) * 3, 1)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -397,7 +413,7 @@ var parsers = {
             match.quarter(string, {width: 'narrow', context: 'standalone'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCMonth((value - 1) * 3, 1)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -408,16 +424,20 @@ var parsers = {
   M: {
     priority: 110,
     parse: function (string, token, match, options) {
+      var valueCallback = function (value) {
+        return value - 1
+      }
+
       switch (token) {
         // 1, 2, ..., 12
         case 'M':
-          return parseNumericPattern(numericPatterns.month, string)
+          return parseNumericPattern(numericPatterns.month, string, valueCallback)
         // 01, 02, ..., 12
         case 'MM':
-          return parseNDigits(2, string)
+          return parseNDigits(2, string, valueCallback)
         // 1st, 2nd, ..., 12th
         case 'Mo':
-          return match.ordinalNumber(string, {unit: 'month'})
+          return match.ordinalNumber(string, {unit: 'month', valueCallback: valueCallback})
         // Jan, Feb, ..., Dec
         case 'MMM':
           return match.month(string, {width: 'abbreviated', context: 'formatting'}) ||
@@ -433,10 +453,7 @@ var parsers = {
             match.month(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
-      if (token === 'M' || token === 'Mo' || token === 'MM') {
-        value = value - 1
-      }
+    set: function (date, value, options) {
       date.setUTCMonth(value, 1)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -447,16 +464,20 @@ var parsers = {
   L: {
     priority: 110,
     parse: function (string, token, match, options) {
+      var valueCallback = function (value) {
+        return value - 1
+      }
+
       switch (token) {
         // 1, 2, ..., 12
         case 'L':
-          return parseNumericPattern(numericPatterns.month, string)
+          return parseNumericPattern(numericPatterns.month, string, valueCallback)
         // 01, 02, ..., 12
         case 'LL':
-          return parseNDigits(2, string)
+          return parseNDigits(2, string, valueCallback)
         // 1st, 2nd, ..., 12th
         case 'Lo':
-          return match.ordinalNumber(string, {unit: 'month'})
+          return match.ordinalNumber(string, {unit: 'month', valueCallback: valueCallback})
         // Jan, Feb, ..., Dec
         case 'LLL':
           return match.month(string, {width: 'abbreviated', context: 'standalone'}) ||
@@ -472,10 +493,7 @@ var parsers = {
             match.month(string, {width: 'narrow', context: 'standalone'})
       }
     },
-    set: function (date, value, token, options) {
-      if (token === 'L' || token === 'Lo' || token === 'LL') {
-        value = value - 1
-      }
+    set: function (date, value, options) {
       date.setUTCMonth(value, 1)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -495,7 +513,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       return startOfUTCWeek(setUTCWeek(date, value, options), options)
     }
   },
@@ -513,7 +531,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       return startOfUTCISOWeek(setUTCISOWeek(date, value, options), options)
     }
   },
@@ -531,7 +549,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCDate(value)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -552,7 +570,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCMonth(0, value)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -587,7 +605,7 @@ var parsers = {
             match.day(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date = setUTCDay(date, value, options)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -598,14 +616,18 @@ var parsers = {
   e: {
     priority: 90,
     parse: function (string, token, match, options) {
+      var valueCallback = function (value) {
+        return (value + options.weekStartsOn + 6) % 7
+      }
+
       switch (token) {
         // 3
         case 'e':
         case 'ee': // 03
-          return parseNDigits(token.length, string)
+          return parseNDigits(token.length, string, valueCallback)
         // 3rd
         case 'eo':
-          return match.ordinalNumber(string, {unit: 'day'})
+          return match.ordinalNumber(string, {unit: 'day', valueCallback: valueCallback})
         // Tue
         case 'eee':
           return match.day(string, {width: 'abbreviated', context: 'formatting'}) ||
@@ -627,10 +649,7 @@ var parsers = {
             match.day(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
-      if (token === 'e' || token === 'ee' || token === 'eo') {
-        value = (value + options.weekStartsOn + 6) % 7
-      }
+    set: function (date, value, options) {
       date = setUTCDay(date, value, options)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -641,14 +660,18 @@ var parsers = {
   c: {
     priority: 90,
     parse: function (string, token, match, options) {
+      var valueCallback = function (value) {
+        return (value + options.weekStartsOn + 6) % 7
+      }
+
       switch (token) {
         // 3
         case 'c':
         case 'cc': // 03
-          return parseNDigits(token.length, string)
+          return parseNDigits(token.length, string, valueCallback)
         // 3rd
         case 'co':
-          return match.ordinalNumber(string, {unit: 'day'})
+          return match.ordinalNumber(string, {unit: 'day', valueCallback: valueCallback})
         // Tue
         case 'ccc':
           return match.day(string, {width: 'abbreviated', context: 'standalone'}) ||
@@ -670,10 +693,7 @@ var parsers = {
             match.day(string, {width: 'narrow', context: 'standalone'})
       }
     },
-    set: function (date, value, token, options) {
-      if (token === 'c' || token === 'cc' || token === 'co') {
-        value = (value + options.weekStartsOn + 6) % 7
-      }
+    set: function (date, value, options) {
       date = setUTCDay(date, value, options)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -713,7 +733,7 @@ var parsers = {
             match.day(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date = setUTCISODay(date, value % 7 || 7, options)
       date.setUTCHours(0, 0, 0, 0)
       return date
@@ -739,7 +759,7 @@ var parsers = {
             match.dayPeriod(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCHours(dayPeriodEnumToHours(value), 0, 0, 0)
       return date
     }
@@ -764,7 +784,7 @@ var parsers = {
             match.dayPeriod(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCHours(dayPeriodEnumToHours(value), 0, 0, 0)
       return date
     }
@@ -789,7 +809,7 @@ var parsers = {
             match.dayPeriod(string, {width: 'narrow', context: 'formatting'})
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCHours(dayPeriodEnumToHours(value), 0, 0, 0)
       return date
     }
@@ -808,7 +828,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       var isPM = date.getUTCHours() >= 12
       if (isPM && value < 12) {
         date.setUTCHours(value + 12, 0, 0, 0)
@@ -834,7 +854,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCHours(value, 0, 0, 0)
       return date
     }
@@ -853,7 +873,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       var isPM = date.getUTCHours() >= 12
       if (isPM && value < 12) {
         date.setUTCHours(value + 12, 0, 0, 0)
@@ -877,7 +897,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       var hours = value <= 24 ? value % 24 : value
       date.setUTCHours(hours, 0, 0, 0)
       return date
@@ -897,7 +917,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCMinutes(value, 0, 0)
       return date
     }
@@ -916,7 +936,7 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       date.setUTCSeconds(value, 0)
       return date
     }
@@ -926,11 +946,13 @@ var parsers = {
   S: {
     priority: 40,
     parse: function (string, token, match, options) {
-      return parseNDigits(token.length, string)
+      var valueCallback = function (value) {
+        return Math.floor(value * Math.pow(10, -token.length + 3))
+      }
+      return parseNDigits(token.length, string, valueCallback)
     },
-    set: function (date, value, token, options) {
-      var milliseconds = Math.floor(value * Math.pow(10, -token.length + 3))
-      date.setUTCMilliseconds(milliseconds)
+    set: function (date, value, options) {
+      date.setUTCMilliseconds(value)
       return date
     }
   },
@@ -953,7 +975,7 @@ var parsers = {
           return parseTimezonePattern(timezonePatterns.extended, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       return new Date(date.getTime() - value)
     }
   },
@@ -976,7 +998,7 @@ var parsers = {
           return parseTimezonePattern(timezonePatterns.extended, string)
       }
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       return new Date(date.getTime() - value)
     }
   },
@@ -987,7 +1009,7 @@ var parsers = {
     parse: function (string, token, match, options) {
       return parseAnyDigitsSigned(string)
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       return new Date(value * 1000)
     }
   },
@@ -998,7 +1020,7 @@ var parsers = {
     parse: function (string, token, match, options) {
       return parseAnyDigitsSigned(string)
     },
-    set: function (date, value, token, options) {
+    set: function (date, value, options) {
       return new Date(value)
     }
   }

--- a/src/parse/_lib/parsers/index.js
+++ b/src/parse/_lib/parsers/index.js
@@ -160,6 +160,14 @@ function normalizeTwoDigitYear (twoDigitYear, currentYear) {
   return isCommonEra ? result : 1 - result
 }
 
+var DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+var DAYS_IN_MONTH_LEAP_YEAR = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+// User for validation
+function isLeapYearIndex (year) {
+  return year % 400 === 0 || (year % 4 === 0 && year % 100 !== 0)
+}
+
 /*
  * |     | Unit                           |     | Unit                           |
  * |-----|--------------------------------|-----|--------------------------------|
@@ -379,6 +387,9 @@ var parsers = {
             match.quarter(string, {width: 'narrow', context: 'formatting'})
       }
     },
+    validate: function (date, value, options) {
+      return value >= 1 && value <= 4
+    },
     set: function (date, value, options) {
       date.setUTCMonth((value - 1) * 3, 1)
       date.setUTCHours(0, 0, 0, 0)
@@ -412,6 +423,9 @@ var parsers = {
             match.quarter(string, {width: 'abbreviated', context: 'standalone'}) ||
             match.quarter(string, {width: 'narrow', context: 'standalone'})
       }
+    },
+    validate: function (date, value, options) {
+      return value >= 1 && value <= 4
     },
     set: function (date, value, options) {
       date.setUTCMonth((value - 1) * 3, 1)
@@ -453,6 +467,9 @@ var parsers = {
             match.month(string, {width: 'narrow', context: 'formatting'})
       }
     },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 11
+    },
     set: function (date, value, options) {
       date.setUTCMonth(value, 1)
       date.setUTCHours(0, 0, 0, 0)
@@ -493,6 +510,9 @@ var parsers = {
             match.month(string, {width: 'narrow', context: 'standalone'})
       }
     },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 11
+    },
     set: function (date, value, options) {
       date.setUTCMonth(value, 1)
       date.setUTCHours(0, 0, 0, 0)
@@ -513,6 +533,9 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
+    validate: function (date, value, options) {
+      return value >= 1 && value <= 53
+    },
     set: function (date, value, options) {
       return startOfUTCWeek(setUTCWeek(date, value, options), options)
     }
@@ -531,6 +554,9 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
+    validate: function (date, value, options) {
+      return value >= 1 && value <= 53
+    },
     set: function (date, value, options) {
       return startOfUTCISOWeek(setUTCISOWeek(date, value, options), options)
     }
@@ -547,6 +573,16 @@ var parsers = {
           return match.ordinalNumber(string, {unit: 'date'})
         default:
           return parseNDigits(token.length, string)
+      }
+    },
+    validate: function (date, value, options) {
+      var year = date.getUTCFullYear()
+      var isLeapYear = isLeapYearIndex(year)
+      var month = date.getUTCMonth()
+      if (isLeapYear) {
+        return value >= 1 && value <= DAYS_IN_MONTH_LEAP_YEAR[month]
+      } else {
+        return value >= 1 && value <= DAYS_IN_MONTH[month]
       }
     },
     set: function (date, value, options) {
@@ -568,6 +604,15 @@ var parsers = {
           return match.ordinalNumber(string, {unit: 'date'})
         default:
           return parseNDigits(token.length, string)
+      }
+    },
+    validate: function (date, value, options) {
+      var year = date.getUTCFullYear()
+      var isLeapYear = isLeapYearIndex(year)
+      if (isLeapYear) {
+        return value >= 1 && value <= 366
+      } else {
+        return value >= 1 && value <= 365
       }
     },
     set: function (date, value, options) {
@@ -604,6 +649,9 @@ var parsers = {
             match.day(string, {width: 'short', context: 'formatting'}) ||
             match.day(string, {width: 'narrow', context: 'formatting'})
       }
+    },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 6
     },
     set: function (date, value, options) {
       date = setUTCDay(date, value, options)
@@ -649,6 +697,9 @@ var parsers = {
             match.day(string, {width: 'narrow', context: 'formatting'})
       }
     },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 6
+    },
     set: function (date, value, options) {
       date = setUTCDay(date, value, options)
       date.setUTCHours(0, 0, 0, 0)
@@ -693,6 +744,9 @@ var parsers = {
             match.day(string, {width: 'narrow', context: 'standalone'})
       }
     },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 6
+    },
     set: function (date, value, options) {
       date = setUTCDay(date, value, options)
       date.setUTCHours(0, 0, 0, 0)
@@ -732,6 +786,9 @@ var parsers = {
             match.day(string, {width: 'short', context: 'formatting'}) ||
             match.day(string, {width: 'narrow', context: 'formatting'})
       }
+    },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 6
     },
     set: function (date, value, options) {
       date = setUTCISODay(date, value % 7 || 7, options)
@@ -828,6 +885,9 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
+    validate: function (date, value, options) {
+      return value >= 1 && value <= 12
+    },
     set: function (date, value, options) {
       var isPM = date.getUTCHours() >= 12
       if (isPM && value < 12) {
@@ -854,6 +914,9 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 23
+    },
     set: function (date, value, options) {
       date.setUTCHours(value, 0, 0, 0)
       return date
@@ -872,6 +935,9 @@ var parsers = {
         default:
           return parseNDigits(token.length, string)
       }
+    },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 11
     },
     set: function (date, value, options) {
       var isPM = date.getUTCHours() >= 12
@@ -897,6 +963,9 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
+    validate: function (date, value, options) {
+      return value >= 1 && value <= 24
+    },
     set: function (date, value, options) {
       var hours = value <= 24 ? value % 24 : value
       date.setUTCHours(hours, 0, 0, 0)
@@ -917,6 +986,9 @@ var parsers = {
           return parseNDigits(token.length, string)
       }
     },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 59
+    },
     set: function (date, value, options) {
       date.setUTCMinutes(value, 0, 0)
       return date
@@ -935,6 +1007,9 @@ var parsers = {
         default:
           return parseNDigits(token.length, string)
       }
+    },
+    validate: function (date, value, options) {
+      return value >= 0 && value <= 59
     },
     set: function (date, value, options) {
       date.setUTCSeconds(value, 0)

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -365,8 +365,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
         priority: parser.priority,
         set: parser.set,
         value: parseResult.value,
-        index: setters.length,
-        token: token
+        index: setters.length
       })
 
       dateString = parseResult.rest
@@ -421,7 +420,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
 
   for (i = 0; i < uniquePrioritySetters.length; i++) {
     var setter = uniquePrioritySetters[i]
-    utcDate = setter.set(utcDate, setter.value, setter.token, subFnOptions)
+    utcDate = setter.set(utcDate, setter.value, subFnOptions)
   }
 
   return utcDate

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -364,6 +364,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
       setters.push({
         priority: parser.priority,
         set: parser.set,
+        validate: parser.validate,
         value: parseResult.value,
         index: setters.length
       })
@@ -420,6 +421,11 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
 
   for (i = 0; i < uniquePrioritySetters.length; i++) {
     var setter = uniquePrioritySetters[i]
+
+    if (setter.validate && !setter.validate(utcDate, setter.value, subFnOptions)) {
+      return new Date(NaN)
+    }
+
     utcDate = setter.set(utcDate, setter.value, subFnOptions)
   }
 

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -258,10 +258,6 @@ var doubleQuoteRegExp = /''/g
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
- * @param {Boolean} [options.strictValidation=false] - if true, returns `Invalid Date`
- *   if the separate values are not within respective ranges,
- *   e.g. when parsing 13th month, 32nd day of month etc.
- *   If false or not set, overflows the values, e.g. the 13th month is the 1st month of the next year.
  * @returns {Date} the parsed date
  * @throws {TypeError} 3 arguments required
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
@@ -288,16 +284,6 @@ var doubleQuoteRegExp = /''/g
  *   {locale: eo}
  * )
  * //=> Sun Feb 28 2010 00:00:00
- *
- * @example
- * // Parsing 30th of February with strict validation:
- * var result = parse(
- *   '2014-02-30',
- *   'yyyy-MM-dd',
- *   new Date(),
- *   {strictValidation: true}
- * )
- * //=> Invalid Date
  */
 export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate, dirtyOptions) {
   if (arguments.length < 3) {
@@ -325,8 +311,6 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
     options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
-
-  var strictValidation = options.strictValidation
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {
@@ -438,7 +422,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   for (i = 0; i < uniquePrioritySetters.length; i++) {
     var setter = uniquePrioritySetters[i]
 
-    if (strictValidation && setter.validate && !setter.validate(utcDate, setter.value, subFnOptions)) {
+    if (setter.validate && !setter.validate(utcDate, setter.value, subFnOptions)) {
       return new Date(NaN)
     }
 

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -258,6 +258,10 @@ var doubleQuoteRegExp = /''/g
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
+ * @param {Boolean} [options.strictValidation=false] - if true, returns `Invalid Date`
+ *   if the separate values are not within respective ranges,
+ *   e.g. when parsing 13th month, 32nd day of month etc.
+ *   If false or not set, overflows the values, e.g. the 13th month is the 1st month of the next year.
  * @returns {Date} the parsed date
  * @throws {TypeError} 3 arguments required
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
@@ -284,6 +288,16 @@ var doubleQuoteRegExp = /''/g
  *   {locale: eo}
  * )
  * //=> Sun Feb 28 2010 00:00:00
+ *
+ * @example
+ * // Parsing 30th of February with strict validation:
+ * var result = parse(
+ *   '2014-02-30',
+ *   'yyyy-MM-dd',
+ *   new Date(),
+ *   {strictValidation: true}
+ * )
+ * //=> Invalid Date
  */
 export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate, dirtyOptions) {
   if (arguments.length < 3) {
@@ -311,6 +325,8 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
     options.firstWeekContainsDate == null
       ? defaultFirstWeekContainsDate
       : toInteger(options.firstWeekContainsDate)
+
+  var strictValidation = options.strictValidation
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {
@@ -422,7 +438,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   for (i = 0; i < uniquePrioritySetters.length; i++) {
     var setter = uniquePrioritySetters[i]
 
-    if (setter.validate && !setter.validate(utcDate, setter.value, subFnOptions)) {
+    if (strictValidation && setter.validate && !setter.validate(utcDate, setter.value, subFnOptions)) {
       return new Date(NaN)
     }
 

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -1006,188 +1006,188 @@ describe('parse', function () {
   describe('with `options.strictValidation` = true', function () {
     describe('calendar year', function () {
       it('returns `Invalid Date` for year zero', function () {
-        var result = parse('0', 'y', baseDate, {strictValidation: true})
+        var result = parse('0', 'y', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('works correctly for two-digit year zero', function () {
-        var result = parse('00', 'yy', baseDate, {strictValidation: true})
+        var result = parse('00', 'yy', baseDate)
         assert.deepEqual(result, new Date(2000, 0 /* Jan */, 1))
       })
     })
 
     describe('local week-numbering year', function () {
       it('returns `Invalid Date` for year zero', function () {
-        var result = parse('0', 'Y', baseDate, {strictValidation: true})
+        var result = parse('0', 'Y', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('works correctly for two-digit year zero', function () {
-        var result = parse('00', 'YY', baseDate, {strictValidation: true})
+        var result = parse('00', 'YY', baseDate)
         assert.deepEqual(result, new Date(1999, 11 /* Dec */, 26))
       })
     })
 
     describe('quarter (formatting)', function () {
       it('returns `Invalid Date` for invalid quarter', function () {
-        var result = parse('0', 'Q', baseDate, {strictValidation: true})
+        var result = parse('0', 'Q', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('quarter (stand-alone)', function () {
       it('returns `Invalid Date` for invalid quarter', function () {
-        var result = parse('5', 'q', baseDate, {strictValidation: true})
+        var result = parse('5', 'q', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('month (formatting)', function () {
       it('returns `Invalid Date` for invalid month', function () {
-        var result = parse('00', 'MM', baseDate, {strictValidation: true})
+        var result = parse('00', 'MM', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('month (stand-alone)', function () {
       it('returns `Invalid Date` for invalid month', function () {
-        var result = parse('13', 'LL', baseDate, {strictValidation: true})
+        var result = parse('13', 'LL', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('local week of year', function () {
       it('returns `Invalid Date` for invalid week', function () {
-        var result = parse('0', 'w', baseDate, {strictValidation: true})
+        var result = parse('0', 'w', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('ISO week of year', function () {
       it('returns `Invalid Date` for invalid week', function () {
-        var result = parse('54', 'II', baseDate, {strictValidation: true})
+        var result = parse('54', 'II', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('day of month', function () {
       it('returns `Invalid Date` for invalid day of the month', function () {
-        var result = parse('30', 'd', new Date(2012, 1 /* Feb */, 1), {strictValidation: true})
+        var result = parse('30', 'd', new Date(2012, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for 29th of February of non-leap year', function () {
-        var result = parse('29', 'd', new Date(2014, 1 /* Feb */, 1), {strictValidation: true})
+        var result = parse('29', 'd', new Date(2014, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
       it('parses 29th of February of leap year', function () {
-        var result = parse('29', 'd', new Date(2012, 1 /* Feb */, 1), {strictValidation: true})
+        var result = parse('29', 'd', new Date(2012, 1 /* Feb */, 1))
         assert.deepEqual(result, new Date(2012, 1 /* Feb */, 29))
       })
     })
 
     describe('day of year', function () {
       it('returns `Invalid Date` for invalid day of the year', function () {
-        var result = parse('0', 'D', baseDate, {strictValidation: true})
+        var result = parse('0', 'D', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for 366th day of non-leap year', function () {
-        var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1), {strictValidation: true})
+        var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
       it('parses 366th day of leap year', function () {
-        var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1), {strictValidation: true})
+        var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1))
         assert.deepEqual(result, new Date(2012, 11 /* Dec */, 31))
       })
     })
 
     describe('ISO day of week (formatting)', function () {
       it('returns `Invalid Date` for day zero', function () {
-        var result = parse('0', 'i', baseDate, {strictValidation: true})
+        var result = parse('0', 'i', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for eight day of week', function () {
-        var result = parse('8', 'i', baseDate, {strictValidation: true})
+        var result = parse('8', 'i', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('local day of week (formatting)', function () {
       it('returns `Invalid Date` for day zero', function () {
-        var result = parse('0', 'e', baseDate, {strictValidation: true})
+        var result = parse('0', 'e', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for eight day of week', function () {
-        var result = parse('8', 'e', baseDate, {strictValidation: true})
+        var result = parse('8', 'e', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('local day of week (stand-alone)', function () {
       it('returns `Invalid Date` for day zero', function () {
-        var result = parse('0', 'c', baseDate, {strictValidation: true})
+        var result = parse('0', 'c', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for eight day of week', function () {
-        var result = parse('8', 'c', baseDate, {strictValidation: true})
+        var result = parse('8', 'c', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('hour [1-12]', function () {
       it('returns `Invalid Date` for hour zero', function () {
-        var result = parse('00', 'hh', baseDate, {strictValidation: true})
+        var result = parse('00', 'hh', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for invalid hour', function () {
-        var result = parse('13', 'hh', baseDate, {strictValidation: true})
+        var result = parse('13', 'hh', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('hour [0-23]', function () {
       it('returns `Invalid Date` for invalid hour', function () {
-        var result = parse('24', 'HH', baseDate, {strictValidation: true})
+        var result = parse('24', 'HH', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('hour [0-11]', function () {
       it('returns `Invalid Date` for invalid hour', function () {
-        var result = parse('12', 'KK', baseDate, {strictValidation: true})
+        var result = parse('12', 'KK', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('hour [1-24]', function () {
       it('returns `Invalid Date` for hour zero', function () {
-        var result = parse('00', 'kk', baseDate, {strictValidation: true})
+        var result = parse('00', 'kk', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for invalid hour', function () {
-        var result = parse('25', 'kk', baseDate, {strictValidation: true})
+        var result = parse('25', 'kk', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('minute', function () {
       it('returns `Invalid Date` for invalid minute', function () {
-        var result = parse('60', 'mm', baseDate, {strictValidation: true})
+        var result = parse('60', 'mm', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
     describe('second', function () {
       it('returns `Invalid Date` for invalid second', function () {
-        var result = parse('60', 'ss', baseDate, {strictValidation: true})
+        var result = parse('60', 'ss', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -82,7 +82,7 @@ describe('parse', function () {
     })
   })
 
-  describe('Local week-numbering year', function () {
+  describe('local week-numbering year', function () {
     it('numeric', function () {
       var result = parse('2002', 'Y', baseDate)
       assert.deepEqual(result, new Date(2001, 11 /* Dec */, 30))
@@ -1000,6 +1000,196 @@ describe('parse', function () {
       // $ExpectedMistake
       var result = parse('2018', 'Y', baseDate, {weekStartsOn: 1 /* Mon */, firstWeekContainsDate: '4'})
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
+    })
+  })
+
+  describe('with `options.strictValidation` = true', function () {
+    describe('calendar year', function () {
+      it('returns `Invalid Date` for year zero', function () {
+        var result = parse('0', 'y', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('works correctly for two-digit year zero', function () {
+        var result = parse('00', 'yy', baseDate, {strictValidation: true})
+        assert.deepEqual(result, new Date(2000, 0 /* Jan */, 1))
+      })
+    })
+
+    describe('local week-numbering year', function () {
+      it('returns `Invalid Date` for year zero', function () {
+        var result = parse('0', 'Y', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('works correctly for two-digit year zero', function () {
+        var result = parse('00', 'YY', baseDate, {strictValidation: true})
+        assert.deepEqual(result, new Date(1999, 11 /* Dec */, 26))
+      })
+    })
+
+    describe('quarter (formatting)', function () {
+      it('returns `Invalid Date` for invalid quarter', function () {
+        var result = parse('0', 'Q', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('quarter (stand-alone)', function () {
+      it('returns `Invalid Date` for invalid quarter', function () {
+        var result = parse('5', 'q', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('month (formatting)', function () {
+      it('returns `Invalid Date` for invalid month', function () {
+        var result = parse('00', 'MM', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('month (stand-alone)', function () {
+      it('returns `Invalid Date` for invalid month', function () {
+        var result = parse('13', 'LL', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('local week of year', function () {
+      it('returns `Invalid Date` for invalid week', function () {
+        var result = parse('0', 'w', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('ISO week of year', function () {
+      it('returns `Invalid Date` for invalid week', function () {
+        var result = parse('54', 'II', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('day of month', function () {
+      it('returns `Invalid Date` for invalid day of the month', function () {
+        var result = parse('30', 'd', new Date(2012, 1 /* Feb */, 1), {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for 29th of February of non-leap year', function () {
+        var result = parse('29', 'd', new Date(2014, 1 /* Feb */, 1), {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('parses 29th of February of leap year', function () {
+        var result = parse('29', 'd', new Date(2012, 1 /* Feb */, 1), {strictValidation: true})
+        assert.deepEqual(result, new Date(2012, 1 /* Feb */, 29))
+      })
+    })
+
+    describe('day of year', function () {
+      it('returns `Invalid Date` for invalid day of the year', function () {
+        var result = parse('0', 'D', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for 366th day of non-leap year', function () {
+        var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1), {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('parses 366th day of leap year', function () {
+        var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1), {strictValidation: true})
+        assert.deepEqual(result, new Date(2012, 11 /* Dec */, 31))
+      })
+    })
+
+    describe('ISO day of week (formatting)', function () {
+      it('returns `Invalid Date` for day zero', function () {
+        var result = parse('0', 'i', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for eight day of week', function () {
+        var result = parse('8', 'i', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('local day of week (formatting)', function () {
+      it('returns `Invalid Date` for day zero', function () {
+        var result = parse('0', 'e', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for eight day of week', function () {
+        var result = parse('8', 'e', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('local day of week (stand-alone)', function () {
+      it('returns `Invalid Date` for day zero', function () {
+        var result = parse('0', 'c', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for eight day of week', function () {
+        var result = parse('8', 'c', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('hour [1-12]', function () {
+      it('returns `Invalid Date` for hour zero', function () {
+        var result = parse('00', 'hh', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for invalid hour', function () {
+        var result = parse('13', 'hh', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('hour [0-23]', function () {
+      it('returns `Invalid Date` for invalid hour', function () {
+        var result = parse('24', 'HH', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('hour [0-11]', function () {
+      it('returns `Invalid Date` for invalid hour', function () {
+        var result = parse('12', 'KK', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('hour [1-24]', function () {
+      it('returns `Invalid Date` for hour zero', function () {
+        var result = parse('00', 'kk', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+
+      it('returns `Invalid Date` for invalid hour', function () {
+        var result = parse('25', 'kk', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('minute', function () {
+      it('returns `Invalid Date` for invalid minute', function () {
+        var result = parse('60', 'mm', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    describe('second', function () {
+      it('returns `Invalid Date` for invalid second', function () {
+        var result = parse('60', 'ss', baseDate, {strictValidation: true})
+        assert(result instanceof Date && isNaN(result))
+      })
     })
   })
 


### PR DESCRIPTION
Adds new option `strictValidation` for resolving this issue: #781

I actually feel like strict validation should be parse's behaviour by default. What do you think?