### PR TITLE
Added three new week helper functions: getWeekendsBetween, getWeekend…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ for the list of changes made since `v2.0.0-alpha.1`.
 
 ### Added
 
+-   New interval, month, and year helpers to fetch a list of all Saturdays and Sundays (weekends) for a given date interval. `eachWeekendOfInterval` is the handler function while the other two are wrapper functions.
+
+    -   `eachWeekendOfInterval`
+
+    -   `eachWeekendOfMonth`
+
+    -   `eachWeekendOfYear`
+
 - FP functions like those in [lodash](https://github.com/lodash/lodash/wiki/FP-Guide),
   that support [currying](https://en.wikipedia.org/wiki/Currying), and, as a consequence,
   functional-style [function composing](https://medium.com/making-internets/why-using-chain-is-a-mistake-9bc1f80d51ba).
@@ -698,7 +706,7 @@ for the list of changes made since `v2.0.0-alpha.1`.
 
 - `toDate` (previously `parse`) and `isValid` functions now accept `any` type
   as the first argument.
-  
+
 - [Exclude `docs.json` from the npm package](https://github.com/date-fns/date-fns/pull/837). Kudos to [@hawkrives](https://github.com/hawkrives).
 
 ### Fixed

--- a/src/eachWeekendOfInterval/benchmark.js
+++ b/src/eachWeekendOfInterval/benchmark.js
@@ -1,0 +1,16 @@
+// @flow
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import eachWeekendOfInterval from '.'
+
+suite('eachWeekendOfInterval', function () {
+  benchmark('date-fns', function () {
+    return eachWeekendOfInterval({start: this.dateStart, end: this.dateEnd})
+  })
+}, {
+  setup: function () {
+    this.dateStart = new Date(2022, 0, 1)
+    this.dateEnd = new Date(2022, 11, 31)
+  }
+})

--- a/src/eachWeekendOfInterval/index.d.ts
+++ b/src/eachWeekendOfInterval/index.d.ts
@@ -1,0 +1,4 @@
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+import {eachWeekendOfInterval} from 'date-fns'
+export = eachWeekendOfInterval

--- a/src/eachWeekendOfInterval/index.js
+++ b/src/eachWeekendOfInterval/index.js
@@ -1,0 +1,95 @@
+import toDate from '../toDate/index.js'
+import toInteger from '../_lib/toInteger/index.js'
+import eachDayOfInterval from '../eachDayOfInterval/index.js'
+import isSunday from '../isSunday/index.js'
+import isWeekend from '../isWeekend/index.js'
+
+/**
+ * @name eachWeekendOfInterval
+ * @category Interval Helpers
+ * @summary List all the Saturdays and Sundays in the given date interval.
+ *
+ * @description
+ * Get all the Saturdays and Sundays in the given date interval.
+ *
+ * @param {Interval} interval - the given interval. See [Interval]{@link docs/types/Interval}
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Array} an array containing all the Saturdays and Sundays
+ * @throws {TypeError} 1 argument required
+ * @throws {RangeError} The start of an interval cannot be after its end
+ * @throws {RangeError} Date in interval cannot be `Invalid Date`
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given date interval
+ * var result = eachWeekendOfInterval(
+ *   {start: new Date(2022, 8, 17),
+ *   end: new Date(2022, 8, 30)
+ * },
+ *   {weekStartsOn: 2}
+ * )
+ * //=> ['Sat Sep 17 2022', 'Sun Sep 18 2022', 'Sat Sep 24 2022', 'Sun Sep 25 2022']
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given date interval
+ * var result = eachWeekendOfInterval(
+ *   {start: new Date(2016, 2, 5),
+ *   end: new Date(2016, 2, 19)
+ * },
+ *   {weekStartsOn: 2}
+ * )
+ * //=> ['Sat Mar 05 2016', 'Sun Mar 06 2016, 'Sat Mar 12 2016', 'Sun Mar 13 2016', 'Sat Mar 19 2016']
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given date interval
+ * var result = eachWeekendOfInterval(
+ *   {start: new Date(2016, 2, 25),
+ *   end: new Date(2016, 2, 5)
+ * },
+ *   {weekStartsOn: 2}
+ * )
+ * //=> RangeError
+ */
+
+export default function eachWeekendOfInterval (dirtyInterval, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var interval = dirtyInterval || {}
+  var startDate = toDate(interval.start, dirtyOptions)
+  var endDate = toDate(interval.end, dirtyOptions)
+  var endTime = endDate.getTime()
+
+  // Throw an exception if start date is after end date or if any date is `Invalid Date`
+  if (!(startDate.getTime() <= endTime)) {
+    throw new RangeError('Invalid interval')
+  }
+
+  var dateInterval = eachDayOfInterval(interval)
+  var weekends = []
+  var index = 0
+  while (index++ < dateInterval.length) {
+    var date = dateInterval[index]
+    if (isWeekend(date)) {
+      weekends.push(new Date(date))
+      if (isSunday(date)) {
+        index = index + 5
+      }
+    }
+  }
+  return weekends
+}

--- a/src/eachWeekendOfInterval/index.js.flow
+++ b/src/eachWeekendOfInterval/index.js.flow
@@ -1,0 +1,52 @@
+// @flow
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+type Interval = {
+  start: Date | string | number,
+  end: Date | string | number
+}
+
+type Options = {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+  firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+  additionalDigits?: 0 | 1 | 2,
+  locale?: Locale,
+  includeSeconds?: boolean,
+  addSuffix?: boolean,
+  unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
+  roundingMethod?: 'floor' | 'ceil' | 'round'
+}
+
+type Locale = {
+  formatDistance: Function,
+  formatRelative: Function,
+  localize: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  formatLong: Object,
+  date: Function,
+  time: Function,
+  dateTime: Function,
+  match: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  }
+}
+
+declare module.exports: (
+  interval: Interval,
+  options?: Options
+) => Array

--- a/src/eachWeekendOfInterval/test.js
+++ b/src/eachWeekendOfInterval/test.js
@@ -1,0 +1,146 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import eachWeekendOfInterval from '.'
+
+describe('eachWeekendOfInterval', function () {
+  it('returns array length of 4', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result.length === 4)
+  })
+
+  it('returns array length of 4 with date.toISOString()', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8 /* Sept */, 17).toISOString(),
+      end: new Date(2018, 8 /* Sept */, 30).toISOString()
+    })
+    assert(result.length === 4)
+  })
+
+  it('returns array length of 4 when date strings are used', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date('September 17, 2019'),
+      end: new Date('September 30, 2019')
+    })
+    assert(result.length === 4)
+  })
+
+  it('the first Saturday returned is Sat Sep 22 2018', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result[0].toDateString() === 'Sat Sep 22 2018')
+  })
+
+  it('the first Sunday returned is Sun Sep 23 2018', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8, 17),
+      end: new Date(2018, 8, 30)
+    })
+    assert(result[1].toDateString() === 'Sun Sep 23 2018')
+  })
+
+  it('the second Saturday returned is Sat Sep 29 2018', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result[2].toDateString() === 'Sat Sep 29 2018')
+  })
+
+  it('the second Sunday returned is Sun Sep 30 2018', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result[3].toDateString() === 'Sun Sep 30 2018')
+  })
+
+  it('returns array length of 104', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2019, 0 /* Jan */, 1),
+      end: new Date(2019, 11 /* Dec */, 31)
+    })
+    assert(result.length === 104)
+  })
+
+  it('returns Sun Mar 17 2019', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2019, 0 /* Jan */, 1),
+      end: new Date(2019, 11 /* Dec */, 31)
+    })
+    assert(result[21].toDateString() === 'Sun Mar 17 2019')
+  })
+
+  it('returns Sat Oct 26 2019', function () {
+    var result = eachWeekendOfInterval({
+      start: new Date(2019, 0 /* Jan */, 1),
+      end: new Date(2019, 11 /* Dec */, 31)
+    })
+    assert(result[84].toDateString() === 'Sat Oct 26 2019')
+  })
+
+  it('throws `RangeError` invalid interval start date is used', function () {
+    // $ExpectedMistake
+    var block = eachWeekendOfInterval.bind(null,
+      {
+        start: new Date(NaN),
+        end: new Date(2019, 11 /* Dec */, 31)
+      },
+      { weekStartsOn: 6 })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` invalid interval end date is used', function () {
+    // $ExpectedMistake
+    var block = eachWeekendOfInterval.bind(null,
+      {
+        start: new Date(2019, 0 /* Jan */, 1),
+        end: new Date(NaN)
+      },
+      { weekStartsOn: 6 })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(eachWeekendOfInterval.bind(), TypeError)
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // $ExpectedMistake
+    var block = eachWeekendOfInterval.bind(null,
+      {
+        start: new Date(2018, 8 /* Sept */, 17),
+        end: new Date(2018, 8 /* Sept */, 30)
+      },
+      { weekStartsOn: 9 })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` when passing in invalid value', function () {
+    // $ExpectedMistake
+    var block = eachWeekendOfInterval.bind(null,
+      {
+        start: new Date(2018, 8 /* Sept */, 17),
+        end: new Date(2018, 8 /* Sept */, 30)
+      },
+      { weekStartsOn: NaN })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if start of an interval is after its end', function () {
+    // $ExpectedMistake
+    var block = eachWeekendOfInterval.bind(null,
+      {
+        start: new Date(2018, 8 /* Sept */, 25),
+        end: new Date(2018, 8 /* Sept */, 6)
+      },
+      { weekStartsOn: NaN })
+    assert.throws(block, RangeError)
+  })
+})

