### PR TITLE
🎉9️⃣0️⃣0️⃣🎂 Use getISOHours in Spanish locale (closes #884)

### DIFF
--- a/src/locale/es/_lib/formatRelative/index.js
+++ b/src/locale/es/_lib/formatRelative/index.js
@@ -17,7 +17,7 @@ var formatRelativeLocalePlural = {
 }
 
 export default function formatRelative (token, date, baseDate, options) {
-  if (date.getHours() !== 1) {
+  if (date.getUTCHours() !== 1) {
     return formatRelativeLocalePlural[token]
   }
   return formatRelativeLocale[token]


### PR DESCRIPTION
Use `date.getUTCHours()` instead of `date.getHours()` because all calculations in the locales are made in UTC by default.