### PR TITLE
[fr] ordinalnumber function not returning the right results in some cases

### DIFF
--- a/src/locale/fr/_lib/localize/index.js
+++ b/src/locale/fr/_lib/localize/index.js
@@ -82,7 +82,7 @@ function ordinalNumber (dirtyNumber, dirtyOptions) {
       suffix = 'ème'
     }
   }
-  
+
   return number + suffix
 }
 

--- a/src/locale/fr/_lib/localize/index.js
+++ b/src/locale/fr/_lib/localize/index.js
@@ -69,16 +69,20 @@ function ordinalNumber (dirtyNumber, dirtyOptions) {
     return number
   }
 
-  if (unit === 'day' && number === 1) {
-    suffix = 'er'
-  } else {
+  if (unit === 'year' || unit === 'hour' || unit === 'week') {
     if (number === 1) {
       suffix = 'ère'
     } else {
       suffix = 'ème'
     }
+  } else {
+    if (number === 1) {
+      suffix = 'er'
+    } else {
+      suffix = 'ème'
+    }
   }
-
+  
   return number + suffix
 }
 


### PR DESCRIPTION
When I made my first PR I did not fully understand how the ordinalnumber function was used, this PR fixes some errors I made.

Basically, in French, 'year'  'hour' and 'week' are feminine whereas 'day' and 'quarter' are masculine, this PR fixes that.

There might still be some subtleties that I did not grasp but I'll keep on making the language better as my understanding of the lib gets better.