--- a/src/eachWeekendOfMonth/benchmark.js
+++ b/src/eachWeekendOfMonth/benchmark.js
@@ -1,0 +1,15 @@
+// @flow
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import eachWeekendOfMonth from '.'
+
+suite('eachWeekendOfMonth', function () {
+  benchmark('date-fns', function () {
+    return eachWeekendOfMonth(this.date)
+  })
+}, {
+  setup: function () {
+    this.date = new Date(2020, 3, 20)
+  }
+})

--- a/src/eachWeekendOfMonth/index.d.ts
+++ b/src/eachWeekendOfMonth/index.d.ts
@@ -1,0 +1,4 @@
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+import {eachWeekendOfMonth} from 'date-fns'
+export = eachWeekendOfMonth

--- a/src/eachWeekendOfMonth/index.js
+++ b/src/eachWeekendOfMonth/index.js
@@ -1,0 +1,35 @@
+import eachWeekendOfInterval from '../eachWeekendOfInterval/index.js'
+import startOfMonth from '../startOfMonth/index.js'
+import endOfMonth from '../endOfMonth/index.js'
+
+/**
+ * @name eachWeekendOfMonth
+ * @category Month Helpers
+ * @summary List all the Saturdays and Sundays in the given month.
+ *
+ * @description
+ * Get all the Saturdays and Sundays in the given month.
+ *
+ * @param {Date|String|Number} date - the given month
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Array} an array containing all the Saturdays and Sundays
+ * @throws {TypeError} 1 argument required
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given month
+ * var result = eachWeekendOfMonth(new Date(2020, 1, 1))
+ * //=> ['Sat Feb 01 2020', 'Sun Feb 02 2020', 'Sat Feb 08 2020', ... , 'Sat Feb 22 2020', 'Sun Feb 23 2020', 'Sat Feb 29 2020']
+ */
+
+export default function eachWeekendOfMonth (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError(
+      '1 arguments required, but only ' + arguments.length + ' present'
+    )
+  }
+
+  var startDate = startOfMonth(dirtyDate, dirtyOptions)
+  var endDate = endOfMonth(dirtyDate, dirtyOptions)
+  return eachWeekendOfInterval({ start: startDate, end: endDate })
+}

