### PR TITLE
Improve ja translation of distanceInWords

### DIFF
--- a/src/locale/ja/build_distance_in_words_locale/index.js
+++ b/src/locale/ja/build_distance_in_words_locale/index.js
@@ -64,7 +64,9 @@ function buildDistanceInWordsLocale () {
 
     almostXYears: {
       one: '1年以下',
-      other: '{{count}}年以下'
+      other: '{{count}}年以下',
+      oneWithSuffix: '1年ぐらい',
+      otherWithSuffix: '{{count}}年ぐらい'
     }
   }
 
@@ -75,9 +77,17 @@ function buildDistanceInWordsLocale () {
     if (typeof distanceInWordsLocale[token] === 'string') {
       result = distanceInWordsLocale[token]
     } else if (count === 1) {
-      result = distanceInWordsLocale[token].one
+      if (options.addSuffix && distanceInWordsLocale[token].oneWithSuffix) {
+        result = distanceInWordsLocale[token].oneWithSuffix
+      } else {
+        result = distanceInWordsLocale[token].one
+      }
     } else {
-      result = distanceInWordsLocale[token].other.replace('{{count}}', count)
+      if (options.addSuffix && distanceInWordsLocale[token].otherWithSuffix) {
+        result = distanceInWordsLocale[token].otherWithSuffix.replace('{{count}}', count)
+      } else {
+        result = distanceInWordsLocale[token].other.replace('{{count}}', count)
+      }
     }
 
     if (options.addSuffix) {

--- a/src/locale/ja/build_distance_in_words_locale/test.js
+++ b/src/locale/ja/build_distance_in_words_locale/test.js
@@ -213,6 +213,26 @@ describe('ja locale > buildDistanceInWordsLocale', function () {
       })
       assert(result === '1年ぐらい前')
     })
+
+    context('and locale data has `oneWithSuffix`', function () {
+      it('adds `ago` to a `oneWithSuffix`', function () {
+        var result = buildDistanceInWordsLocale().localize('almostXYears', 1, {
+          addSuffix: true,
+          comparison: -1
+        })
+        assert(result === '1年ぐらい前')
+      })
+    })
+
+    context('and locale data has `otherWithSuffix`', function () {
+      it('adds `ago` to a `otherWithSuffix`', function () {
+        var result = buildDistanceInWordsLocale().localize('almostXYears', 2, {
+          addSuffix: true,
+          comparison: -1
+        })
+        assert(result === '2年ぐらい前')
+      })
+    })
   })
 
   context('with a future suffix', function () {


### PR DESCRIPTION
I fixed a unnatural japanese translation of `distanceInWords` of v1.
Currently, `almostXYears` with a suffix is translated into Japanese `X年以下前`, but this expression is not used by Japanese.
So I changed it to be `X年ぐらい前` which is a natural Japanese translation.

`formatDistance` has a same problem, so if this PR is merged, I will also create PR for `formatDistance` to master branch :)