### PR TITLE
#810 Correct short and abbreviated dayValues for de locale

### DIFF
--- a/src/locale/de/_lib/localize/index.js
+++ b/src/locale/de/_lib/localize/index.js
@@ -24,8 +24,8 @@ var monthValues = {
 
 var dayValues = {
   narrow: ['S', 'M', 'D', 'M', 'D', 'F', 'S'],
-  short: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
-  abbreviated: ['Son', 'Mon', 'Die', 'Mit', 'Don', 'Fre', 'Sam'],
+  short: ['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
+  abbreviated: ['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
   wide: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag']
 }
 

--- a/src/locale/de/test.js
+++ b/src/locale/de/test.js
@@ -84,7 +84,7 @@ describe('de locale', function () {
     describe('week day', function () {
       it('day of week', function () {
         var result = format(date, 'E, EEEE, EEEEE, EEEEEE', {locale: locale})
-        assert(result === 'Sam, Samstag, S, Sa')
+        assert(result === 'Sa., Samstag, S, Sa.')
       })
 
       it('ordinal day of week', function () {


### PR DESCRIPTION
The values are taken from https://www.unicode.org/cldr/charts/32/summary/de.html#1844, using "Days - (abbreviated|short) - Formatting".
Alternatively, the short values could be left as is (without the period). According to the CLDR table, that's the Swiss locale, but it would provide a two-letter version matching the English locale.