--- a/src/eachWeekendOfMonth/index.js.flow
+++ b/src/eachWeekendOfMonth/index.js.flow
@@ -1,0 +1,52 @@
+// @flow
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+type Interval = {
+  start: Date | string | number,
+  end: Date | string | number
+}
+
+type Options = {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+  firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+  additionalDigits?: 0 | 1 | 2,
+  locale?: Locale,
+  includeSeconds?: boolean,
+  addSuffix?: boolean,
+  unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
+  roundingMethod?: 'floor' | 'ceil' | 'round'
+}
+
+type Locale = {
+  formatDistance: Function,
+  formatRelative: Function,
+  localize: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  formatLong: Object,
+  date: Function,
+  time: Function,
+  dateTime: Function,
+  match: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  }
+}
+
+declare module.exports: (
+  date: Date | string | number,
+  options?: Options
+) => Array

--- a/src/eachWeekendOfMonth/test.js
+++ b/src/eachWeekendOfMonth/test.js
@@ -1,0 +1,39 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import eachWeekendOfMonth from '.'
+
+describe('eachWeekendOfMonth', function () {
+  it('returns array length of 8', function () {
+    var result = eachWeekendOfMonth(new Date(2022, 1, 20))
+    assert(result.length === 8)
+  })
+
+  it('returns the first date in array: Sat Feb 05 2022', function () {
+    var result = eachWeekendOfMonth(new Date(2022, 1, 13))
+    assert(result.length === 8)
+    assert(result[0].toDateString() === 'Sat Feb 05 2022')
+  })
+
+  it('returns the last date in array: Sun Feb 27 2022', function () {
+    var result = eachWeekendOfMonth(new Date(2022, 1, 5))
+    assert(result.length === 8)
+    assert(result[result.length - 1].toDateString() === 'Sun Feb 27 2022')
+  })
+
+  it('throws TypeError exception when passed less than 1 argument', function () {
+    assert.throws(eachWeekendOfMonth.bind(null), TypeError)
+  })
+
+  it('throws TypeError exception when the expected year is a NaN', function () {
+    assert.throws(eachWeekendOfMonth.bind(1, NaN), RangeError)
+  })
+
+  it('throws RangeError exception when the additionalDigits option is a NaN', function () {
+    assert.throws(
+      eachWeekendOfMonth.bind(null, new Date(2020, 1, 5), { additionalDigits: NaN }),
+      RangeError
+    )
+  })
+})

--- a/src/eachWeekendOfYear/benchmark.js
+++ b/src/eachWeekendOfYear/benchmark.js
@@ -1,0 +1,14 @@
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import eachWeekendOfYear from '.'
+
+suite('eachWeekendOfYear', function () {
+  benchmark('date-fns', function () {
+    return eachWeekendOfYear(this.date)
+  })
+}, {
+  setup: function () {
+    this.date = new Date(2022, 7, 12)
+  }
+})

--- a/src/eachWeekendOfYear/index.d.ts
+++ b/src/eachWeekendOfYear/index.d.ts
@@ -1,0 +1,4 @@
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+import {eachWeekendOfYear} from 'date-fns'
+export = eachWeekendOfYear

--- a/src/eachWeekendOfYear/index.js
+++ b/src/eachWeekendOfYear/index.js
@@ -1,0 +1,35 @@
+import eachWeekendOfInterval from '../eachWeekendOfInterval/index.js'
+import startOfYear from '../startOfYear/index.js'
+import endOfYear from '../endOfYear/index.js'
+
+/**
+ * @name eachWeekendOfYear
+ * @category Year Helpers
+ * @summary List all the Saturdays and Sundays in the year.
+ *
+ * @description
+ * Get all the Saturdays and Sundays in the year.
+ *
+ * @param {Date|String|Number} date - the given year
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @returns {Array} an array containing all the Saturdays and Sundays
+ * @throws {TypeError} 1 argument required
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the year
+ * var result = eachWeekendOfYear(new Date(2020, 1, 1))
+ * //=> ['Sat Jan 04 2020', 'Sun Jan 05 2020', 'Sat Jan 11 2020', ... , 'Sun Dec 20 2020', 'Sat Dec 26 2020', 'Sun Dec 27 2020']
+ */
+
+export default function eachWeekendOfYear (dirtyDate, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError(
+      '1 arguments required, but only ' + arguments.length + ' present'
+    )
+  }
+
+  var startDate = startOfYear(dirtyDate, dirtyOptions)
+  var endDate = endOfYear(dirtyDate, dirtyOptions)
+  return eachWeekendOfInterval({ start: startDate, end: endDate })
+}

--- a/src/eachWeekendOfYear/index.js.flow
+++ b/src/eachWeekendOfYear/index.js.flow
@@ -1,0 +1,52 @@
+// @flow
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+type Interval = {
+  start: Date | string | number,
+  end: Date | string | number
+}
+
+type Options = {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+  firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+  additionalDigits?: 0 | 1 | 2,
+  locale?: Locale,
+  includeSeconds?: boolean,
+  addSuffix?: boolean,
+  unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
+  roundingMethod?: 'floor' | 'ceil' | 'round'
+}
+
+type Locale = {
+  formatDistance: Function,
+  formatRelative: Function,
+  localize: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  formatLong: Object,
+  date: Function,
+  time: Function,
+  dateTime: Function,
+  match: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  }
+}
+
+declare module.exports: (
+  date: Date | string | number,
+  options?: Options
+) => Array

--- a/src/eachWeekendOfYear/test.js
+++ b/src/eachWeekendOfYear/test.js
@@ -1,0 +1,49 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import eachWeekendOfYear from '.'
+
+describe('eachWeekendOfYear', function () {
+  it('returns array length of 104', function () {
+    var result = eachWeekendOfYear(new Date(2020, 0, 1))
+    assert(result.length === 104)
+  })
+
+  it('returns array length of 104 when year value is a string', function () {
+    var result = eachWeekendOfYear(new Date(2018, 11, 31))
+    assert(result.length === 104)
+  })
+
+  it('returns the date of index 60: Sat Aug 01 2020', function () {
+    var result = eachWeekendOfYear(new Date(2020, 2, 22))
+    assert(result[60].toDateString() === 'Sat Aug 01 2020')
+  })
+
+  it('returns the last Sunday of the year: Sun Dec 27 2020', function () {
+    var result = eachWeekendOfYear(new Date(2020, 8, 12))
+    assert(result[103].toDateString() === 'Sun Dec 27 2020')
+  })
+
+  it('throws TypeError exception when no argument is passed in', function () {
+    assert.throws(eachWeekendOfYear.bind(null), TypeError)
+  })
+
+  it('throws TypeError exception when the expected year is a NaN', function () {
+    assert.throws(eachWeekendOfYear.bind(NaN), TypeError)
+  })
+
+  it('throws RangeError exception when the additionalDigits option is a NaN', function () {
+    assert.throws(
+      eachWeekendOfYear.bind(null, new Date(2020, 5, 28), { additionalDigits: NaN }),
+      RangeError
+    )
+  })
+
+  it('throws RangeError exception when date is invalid', function () {
+    assert.throws(
+      eachWeekendOfYear.bind(null, new Date(NaN), { additionalDigits: 2 }),
+      RangeError
+    )
+  })
+})

--- a/src/getWeekendsBetween/benchmark.js
+++ b/src/getWeekendsBetween/benchmark.js
@@ -1,0 +1,16 @@
+// @flow
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import getWeekendsBetween from '.'
+
+suite('getWeekendsBetween', function () {
+  benchmark('date-fns', function () {
+    return getWeekendsBetween({start: this.dateStart, end: this.dateEnd})
+  })
+}, {
+  setup: function () {
+    this.dateStart = new Date(2022, 0, 1)
+    this.dateEnd = new Date(2022, 11, 31)
+  }
+})

--- a/src/getWeekendsBetween/index.d.ts
+++ b/src/getWeekendsBetween/index.d.ts
@@ -1,0 +1,4 @@
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+import {getWeekendsBetween} from 'date-fns'
+export = getWeekendsBetween

--- a/src/getWeekendsBetween/index.js
+++ b/src/getWeekendsBetween/index.js
@@ -1,0 +1,81 @@
+import toInteger from '../_lib/toInteger/index.js'
+import eachDayOfInterval from '../eachDayOfInterval/index.js'
+import isSunday from '../isSunday/index.js'
+import isWeekend from '../isWeekend/index.js'
+
+/**
+ * @name getWeekendsBetween
+ * @category Week Helpers
+ * @summary List all the Saturdays and Sundays in the given date interval.
+ *
+ * @description
+ * Get all the Saturdays and Sundays in the given date interval.
+ *
+ * @param {Date|String|Number} dateStart - the start date
+ * @param {Date|String|Number} dateEnd - the end date
+ * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
+ * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @returns {Array} an array containing all the Saturdays and Sundays
+ * @throws {TypeError} 2 arguments required
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given date interval
+ * let result = getWeekendsBetween(
+ *   {start: new Date(2022, 8, 17),
+ *   end: new Date(2022, 8, 30)},
+ *   {weekStartsOn: 2}
+ * )
+ * //=> ['Sat Sep 17 2022', 'Sun Sep 18 2022', 'Sat Sep 24 2022', 'Sun Sep 25 2022']
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given date interval
+ * let result = getWeekendsBetween(
+ *   {start: new Date('March 5, 2016'),
+ *   end: new Date('March 19, 2016')},
+ *   {weekStartsOn: 2}
+ * )
+ * //=> ['Sat Mar 05 2016', 'Sun Mar 06 2016, 'Sat Mar 12 2016', 'Sun Mar 13 2016', 'Sat Mar 19 2016']
+ *
+ * @example
+ * // Lists all Saturdays and Sundays in the given date interval
+ * let result = getWeekendsBetween(
+ *   {start: new Date('March 25, 2016'),
+ *   end: new Date('March 5, 2016')},
+ *   {weekStartsOn: 2}
+ * )
+ * //=> []
+ */
+
+export default function getWeekendsBetween (dirtyInterval, dirtyOptions) {
+  if (arguments.length < 1) {
+    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
+  }
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn = locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+
+  // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
+  if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
+    throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
+  }
+
+  var interval = dirtyInterval || {}
+  var dateInterval = eachDayOfInterval(interval)
+  var weekends = []
+  var index = 0
+  while (index++ < dateInterval.length) {
+    var date = dateInterval[index]
+    if (isWeekend(date)) {
+      weekends.push(new Date(date))
+      if (isSunday(date)) {
+        index = index + 5
+      }
+    }
+  }
+  return weekends
+}

--- a/src/getWeekendsBetween/index.js.flow
+++ b/src/getWeekendsBetween/index.js.flow
@@ -1,0 +1,53 @@
+// @flow
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+type Interval = {
+  start: Date | string | number,
+  end: Date | string | number
+}
+
+type Options = {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+  firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+  additionalDigits?: 0 | 1 | 2,
+  locale?: Locale,
+  includeSeconds?: boolean,
+  addSuffix?: boolean,
+  unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
+  roundingMethod?: 'floor' | 'ceil' | 'round'
+}
+
+type Locale = {
+  formatDistance: Function,
+  formatRelative: Function,
+  localize: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  formatLong: Object,
+  date: Function,
+  time: Function,
+  dateTime: Function,
+  match: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  }
+}
+
+declare module.exports: (
+  dateStart: Date | string | number,
+  dateEnd: Date | string | number,
+  options?: Options
+) => Array

--- a/src/getWeekendsBetween/test.js
+++ b/src/getWeekendsBetween/test.js
@@ -1,0 +1,135 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import getWeekendsBetween from '.'
+
+describe('getWeekendsBetween', function () {
+  it('returns array length of 4', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result.length === 4)
+  })
+
+  it('returns array length of 4 with date.toISOString()', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2018, 8 /* Sept */, 17).toISOString(),
+      end: new Date(2018, 8 /* Sept */, 30).toISOString()
+    })
+    assert(result.length === 4)
+  })
+
+  it('returns array length of 4 when date strings are used', function () {
+    var result = getWeekendsBetween({
+      start: new Date('September 17, 2019'),
+      end: new Date('September 30, 2019')
+    })
+    assert(result.length === 4)
+  })
+
+  it('the first Saturday returned is Sat Sep 22 2018', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result[0].toDateString() === 'Sat Sep 22 2018')
+  })
+
+  it('the first Sunday returned is Sun Sep 23 2018', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2018, 8, 17),
+      end: new Date(2018, 8, 30)
+    })
+    assert(result[1].toDateString() === 'Sun Sep 23 2018')
+  })
+
+  it('the second Saturday returned is Sat Sep 29 2018', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result[2].toDateString() === 'Sat Sep 29 2018')
+  })
+
+  it('the second Sunday returned is Sun Sep 30 2018', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2018, 8 /* Sept */, 17),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert(result[3].toDateString() === 'Sun Sep 30 2018')
+  })
+
+  it('returns array length of 104', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2019, 0 /* Jan */, 1),
+      end: new Date(2019, 11 /* Dec */, 31)
+    })
+    assert(result.length === 104)
+  })
+
+  it('returns Sun Mar 17 2019', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2019, 0 /* Jan */, 1),
+      end: new Date(2019, 11 /* Dec */, 31)
+    })
+    assert(result[21].toDateString() === 'Sun Mar 17 2019')
+  })
+
+  it('returns Sat Oct 26 2019', function () {
+    var result = getWeekendsBetween({
+      start: new Date(2019, 0 /* Jan */, 1),
+      end: new Date(2019, 11 /* Dec */, 31)
+    })
+    assert(result[84].toDateString() === 'Sat Oct 26 2019')
+  })
+
+  it('throws `RangeError` invalid interval start date is used', function () {
+    // $ExpectedMistake
+    var block = getWeekendsBetween.bind(null,
+      {
+        start: new Date(NaN),
+        end: new Date(2019, 11 /* Dec */, 31)
+      },
+      { weekStartsOn: 6 })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` invalid interval end date is used', function () {
+    // $ExpectedMistake
+    var block = getWeekendsBetween.bind(null,
+      {
+        start: new Date(2019, 0 /* Jan */, 1),
+        end: new Date(NaN)
+      },
+      { weekStartsOn: 6 })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    assert.throws(getWeekendsBetween.bind(), TypeError)
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // $ExpectedMistake
+    var block = getWeekendsBetween.bind(null,
+      {
+        start: new Date(2018, 8 /* Sept */, 17),
+        end: new Date(2018, 8 /* Sept */, 30)
+      },
+      { weekStartsOn: 9 })
+    assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.weekStartsOn` when passing in invalid value', function () {
+    // $ExpectedMistake
+    var block = getWeekendsBetween.bind(null,
+      {
+        start: new Date(2018, 8 /* Sept */, 17),
+        end: new Date(2018, 8 /* Sept */, 30)
+      },
+      { weekStartsOn: NaN })
+    assert.throws(block, RangeError)
+  })
+})


### PR DESCRIPTION
Added three new week helper functions. The getWeekendsBetween function is the handler whereas the other two are merely wrapper functions? How will these new functions be useful? Just imagine a calendar widget where each of the weekend days need to be visually different from the rest of the weekends. Or some kind of an event planning app where a planner would like to see what future weekends are available during the peak season. Furthermore, some kind of vacation booking site that needs to determine which weekends are available. These are just simple contrived examples.