### PR TITLE
Resolve the confusion caused by the Unicode tokens (closes #760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,13 @@ for the list of changes made since `v2.0.0-alpha.1`.
 
   Characters are now escaped using single quote symbols (`'`) instead of square brackets.
 
+  To use `D`,`DD`, `YY`, `YYYY` tokens you should set `awareOfUnicodeTokens`:
+
+  ```javascript
+  format(Date.now(), 'YY', { awareOfUnicodeTokens: true })
+  //=> '86'
+  ```
+
 - **BREAKING**: function submodules now use camelCase naming schema:
 
   ```javascript

--- a/docs/Options.js
+++ b/docs/Options.js
@@ -28,6 +28,11 @@
  *   If specified, will force a unit
  * @property {'floor'|'ceil'|'round'} [roundingMethod='floor'] - used by `formatDistanceStrict`.
  *   Specifies, which way to round partial units
+ * @property {Boolean} [awareOfUnicodeTokens=false] - used by `format` and `parse`.
+ *   If true, allows usage of Unicode tokens causes confusion:
+ *   - Some of the day of year tokens (`D`, `DD`) that are confused with the day of month tokens (`d`, `dd`).
+ *   - Some of the local week-numbering year tokens (`YY`, `YYYY`) that are confused with the calendar year tokens (`yy`, `yyyy`).
+ *   See: https://git.io/fxCyr
  *
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2.
  *   Thrown by **all** functions
@@ -51,6 +56,8 @@
  *   Thrown by `formatDistance` and `formatDistanceStrict`
  * @throws {RangeError} `options.locale` must contain `match` property.
  *   Thrown by `parse`
+ * @throws {RangeError} `options.awareOfUnicodeTokens` must be set to `true` to use `XX` token; see: https://git.io/fxCyr
+ *   Thrown by `format` and `parse`
  *
  * @example
  * // For 15 December 12345 AD, represent the start of the week in Esperanto,

--- a/docs/index.js
+++ b/docs/index.js
@@ -89,6 +89,14 @@ module.exports = {
     },
     {
       type: 'markdown',
+      urlId: 'Unicode-Tokens',
+      category: 'General',
+      title: 'Unicode Tokens',
+      description: 'Usage of the Unicode tokens in parse and format',
+      path: path.join(__dirname, 'unicodeTokens.md')
+    },
+    {
+      type: 'markdown',
       urlId: 'License',
       category: 'General',
       title: 'License',

--- a/docs/printV2Notice.js
+++ b/docs/printV2Notice.js
@@ -1,0 +1,13 @@
+console.log(`
+🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+  Thank you for testing (⩗) date-fns v2!
+
+  In v2 we've introduced a number of breaking changes
+  that make date-fns even more consistent and reliable.
+  Please read the changelog carefully: https://git.io/fxCWb
+
+  Please support us at Open Collective: https://opencollective.com/date-fns
+
+🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+`)

--- a/docs/unicodeTokens.md
+++ b/docs/unicodeTokens.md
@@ -1,0 +1,53 @@
+# Unicode Tokens
+
+Starting with v2 `format` and `parse` uses [Unicode tokens].
+
+The tokens are different from Moment.js and other libraries that opted to use
+custom formatting rules. While usage of a standard ensures compatibility and
+the future of the library it causes confusion that this document intended
+to resolve.
+
+## Popular mistakes
+
+There are 4 tokens that causes the most of confusion:
+
+- `D` and `DD` that represent the day of a year (1, 2, ..., 365, 366)
+  are often confused with `d` and `dd` that represent the day of a month
+  (1, 2, ..., 31).
+
+- `YY` and `YYYY` that represent the local week-numbering year (44, 01, 00, 17)
+  are often confused with `yy` and `yyyy` that represent the the calendar year.
+
+```js
+// ❌ Wrong!
+format(new Date(), 'YYYY-MM-DD')
+//=> 2018-10-283
+
+// ✅ Correct
+format(new Date(), 'yyyy-MM-dd')
+//=> 2018-10-10
+
+// ❌ Wrong!
+parse('11.02.87', 'D.MM.YY', new Date()).toString()
+//=> 'Sat Jan 11 1986 00:00:00 GMT+0200 (EET)'
+
+// ✅ Correct
+parse('11.02.87', 'd.MM.yy', new Date()).toString()
+//=> 'Wed Feb 11 1987 00:00:00 GMT+0200 (EET)'
+```
+
+To help with the issue, `format` and `parse` functions won't accept
+`D`, `DD`, `YY` and `YYYY` without `awareOfUnicodeTokens` option:
+
+```js
+format(new Date(), 'D', { awareOfUnicodeTokens: true })
+//=> '283'
+
+parse('365+1987', 'DD+YYYY', new Date(), { awareOfUnicodeTokens: true }).toString()
+//=> 'Wed Dec 31 1986 00:00:00 GMT+0200 (EET)'
+```
+
+The option is supposed to be a temporary solution and might be removed
+in the future minor or major versions.
+
+[Unicode tokens]: https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "date-fns",
-  "version":
-    "DON'T CHANGE; IT'S SET AUTOMATICALLY DURING DEPLOYMENT; ALSO, USE YARN FOR DEVELOPMENT",
+  "version": "DON'T CHANGE; IT'S SET AUTOMATICALLY DURING DEPLOYMENT; ALSO, USE YARN FOR DEVELOPMENT",
   "sideEffects": false,
   "contributors": [
     "Sasha Koss <koss@nocorp.me>",
@@ -18,10 +17,10 @@
   "module": "esm/index.js",
   "scripts": {
     "test": "karma start config/karma.js",
-    "lint":
-      "echo \"Due to ongoing migration to Prettier, the linter is disabled.\"",
+    "lint": "echo \"Due to ongoing migration to Prettier, the linter is disabled.\"",
     "benchmark": "env TEST_BENCHMARK=true yarn test -- --single-run",
-    "stats": "cloc . --exclude-dir=node_modules,tmp,.git"
+    "stats": "cloc . --exclude-dir=node_modules,tmp,.git",
+    "postinstall": "node ./docs/printV2Notice.js"
   },
   "husky": {
     "hooks": {
@@ -29,7 +28,10 @@
     }
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "prettier": {
     "singleQuote": true,

--- a/src/_lib/protectedTokens/index.js
+++ b/src/_lib/protectedTokens/index.js
@@ -1,0 +1,13 @@
+export const protectedTokens = ['D', 'DD', 'YY', 'YYYY']
+
+export function isProtectedToken(token) {
+  return protectedTokens.indexOf(token) !== -1
+}
+
+export function throwProtectedError(token) {
+  throw new RangeError(
+    '`options.awareOfUnicodeTokens` must be set to `true` to use `' +
+      token +
+      '` token; see: https://git.io/fxCyr'
+  )
+}

--- a/src/addDays/index.js.flow
+++ b/src/addDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addHours/index.js.flow
+++ b/src/addHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addISOWeekYears/index.js.flow
+++ b/src/addISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addMilliseconds/index.js.flow
+++ b/src/addMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addMinutes/index.js.flow
+++ b/src/addMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addMonths/index.js.flow
+++ b/src/addMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addQuarters/index.js.flow
+++ b/src/addQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addSeconds/index.js.flow
+++ b/src/addSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addWeeks/index.js.flow
+++ b/src/addWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/addYears/index.js.flow
+++ b/src/addYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/areIntervalsOverlapping/index.js.flow
+++ b/src/areIntervalsOverlapping/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/closestIndexTo/index.js.flow
+++ b/src/closestIndexTo/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/closestTo/index.js.flow
+++ b/src/closestTo/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/compareAsc/index.js.flow
+++ b/src/compareAsc/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/compareDesc/index.js.flow
+++ b/src/compareDesc/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarDays/index.js.flow
+++ b/src/differenceInCalendarDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarISOWeekYears/index.js.flow
+++ b/src/differenceInCalendarISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarISOWeeks/index.js.flow
+++ b/src/differenceInCalendarISOWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarMonths/index.js.flow
+++ b/src/differenceInCalendarMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarQuarters/index.js.flow
+++ b/src/differenceInCalendarQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarWeeks/index.js.flow
+++ b/src/differenceInCalendarWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInCalendarYears/index.js.flow
+++ b/src/differenceInCalendarYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInDays/index.js.flow
+++ b/src/differenceInDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInHours/index.js.flow
+++ b/src/differenceInHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInISOWeekYears/index.js.flow
+++ b/src/differenceInISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInMilliseconds/index.js.flow
+++ b/src/differenceInMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInMinutes/index.js.flow
+++ b/src/differenceInMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInMonths/index.js.flow
+++ b/src/differenceInMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInQuarters/index.js.flow
+++ b/src/differenceInQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInSeconds/index.js.flow
+++ b/src/differenceInSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInWeeks/index.js.flow
+++ b/src/differenceInWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/differenceInYears/index.js.flow
+++ b/src/differenceInYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/eachDayOfInterval/index.js.flow
+++ b/src/eachDayOfInterval/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/eachWeekOfInterval/index.js.flow
+++ b/src/eachWeekOfInterval/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfDay/index.js.flow
+++ b/src/endOfDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfDecade/index.js.flow
+++ b/src/endOfDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfHour/index.js.flow
+++ b/src/endOfHour/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfISOWeek/index.js.flow
+++ b/src/endOfISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfISOWeekYear/index.js.flow
+++ b/src/endOfISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfMinute/index.js.flow
+++ b/src/endOfMinute/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfMonth/index.js.flow
+++ b/src/endOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfQuarter/index.js.flow
+++ b/src/endOfQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfSecond/index.js.flow
+++ b/src/endOfSecond/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfWeek/index.js.flow
+++ b/src/endOfWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/endOfYear/index.js.flow
+++ b/src/endOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -6,7 +6,10 @@ import defaultLocale from '../locale/en-US/index.js'
 import formatters from './_lib/formatters/index.js'
 import longFormatters from './_lib/longFormatters/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
-import { isProtectedToken, throwProtectedError } from '../_lib/protectedTokens'
+import {
+  isProtectedToken,
+  throwProtectedError
+} from '../_lib/protectedTokens/index.js'
 
 // This RegExp consists of three parts separated by `|`:
 // - [yYQqMLwIdDecihHKkms]o matches any available ordinal number token

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -6,6 +6,7 @@ import defaultLocale from '../locale/en-US/index.js'
 import formatters from './_lib/formatters/index.js'
 import longFormatters from './_lib/longFormatters/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
+import { isProtectedToken, throwProtectedError } from '../_lib/protectedTokens'
 
 // This RegExp consists of three parts separated by `|`:
 // - [yYQqMLwIdDecihHKkms]o matches any available ordinal number token
@@ -35,6 +36,9 @@ var doubleQuoteRegExp = /''/g
  * @description
  * Return the formatted date string in the given format. The result may vary by locale.
  *
+ * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
+ * > See: https://git.io/fxCyr
+ *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
  * (see the last example)
@@ -57,9 +61,9 @@ var doubleQuoteRegExp = /''/g
  * |                                 | yyyyy   | ...                               | 3,5   |
  * | Local week-numbering year       | Y       | 44, 1, 1900, 2017                 | 5     |
  * |                                 | Yo      | 44th, 1st, 1900th, 2017th         | 5,7   |
- * |                                 | YY      | 44, 01, 00, 17                    | 5     |
+ * |                                 | YY      | 44, 01, 00, 17                    | 5,8   |
  * |                                 | YYY     | 044, 001, 1900, 2017              | 5     |
- * |                                 | YYYY    | 0044, 0001, 1900, 2017            | 5     |
+ * |                                 | YYYY    | 0044, 0001, 1900, 2017            | 5,8   |
  * |                                 | YYYYY   | ...                               | 3,5   |
  * | ISO week-numbering year         | R       | -43, 0, 1, 1900, 2017             | 5,7   |
  * |                                 | RR      | -43, 00, 01, 1900, 2017           | 5,7   |
@@ -104,9 +108,9 @@ var doubleQuoteRegExp = /''/g
  * | Day of month                    | d       | 1, 2, ..., 31                     |       |
  * |                                 | do      | 1st, 2nd, ..., 31st               | 7     |
  * |                                 | dd      | 01, 02, ..., 31                   |       |
- * | Day of year                     | D       | 1, 2, ..., 365, 366               |       |
+ * | Day of year                     | D       | 1, 2, ..., 365, 366               | 8     |
  * |                                 | Do      | 1st, 2nd, ..., 365th, 366th       | 7     |
- * |                                 | DD      | 01, 02, ..., 365, 366             |       |
+ * |                                 | DD      | 01, 02, ..., 365, 366             | 8     |
  * |                                 | DDD     | 001, 002, ..., 365, 366           |       |
  * |                                 | DDDD    | ...                               | 3     |
  * | Day of week (formatting)        | E..EEE  | Mon, Tue, Wed, ..., Su            |       |
@@ -266,6 +270,8 @@ var doubleQuoteRegExp = /''/g
  *    - `P`: long localized date
  *    - `p`: long localized time
  *
+ * 8. These tokens are often confused with others. See: https://git.io/fxCyr
+ *
  * @param {Date|String|Number} date - the original date
  * @param {String} format - the string of tokens
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
@@ -273,6 +279,10 @@ var doubleQuoteRegExp = /''/g
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {Number} [options.firstWeekContainsDate=1] - the day of January, which is
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @param {Boolean} [options.awareOfUnicodeTokens=false] - if true, allows usage of Unicode tokens causes confusion:
+ *   - Some of the day of year tokens (`D`, `DD`) that are confused with the day of month tokens (`d`, `dd`).
+ *   - Some of the local week-numbering year tokens (`YY`, `YYYY`) that are confused with the calendar year tokens (`yy`, `yyyy`).
+ *   See: https://git.io/fxCyr
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
@@ -280,6 +290,7 @@ var doubleQuoteRegExp = /''/g
  * @throws {RangeError} `options.locale` must contain `formatLong` property
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
+ * @throws {RangeError} `options.awareOfUnicodeTokens` must be set to `true` to use `XX` token; see: https://git.io/fxCyr
  *
  * @example
  * // Represent 11 February 2014 in middle-endian format:
@@ -307,9 +318,11 @@ var doubleQuoteRegExp = /''/g
  * )
  * //=> "3 o'clock"
  */
-export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
+export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
   if (arguments.length < 2) {
-    throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
+    throw new TypeError(
+      '2 arguments required, but only ' + arguments.length + ' present'
+    )
   }
 
   var formatStr = String(dirtyFormatStr)
@@ -318,8 +331,7 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   var locale = options.locale || defaultLocale
 
   var localeFirstWeekContainsDate =
-    locale.options &&
-    locale.options.firstWeekContainsDate
+    locale.options && locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate == null
       ? 1
@@ -331,12 +343,18 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {
-    throw new RangeError('firstWeekContainsDate must be between 1 and 7 inclusively')
+    throw new RangeError(
+      'firstWeekContainsDate must be between 1 and 7 inclusively'
+    )
   }
 
   var localeWeekStartsOn = locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn =
+    localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn =
+    options.weekStartsOn == null
+      ? defaultWeekStartsOn
+      : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
@@ -372,7 +390,7 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
 
   var result = formatStr
     .match(longFormattingTokensRegExp)
-    .map(function (substring) {
+    .map(function(substring) {
       var firstCharacter = substring[0]
       if (firstCharacter === 'p' || firstCharacter === 'P') {
         var longFormatter = longFormatters[firstCharacter]
@@ -382,7 +400,7 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
     })
     .join('')
     .match(formattingTokensRegExp)
-    .map(function (substring) {
+    .map(function(substring) {
       // Replace two single quote characters with one single quote character
       if (substring === "''") {
         return "'"
@@ -395,6 +413,9 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
 
       var formatter = formatters[firstCharacter]
       if (formatter) {
+        if (!options.awareOfUnicodeTokens && isProtectedToken(substring)) {
+          throwProtectedError(substring)
+        }
         return formatter(utcDate, substring, locale.localize, formatterOptions)
       }
 
@@ -405,6 +426,6 @@ export default function format (dirtyDate, dirtyFormatStr, dirtyOptions) {
   return result
 }
 
-function cleanEscapedString (input) {
+function cleanEscapedString(input) {
   return input.match(escapedStringRegExp)[1].replace(doubleQuoteRegExp, "'")
 }

--- a/src/format/index.js.flow
+++ b/src/format/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -4,7 +4,7 @@
 import assert from 'power-assert'
 import format from '.'
 
-describe('format', function () {
+describe('format', function() {
   var date = new Date(1986, 3 /* Apr */, 4, 10, 32, 55, 123)
 
   var offset = date.getTimezoneOffset()
@@ -15,82 +15,116 @@ describe('format', function () {
   var minutesLeadingZero = minutes < 10 ? '0' : ''
   var sign = offset > 0 ? '-' : '+'
 
-  var timezone = sign + hoursLeadingZero + hours + ':' + minutesLeadingZero + minutes
+  var timezone =
+    sign + hoursLeadingZero + hours + ':' + minutesLeadingZero + minutes
   var timezoneShort = timezone.replace(':', '')
-  var timezoneWithOptionalMinutesShort = minutes === 0 ? sign + hoursLeadingZero + hours : timezoneShort
+  var timezoneWithOptionalMinutesShort =
+    minutes === 0 ? sign + hoursLeadingZero + hours : timezoneShort
 
   var timezoneWithZ = offset === 0 ? 'Z' : timezone
   var timezoneWithZShort = offset === 0 ? 'Z' : timezoneShort
-  var timezoneWithOptionalMinutesAndZShort = offset === 0 ? 'Z' : timezoneWithOptionalMinutesShort
+  var timezoneWithOptionalMinutesAndZShort =
+    offset === 0 ? 'Z' : timezoneWithOptionalMinutesShort
 
-  var timezoneGMTShort = minutes === 0
-    ? 'GMT' + sign + hours
-    : 'GMT' + sign + hours + ':' + minutesLeadingZero + minutes
+  var timezoneGMTShort =
+    minutes === 0
+      ? 'GMT' + sign + hours
+      : 'GMT' + sign + hours + ':' + minutesLeadingZero + minutes
   var timezoneGMT = 'GMT' + timezone
 
   var timestamp = date.getTime().toString()
   var secondsTimestamp = Math.floor(date.getTime() / 1000).toString()
 
-  it('accepts a string', function () {
+  it('accepts a string', function() {
     var date = new Date(2014, 3, 4).toISOString()
     assert(format(date, 'yyyy-MM-dd') === '2014-04-04')
   })
 
-  it('accepts a timestamp', function () {
+  it('accepts a timestamp', function() {
     var date = new Date(2014, 3, 4).getTime()
     assert(format(date, 'yyyy-MM-dd') === '2014-04-04')
   })
 
-  it('escapes characters between the single quote characters', function () {
+  it('escapes characters between the single quote characters', function() {
     var result = format(date, "'yyyy-'MM-dd'THH:mm:ss.SSSX' yyyy-'MM-dd'")
     assert(result === 'yyyy-04-04THH:mm:ss.SSSX 1986-MM-dd')
   })
 
-  it('two single quote characters are transformed into a "real" single quote', function () {
+  it('two single quote characters are transformed into a "real" single quote', function() {
     var date = new Date(2014, 3, 4, 5)
     assert(format(date, "''h 'o''clock'''") === "'5 o'clock'")
   })
 
-  describe('ordinal numbers', function () {
-    it('ordinal day of an ordinal month', function () {
-      var result = format(date, "do 'day of the' Mo 'month' of YYYY")
+  describe('ordinal numbers', function() {
+    it('ordinal day of an ordinal month', function() {
+      var result = format(date, "do 'day of the' Mo 'month' of YYYY", {
+        awareOfUnicodeTokens: true
+      })
       assert(result === '4th day of the 4th month of 1986')
     })
 
-    it('should return a correct ordinal number', function () {
+    it('should return a correct ordinal number', function() {
       var result = []
       for (var i = 1; i <= 31; i++) {
         result.push(format(new Date(2015, 0, i), 'do'))
       }
       var expected = [
-        '1st', '2nd', '3rd', '4th', '5th', '6th', '7th', '8th', '9th', '10th',
-        '11th', '12th', '13th', '14th', '15th', '16th', '17th', '18th', '19th', '20th',
-        '21st', '22nd', '23rd', '24th', '25th', '26th', '27th', '28th', '29th', '30th', '31st'
+        '1st',
+        '2nd',
+        '3rd',
+        '4th',
+        '5th',
+        '6th',
+        '7th',
+        '8th',
+        '9th',
+        '10th',
+        '11th',
+        '12th',
+        '13th',
+        '14th',
+        '15th',
+        '16th',
+        '17th',
+        '18th',
+        '19th',
+        '20th',
+        '21st',
+        '22nd',
+        '23rd',
+        '24th',
+        '25th',
+        '26th',
+        '27th',
+        '28th',
+        '29th',
+        '30th',
+        '31st'
       ]
       assert.deepEqual(result, expected)
     })
   })
 
-  it('era', function () {
+  it('era', function() {
     var result = format(date, 'G GG GGG GGGG GGGGG')
     assert(result === 'AD AD AD Anno Domini A')
   })
 
-  describe('year', function () {
-    describe('regular year', function () {
-      it('works as expected', function () {
+  describe('year', function() {
+    describe('regular year', function() {
+      it('works as expected', function() {
         var result = format(date, 'y yo yy yyy yyyy yyyyy')
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
-      it('1 BC formats as 1', function () {
+      it('1 BC formats as 1', function() {
         var date = new Date(0, 0 /* Jan */, 1)
         date.setFullYear(0)
         var result = format(date, 'y')
         assert(result === '1')
       })
 
-      it('2 BC formats as 2', function () {
+      it('2 BC formats as 2', function() {
         var date = new Date(0, 0 /* Jan */, 1)
         date.setFullYear(-1)
         var result = format(date, 'y')
@@ -98,38 +132,45 @@ describe('format', function () {
       })
     })
 
-    describe('local week-numbering year', function () {
-      it('works as expected', function () {
-        var result = format(date, 'Y Yo YY YYY YYYY YYYYY')
+    describe('local week-numbering year', function() {
+      it('works as expected', function() {
+        var result = format(date, 'Y Yo YY YYY YYYY YYYYY', {
+          awareOfUnicodeTokens: true
+        })
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
-      it('the first week of the next year', function () {
-        var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY')
+      it('the first week of the next year', function() {
+        var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
+          awareOfUnicodeTokens: true
+        })
         assert(result === '2014')
       })
 
-      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
+      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
           weekStartsOn: 1,
-          firstWeekContainsDate: 4
+          firstWeekContainsDate: 4,
+          awareOfUnicodeTokens: true
         })
         assert(result === '2013')
       })
 
-      it('the first week of year', function () {
-        var result = format(new Date(2016, 0 /* Jan */, 1), 'YYYY')
+      it('the first week of year', function() {
+        var result = format(new Date(2016, 0 /* Jan */, 1), 'YYYY', {
+          awareOfUnicodeTokens: true
+        })
         assert(result === '2016')
       })
 
-      it('1 BC formats as 1', function () {
+      it('1 BC formats as 1', function() {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(0)
         var result = format(date, 'Y')
         assert(result === '1')
       })
 
-      it('2 BC formats as 2', function () {
+      it('2 BC formats as 2', function() {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(-1)
         var result = format(date, 'Y')
@@ -137,30 +178,30 @@ describe('format', function () {
       })
     })
 
-    describe('ISO week-numbering year', function () {
-      it('works as expected', function () {
+    describe('ISO week-numbering year', function() {
+      it('works as expected', function() {
         var result = format(date, 'R RR RRR RRRR RRRRR')
         assert(result === '1986 1986 1986 1986 01986')
       })
 
-      it('the first week of the next year', function () {
+      it('the first week of the next year', function() {
         var result = format(new Date(2013, 11 /* Dec */, 30), 'RRRR')
         assert(result === '2014')
       })
 
-      it('the last week of the previous year', function () {
+      it('the last week of the previous year', function() {
         var result = format(new Date(2016, 0 /* Jan */, 1), 'RRRR')
         assert(result === '2015')
       })
 
-      it('1 BC formats as 0', function () {
+      it('1 BC formats as 0', function() {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(0)
         var result = format(date, 'R')
         assert(result === '0')
       })
 
-      it('2 BC formats as -1', function () {
+      it('2 BC formats as -1', function() {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(-1)
         var result = format(date, 'R')
@@ -168,20 +209,20 @@ describe('format', function () {
       })
     })
 
-    describe('extended year', function () {
-      it('works as expected', function () {
+    describe('extended year', function() {
+      it('works as expected', function() {
         var result = format(date, 'u uu uuu uuuu uuuuu')
         assert(result === '1986 1986 1986 1986 01986')
       })
 
-      it('1 BC formats as 0', function () {
+      it('1 BC formats as 0', function() {
         var date = new Date(0, 0, 1)
         date.setFullYear(0)
         var result = format(date, 'u')
         assert(result === '0')
       })
 
-      it('2 BC formats as -1', function () {
+      it('2 BC formats as -1', function() {
         var date = new Date(0, 0, 1)
         date.setFullYear(-1)
         var result = format(date, 'u')
@@ -190,48 +231,61 @@ describe('format', function () {
     })
   })
 
-  describe('quarter', function () {
-    it('formatting quarter', function () {
+  describe('quarter', function() {
+    it('formatting quarter', function() {
       var result = format(date, 'Q Qo QQ QQQ QQQQ QQQQQ')
       assert(result === '2 2nd 02 Q2 2nd quarter 2')
     })
 
-    it('stand-alone quarter', function () {
+    it('stand-alone quarter', function() {
       var result = format(date, 'q qo qq qqq qqqq qqqqq')
       assert(result === '2 2nd 02 Q2 2nd quarter 2')
     })
 
-    it('returns a correct quarter for each month', function () {
+    it('returns a correct quarter for each month', function() {
       var result = []
       for (var i = 0; i <= 11; i++) {
         result.push(format(new Date(1986, i, 1), 'Q'))
       }
-      var expected = ['1', '1', '1', '2', '2', '2', '3', '3', '3', '4', '4', '4']
+      var expected = [
+        '1',
+        '1',
+        '1',
+        '2',
+        '2',
+        '2',
+        '3',
+        '3',
+        '3',
+        '4',
+        '4',
+        '4'
+      ]
       assert.deepEqual(result, expected)
     })
   })
 
-  describe('month', function () {
-    it('formatting month', function () {
+  describe('month', function() {
+    it('formatting month', function() {
       var result = format(date, 'M Mo MM MMM MMMM MMMMM')
       assert(result === '4 4th 04 Apr April A')
     })
 
-    it('stand-alone month', function () {
+    it('stand-alone month', function() {
       var result = format(date, 'L Lo LL LLL LLLL LLLLL')
       assert(result === '4 4th 04 Apr April A')
     })
   })
 
-  describe('week', function () {
-    describe('local week of year', function () {
-      it('works as expected', function () {
+  describe('week', function() {
+    describe('local week of year', function() {
+      it('works as expected', function() {
         var date = new Date(1986, 3 /* Apr */, 6)
         var result = format(date, 'w wo ww')
         assert(result === '15 15th 15')
       })
 
-      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
+      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
         var date = new Date(1986, 3 /* Apr */, 6)
         var result = format(date, 'w wo ww', {
           weekStartsOn: 1,
@@ -241,47 +295,53 @@ describe('format', function () {
       })
     })
 
-    it('ISO week of year', function () {
+    it('ISO week of year', function() {
       var date = new Date(1986, 3 /* Apr */, 6)
       var result = format(date, 'I Io II')
       assert(result === '14 14th 14')
     })
   })
 
-  describe('day', function () {
-    it('date', function () {
+  describe('day', function() {
+    it('date', function() {
       var result = format(date, 'd do dd')
       assert(result === '4 4th 04')
     })
 
-    describe('day of year', function () {
-      it('works as expected', function () {
-        var result = format(date, 'D Do DD DDD DDDDD')
+    describe('day of year', function() {
+      it('works as expected', function() {
+        var result = format(date, 'D Do DD DDD DDDDD', {
+          awareOfUnicodeTokens: true
+        })
         assert(result === '94 94th 94 094 00094')
       })
 
-      it('returns a correct day number for the last day of a leap year', function () {
-        var result = format(new Date(1992, 11 /* Dec */, 31, 23, 59, 59, 999), 'D')
+      it('returns a correct day number for the last day of a leap year', function() {
+        var result = format(
+          new Date(1992, 11 /* Dec */, 31, 23, 59, 59, 999),
+          'D',
+          { awareOfUnicodeTokens: true }
+        )
         assert(result === '366')
       })
     })
   })
 
-  describe('week day', function () {
-    describe('day of week', function () {
-      it('works as expected', function () {
+  describe('week day', function() {
+    describe('day of week', function() {
+      it('works as expected', function() {
         var result = format(date, 'E EE EEE EEEE EEEEE EEEEEE')
         assert(result === 'Fri Fri Fri Friday F Fr')
       })
     })
 
-    describe('ISO day of week', function () {
-      it('works as expected', function () {
+    describe('ISO day of week', function() {
+      it('works as expected', function() {
         var result = format(date, 'i io ii iii iiii iiiii iiiiii')
         assert(result === '5 5th 05 Fri Friday F Fr')
       })
 
-      it('returns a correct day of an ISO week', function () {
+      it('returns a correct day of an ISO week', function() {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'i'))
@@ -291,13 +351,13 @@ describe('format', function () {
       })
     })
 
-    describe('formatting day of week', function () {
-      it('works as expected', function () {
+    describe('formatting day of week', function() {
+      it('works as expected', function() {
         var result = format(date, 'e eo ee eee eeee eeeee eeeeee')
         assert(result === '6 6th 06 Fri Friday F Fr')
       })
 
-      it('by default, 1 is Sunday, 2 is Monday, ...', function () {
+      it('by default, 1 is Sunday, 2 is Monday, ...', function() {
         var result = []
         for (var i = 7; i <= 13; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'e'))
@@ -306,23 +366,25 @@ describe('format', function () {
         assert.deepEqual(result, expected)
       })
 
-      it('allows to specify which day is the first day of the week', function () {
+      it('allows to specify which day is the first day of the week', function() {
         var result = []
         for (var i = 1; i <= 7; i++) {
-          result.push(format(new Date(1986, 8 /* Sep */, i), 'e', {weekStartsOn: 1}))
+          result.push(
+            format(new Date(1986, 8 /* Sep */, i), 'e', { weekStartsOn: 1 })
+          )
         }
         var expected = ['1', '2', '3', '4', '5', '6', '7']
         assert.deepEqual(result, expected)
       })
     })
 
-    describe('stand-alone day of week', function () {
-      it('works as expected', function () {
+    describe('stand-alone day of week', function() {
+      it('works as expected', function() {
         var result = format(date, 'c co cc ccc cccc ccccc cccccc')
         assert(result === '6 6th 06 Fri Friday F Fr')
       })
 
-      it('by default, 1 is Sunday, 2 is Monday, ...', function () {
+      it('by default, 1 is Sunday, 2 is Monday, ...', function() {
         var result = []
         for (var i = 7; i <= 13; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'c'))
@@ -331,10 +393,12 @@ describe('format', function () {
         assert.deepEqual(result, expected)
       })
 
-      it('allows to specify which day is the first day of the week', function () {
+      it('allows to specify which day is the first day of the week', function() {
         var result = []
         for (var i = 1; i <= 7; i++) {
-          result.push(format(new Date(1986, 8 /* Sep */, i), 'c', {weekStartsOn: 1}))
+          result.push(
+            format(new Date(1986, 8 /* Sep */, i), 'c', { weekStartsOn: 1 })
+          )
         }
         var expected = ['1', '2', '3', '4', '5', '6', '7']
         assert.deepEqual(result, expected)
@@ -342,111 +406,123 @@ describe('format', function () {
     })
   })
 
-  describe('day period and hour', function () {
-    it('hour [1-12]', function () {
+  describe('day period and hour', function() {
+    it('hour [1-12]', function() {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'h ho hh')
       assert(result === '12 12th 12')
     })
 
-    it('hour [0-23]', function () {
+    it('hour [0-23]', function() {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'H Ho HH')
       assert(result === '0 0th 00')
     })
 
-    it('hour [0-11]', function () {
+    it('hour [0-11]', function() {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'K Ko KK')
       assert(result === '0 0th 00')
     })
 
-    it('hour [1-24]', function () {
+    it('hour [1-24]', function() {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'k ko kk')
       assert(result === '24 24th 24')
     })
 
-    describe('AM, PM', function () {
-      it('works as expected', function () {
-        var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'a aa aaa aaaa aaaaa')
+    describe('AM, PM', function() {
+      it('works as expected', function() {
+        var result = format(
+          new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0),
+          'a aa aaa aaaa aaaaa'
+        )
         assert(result === 'AM AM AM a.m. a')
       })
 
-      it('12 PM', function () {
+      it('12 PM', function() {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'h H K k a') === '12 12 0 12 PM')
       })
 
-      it('12 AM', function () {
+      it('12 AM', function() {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, 'h H K k a') === '12 0 0 24 AM')
       })
     })
 
-    describe('AM, PM, noon, midnight', function () {
-      it('works as expected', function () {
-        var result = format(new Date(1986, 3 /* Apr */, 6, 2, 0, 0, 900), 'b bb bbb bbbb bbbbb')
+    describe('AM, PM, noon, midnight', function() {
+      it('works as expected', function() {
+        var result = format(
+          new Date(1986, 3 /* Apr */, 6, 2, 0, 0, 900),
+          'b bb bbb bbbb bbbbb'
+        )
         assert(result === 'AM AM AM a.m. a')
       })
 
-      it('12 PM', function () {
+      it('12 PM', function() {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'b bb bbb bbbb bbbbb') === 'noon noon noon noon n')
       })
 
-      it('12 AM', function () {
+      it('12 AM', function() {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
-        assert(format(date, 'b bb bbb bbbb bbbbb') === 'midnight midnight midnight midnight mi')
+        assert(
+          format(date, 'b bb bbb bbbb bbbbb') ===
+            'midnight midnight midnight midnight mi'
+        )
       })
     })
 
-    describe('flexible day periods', function () {
-      it('works as expected', function () {
+    describe('flexible day periods', function() {
+      it('works as expected', function() {
         var result = format(date, 'B, BB, BBB, BBBB, BBBBB')
-        assert(result === 'in the morning, in the morning, in the morning, in the morning, in the morning')
+        assert(
+          result ===
+            'in the morning, in the morning, in the morning, in the morning, in the morning'
+        )
       })
 
-      it('12 PM', function () {
+      it('12 PM', function() {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'h B') === '12 in the afternoon')
       })
 
-      it('5 PM', function () {
+      it('5 PM', function() {
         var date = new Date(1986, 3 /* Apr */, 6, 17, 0, 0, 900)
         assert(format(date, 'h B') === '5 in the evening')
       })
 
-      it('12 AM', function () {
+      it('12 AM', function() {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, 'h B') === '12 at night')
       })
 
-      it('4 AM', function () {
+      it('4 AM', function() {
         var date = new Date(1986, 3 /* Apr */, 6, 4, 0, 0, 900)
         assert(format(date, 'h B') === '4 in the morning')
       })
     })
   })
 
-  it('minute', function () {
+  it('minute', function() {
     var result = format(date, 'm mo mm')
     assert(result === '32 32nd 32')
   })
 
-  describe('second', function () {
-    it('second', function () {
+  describe('second', function() {
+    it('second', function() {
       var result = format(date, 's so ss')
       assert(result === '55 55th 55')
     })
 
-    it('fractional seconds', function () {
+    it('fractional seconds', function() {
       var result = format(date, 'S SS SSS SSSS')
       assert(result === '1 12 123 1230')
     })
   })
 
-  describe('time zone', function () {
-    it('should toDate the given date in a local timezone', function () {
+  describe('time zone', function() {
+    it('should toDate the given date in a local timezone', function() {
       assert(format('2015-01-01', 'yyyy-MM-dd') === '2015-01-01')
     })
-    it('ISO-8601 with Z', function () {
+    it('ISO-8601 with Z', function() {
       var result = format(date, 'X XX XXX XXXX XXXXX')
       var expectedResult = [
         timezoneWithOptionalMinutesAndZShort,
@@ -458,7 +534,7 @@ describe('format', function () {
       assert(result === expectedResult)
     })
 
-    it('ISO-8601 without Z', function () {
+    it('ISO-8601 without Z', function() {
       var result = format(date, 'x xx xxx xxxx xxxxx')
       var expectedResult = [
         timezoneWithOptionalMinutesShort,
@@ -470,7 +546,7 @@ describe('format', function () {
       assert(result === expectedResult)
     })
 
-    it('GMT', function () {
+    it('GMT', function() {
       var result = format(date, 'O OO OOO OOOO')
       var expectedResult = [
         timezoneGMTShort,
@@ -481,7 +557,7 @@ describe('format', function () {
       assert(result === expectedResult)
     })
 
-    it('Specific non-location', function () {
+    it('Specific non-location', function() {
       var result = format(date, 'z zz zzz zzzz')
       var expectedResult = [
         timezoneGMTShort,
@@ -493,91 +569,91 @@ describe('format', function () {
     })
   })
 
-  describe('timestamp', function () {
-    it('seconds timestamp', function () {
+  describe('timestamp', function() {
+    it('seconds timestamp', function() {
       var result = format(date, 't')
       assert(result === secondsTimestamp)
     })
 
-    it('milliseconds timestamp', function () {
+    it('milliseconds timestamp', function() {
       var result = format(date, 'T')
       assert(result === timestamp)
     })
   })
 
-  describe('long format', function () {
-    it('short date', function () {
+  describe('long format', function() {
+    it('short date', function() {
       var result = format(date, 'P')
       assert(result === '04/04/1986')
     })
 
-    it('medium date', function () {
+    it('medium date', function() {
       var result = format(date, 'PP')
       assert(result === 'Apr 4, 1986')
     })
 
-    it('long date', function () {
+    it('long date', function() {
       var result = format(date, 'PPP')
       assert(result === 'April 4th, 1986')
     })
 
-    it('full date', function () {
+    it('full date', function() {
       var result = format(date, 'PPPP')
       assert(result === 'Friday, April 4th, 1986')
     })
 
-    it('short time', function () {
+    it('short time', function() {
       var result = format(date, 'p')
       assert(result === '10:32 AM')
     })
 
-    it('medium time', function () {
+    it('medium time', function() {
       var result = format(date, 'pp')
       assert(result === '10:32:55 AM')
     })
 
-    it('long time', function () {
+    it('long time', function() {
       var result = format(date, 'ppp')
       assert(result === '10:32:55 AM ' + timezoneGMTShort)
     })
 
-    it('full time', function () {
+    it('full time', function() {
       var result = format(date, 'pppp')
       assert(result === '10:32:55 AM ' + timezoneGMT)
     })
 
-    it('short date + time', function () {
+    it('short date + time', function() {
       var result = format(date, 'Pp')
       assert(result === '04/04/1986, 10:32 AM')
     })
 
-    it('medium date + time', function () {
+    it('medium date + time', function() {
       var result = format(date, 'PPpp')
       assert(result === 'Apr 4, 1986, 10:32:55 AM')
     })
 
-    it('long date + time', function () {
+    it('long date + time', function() {
       var result = format(date, 'PPPppp')
       assert(result === 'April 4th, 1986 at 10:32:55 AM ' + timezoneGMTShort)
     })
 
-    it('full date + time', function () {
+    it('full date + time', function() {
       var result = format(date, 'PPPPpppp')
       assert(result === 'Friday, April 4th, 1986 at 10:32:55 AM ' + timezoneGMT)
     })
 
-    it('allows arbitrary combination of date and time', function () {
+    it('allows arbitrary combination of date and time', function() {
       var result = format(date, 'Ppppp')
       assert(result === '04/04/1986, 10:32:55 AM ' + timezoneGMT)
     })
   })
 
-  describe('edge cases', function () {
-    it("returns String('Invalid Date') if the date isn't valid", function () {
+  describe('edge cases', function() {
+    it("returns String('Invalid Date') if the date isn't valid", function() {
       assert(format(new Date(NaN), 'MMMM d, yyyy') === 'Invalid Date')
     })
 
-    it('handles dates before 100 AD', function () {
+    it('handles dates before 100 AD', function() {
       var initialDate = new Date(0)
       initialDate.setFullYear(7, 11 /* Dec */, 31)
       initialDate.setHours(0, 0, 0, 0)
@@ -585,7 +661,7 @@ describe('format', function () {
     })
   })
 
-  it('implicitly converts `formatString`', function () {
+  it('implicitly converts `formatString`', function() {
     // eslint-disable-next-line no-new-wrappers
     var formatString = new String('yyyy-MM-dd')
 
@@ -595,65 +671,131 @@ describe('format', function () {
     assert(format(date, formatString) === '2014-04-04')
   })
 
-  describe('custom locale', function () {
-    it('allows to pass a custom locale', function () {
+  describe('custom locale', function() {
+    it('allows to pass a custom locale', function() {
       var customLocale = {
         localize: {
-          month: function () {
+          month: function() {
             return 'works'
           }
         },
         formatLong: {
-          date: function () {
+          date: function() {
             return "'It' MMMM!"
           }
         }
       }
       // $ExpectedMistake
-      var result = format(date, 'PPPP', {locale: customLocale})
+      var result = format(date, 'PPPP', { locale: customLocale })
       assert(result === 'It works!')
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function () {
+    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function() {
       var customLocale = {
         formatLong: {}
       }
       // $ExpectedMistake
-      var block = format.bind(null, date, 'yyyy-MM-dd', {locale: customLocale})
+      var block = format.bind(null, date, 'yyyy-MM-dd', {
+        locale: customLocale
+      })
       assert.throws(block, RangeError)
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function () {
+    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function() {
       var customLocale = {
         // $ExpectedMistake
         localize: {}
       }
       // $ExpectedMistake
-      var block = format.bind(null, date, 'yyyy-MM-dd', {locale: customLocale})
+      var block = format.bind(null, date, 'yyyy-MM-dd', {
+        locale: customLocale
+      })
       assert.throws(block, RangeError)
     })
   })
 
-  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
     // $ExpectedMistake
-    var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {weekStartsOn: NaN})
+    var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {
+      weekStartsOn: NaN
+    })
     assert.throws(block, RangeError)
   })
 
-  it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function () {
+  it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function() {
     // $ExpectedMistake
-    var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {firstWeekContainsDate: NaN})
+    var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {
+      firstWeekContainsDate: NaN
+    })
     assert.throws(block, RangeError)
   })
 
-  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function () {
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined', function() {
     // $ExpectedMistake
-    var block = format.bind(null, date, 'yyyy-MM-dd', {additionalDigits: NaN})
+    var block = format.bind(null, date, 'yyyy-MM-dd', { additionalDigits: NaN })
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function () {
+  it('throws TypeError exception if passed less than 2 arguments', function() {
     assert.throws(format.bind(null), TypeError)
     assert.throws(format.bind(null, 1), TypeError)
+  })
+
+  describe('awareOfUnicodeTokens option', () => {
+    it('throws an error if D token is used', () => {
+      const block = format.bind(null, date, 'yyyy-MM-D')
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `D` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows D token if awareOfUnicodeTokens is set to true', () => {
+      const result = format(date, 'yyyy-MM-D', { awareOfUnicodeTokens: true })
+      assert.deepEqual(result, '1986-04-94')
+    })
+
+    it('throws an error if DD token is used', () => {
+      const block = format.bind(null, date, 'yyyy-MM-DD')
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `DD` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows DD token if awareOfUnicodeTokens is set to true', () => {
+      const result = format(date, 'yyyy-MM-DD', { awareOfUnicodeTokens: true })
+      assert.deepEqual(result, '1986-04-94')
+    })
+
+    it('throws an error if YY token is used', () => {
+      const block = format.bind(null, date, 'YY-MM-dd')
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows YY token if awareOfUnicodeTokens is set to true', () => {
+      const result = format(date, 'YY-MM-dd', { awareOfUnicodeTokens: true })
+      assert.deepEqual(result, '86-04-04')
+    })
+
+    it('throws an error if YYYY token is used', () => {
+      const block = format.bind(null, date, 'YYYY-MM-dd')
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows YYYY token if awareOfUnicodeTokens is set to true', () => {
+      const result = format(date, 'YYYY-MM-dd', { awareOfUnicodeTokens: true })
+      assert.deepEqual(result, '1986-04-04')
+    })
   })
 })

--- a/src/formatDistance/index.js.flow
+++ b/src/formatDistance/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/formatDistanceStrict/index.js.flow
+++ b/src/formatDistanceStrict/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/formatRelative/index.js.flow
+++ b/src/formatRelative/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addDays/index.js.flow
+++ b/src/fp/addDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addDaysWithOptions/index.js.flow
+++ b/src/fp/addDaysWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addHours/index.js.flow
+++ b/src/fp/addHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addHoursWithOptions/index.js.flow
+++ b/src/fp/addHoursWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addISOWeekYears/index.js.flow
+++ b/src/fp/addISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addISOWeekYearsWithOptions/index.js.flow
+++ b/src/fp/addISOWeekYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addMilliseconds/index.js.flow
+++ b/src/fp/addMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addMillisecondsWithOptions/index.js.flow
+++ b/src/fp/addMillisecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addMinutes/index.js.flow
+++ b/src/fp/addMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addMinutesWithOptions/index.js.flow
+++ b/src/fp/addMinutesWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addMonths/index.js.flow
+++ b/src/fp/addMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addMonthsWithOptions/index.js.flow
+++ b/src/fp/addMonthsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addQuarters/index.js.flow
+++ b/src/fp/addQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addQuartersWithOptions/index.js.flow
+++ b/src/fp/addQuartersWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addSeconds/index.js.flow
+++ b/src/fp/addSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addSecondsWithOptions/index.js.flow
+++ b/src/fp/addSecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addWeeks/index.js.flow
+++ b/src/fp/addWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addWeeksWithOptions/index.js.flow
+++ b/src/fp/addWeeksWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addYears/index.js.flow
+++ b/src/fp/addYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/addYearsWithOptions/index.js.flow
+++ b/src/fp/addYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/areIntervalsOverlapping/index.js.flow
+++ b/src/fp/areIntervalsOverlapping/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/areIntervalsOverlappingWithOptions/index.js.flow
+++ b/src/fp/areIntervalsOverlappingWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/closestIndexTo/index.js.flow
+++ b/src/fp/closestIndexTo/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/closestIndexToWithOptions/index.js.flow
+++ b/src/fp/closestIndexToWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/closestTo/index.js.flow
+++ b/src/fp/closestTo/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/closestToWithOptions/index.js.flow
+++ b/src/fp/closestToWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/compareAsc/index.js.flow
+++ b/src/fp/compareAsc/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/compareAscWithOptions/index.js.flow
+++ b/src/fp/compareAscWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/compareDesc/index.js.flow
+++ b/src/fp/compareDesc/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/compareDescWithOptions/index.js.flow
+++ b/src/fp/compareDescWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarDays/index.js.flow
+++ b/src/fp/differenceInCalendarDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarDaysWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarDaysWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarISOWeekYears/index.js.flow
+++ b/src/fp/differenceInCalendarISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarISOWeekYearsWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarISOWeekYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarISOWeeks/index.js.flow
+++ b/src/fp/differenceInCalendarISOWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarISOWeeksWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarISOWeeksWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarMonths/index.js.flow
+++ b/src/fp/differenceInCalendarMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarMonthsWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarMonthsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarQuarters/index.js.flow
+++ b/src/fp/differenceInCalendarQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarQuartersWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarQuartersWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarWeeks/index.js.flow
+++ b/src/fp/differenceInCalendarWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarWeeksWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarWeeksWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarYears/index.js.flow
+++ b/src/fp/differenceInCalendarYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInCalendarYearsWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInDays/index.js.flow
+++ b/src/fp/differenceInDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInDaysWithOptions/index.js.flow
+++ b/src/fp/differenceInDaysWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInHours/index.js.flow
+++ b/src/fp/differenceInHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInHoursWithOptions/index.js.flow
+++ b/src/fp/differenceInHoursWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInISOWeekYears/index.js.flow
+++ b/src/fp/differenceInISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInISOWeekYearsWithOptions/index.js.flow
+++ b/src/fp/differenceInISOWeekYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInMilliseconds/index.js.flow
+++ b/src/fp/differenceInMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInMillisecondsWithOptions/index.js.flow
+++ b/src/fp/differenceInMillisecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInMinutes/index.js.flow
+++ b/src/fp/differenceInMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInMinutesWithOptions/index.js.flow
+++ b/src/fp/differenceInMinutesWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInMonths/index.js.flow
+++ b/src/fp/differenceInMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInMonthsWithOptions/index.js.flow
+++ b/src/fp/differenceInMonthsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInQuarters/index.js.flow
+++ b/src/fp/differenceInQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInQuartersWithOptions/index.js.flow
+++ b/src/fp/differenceInQuartersWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInSeconds/index.js.flow
+++ b/src/fp/differenceInSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInSecondsWithOptions/index.js.flow
+++ b/src/fp/differenceInSecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInWeeks/index.js.flow
+++ b/src/fp/differenceInWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInWeeksWithOptions/index.js.flow
+++ b/src/fp/differenceInWeeksWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInYears/index.js.flow
+++ b/src/fp/differenceInYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/differenceInYearsWithOptions/index.js.flow
+++ b/src/fp/differenceInYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/eachDayOfInterval/index.js.flow
+++ b/src/fp/eachDayOfInterval/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/eachDayOfIntervalWithOptions/index.js.flow
+++ b/src/fp/eachDayOfIntervalWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/eachWeekOfInterval/index.js.flow
+++ b/src/fp/eachWeekOfInterval/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/eachWeekOfIntervalWithOptions/index.js.flow
+++ b/src/fp/eachWeekOfIntervalWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfDay/index.js.flow
+++ b/src/fp/endOfDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfDayWithOptions/index.js.flow
+++ b/src/fp/endOfDayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfDecade/index.js.flow
+++ b/src/fp/endOfDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfDecadeWithOptions/index.js.flow
+++ b/src/fp/endOfDecadeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfHour/index.js.flow
+++ b/src/fp/endOfHour/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfHourWithOptions/index.js.flow
+++ b/src/fp/endOfHourWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfISOWeek/index.js.flow
+++ b/src/fp/endOfISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfISOWeekWithOptions/index.js.flow
+++ b/src/fp/endOfISOWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfISOWeekYear/index.js.flow
+++ b/src/fp/endOfISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfISOWeekYearWithOptions/index.js.flow
+++ b/src/fp/endOfISOWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfMinute/index.js.flow
+++ b/src/fp/endOfMinute/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfMinuteWithOptions/index.js.flow
+++ b/src/fp/endOfMinuteWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfMonth/index.js.flow
+++ b/src/fp/endOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfMonthWithOptions/index.js.flow
+++ b/src/fp/endOfMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfQuarter/index.js.flow
+++ b/src/fp/endOfQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfQuarterWithOptions/index.js.flow
+++ b/src/fp/endOfQuarterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfSecond/index.js.flow
+++ b/src/fp/endOfSecond/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfSecondWithOptions/index.js.flow
+++ b/src/fp/endOfSecondWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfWeek/index.js.flow
+++ b/src/fp/endOfWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfWeekWithOptions/index.js.flow
+++ b/src/fp/endOfWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfYear/index.js.flow
+++ b/src/fp/endOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/endOfYearWithOptions/index.js.flow
+++ b/src/fp/endOfYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/format/index.js.flow
+++ b/src/fp/format/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatDistance/index.js.flow
+++ b/src/fp/formatDistance/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatDistanceStrict/index.js.flow
+++ b/src/fp/formatDistanceStrict/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatDistanceStrictWithOptions/index.js.flow
+++ b/src/fp/formatDistanceStrictWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatDistanceWithOptions/index.js.flow
+++ b/src/fp/formatDistanceWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatRelative/index.js.flow
+++ b/src/fp/formatRelative/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatRelativeWithOptions/index.js.flow
+++ b/src/fp/formatRelativeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/formatWithOptions/index.js.flow
+++ b/src/fp/formatWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDate/index.js.flow
+++ b/src/fp/getDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDateWithOptions/index.js.flow
+++ b/src/fp/getDateWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDay/index.js.flow
+++ b/src/fp/getDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDayOfYear/index.js.flow
+++ b/src/fp/getDayOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDayOfYearWithOptions/index.js.flow
+++ b/src/fp/getDayOfYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDayWithOptions/index.js.flow
+++ b/src/fp/getDayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDaysInMonth/index.js.flow
+++ b/src/fp/getDaysInMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDaysInMonthWithOptions/index.js.flow
+++ b/src/fp/getDaysInMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDaysInYear/index.js.flow
+++ b/src/fp/getDaysInYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDaysInYearWithOptions/index.js.flow
+++ b/src/fp/getDaysInYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDecade/index.js.flow
+++ b/src/fp/getDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getDecadeWithOptions/index.js.flow
+++ b/src/fp/getDecadeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getHours/index.js.flow
+++ b/src/fp/getHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getHoursWithOptions/index.js.flow
+++ b/src/fp/getHoursWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISODay/index.js.flow
+++ b/src/fp/getISODay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISODayWithOptions/index.js.flow
+++ b/src/fp/getISODayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISOWeek/index.js.flow
+++ b/src/fp/getISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISOWeekWithOptions/index.js.flow
+++ b/src/fp/getISOWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISOWeekYear/index.js.flow
+++ b/src/fp/getISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISOWeekYearWithOptions/index.js.flow
+++ b/src/fp/getISOWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISOWeeksInYear/index.js.flow
+++ b/src/fp/getISOWeeksInYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getISOWeeksInYearWithOptions/index.js.flow
+++ b/src/fp/getISOWeeksInYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getMilliseconds/index.js.flow
+++ b/src/fp/getMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getMillisecondsWithOptions/index.js.flow
+++ b/src/fp/getMillisecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getMinutes/index.js.flow
+++ b/src/fp/getMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getMinutesWithOptions/index.js.flow
+++ b/src/fp/getMinutesWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getMonth/index.js.flow
+++ b/src/fp/getMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getMonthWithOptions/index.js.flow
+++ b/src/fp/getMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getOverlappingDaysInIntervals/index.js.flow
+++ b/src/fp/getOverlappingDaysInIntervals/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getOverlappingDaysInIntervalsWithOptions/index.js.flow
+++ b/src/fp/getOverlappingDaysInIntervalsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getQuarter/index.js.flow
+++ b/src/fp/getQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getQuarterWithOptions/index.js.flow
+++ b/src/fp/getQuarterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getSeconds/index.js.flow
+++ b/src/fp/getSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getSecondsWithOptions/index.js.flow
+++ b/src/fp/getSecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getTime/index.js.flow
+++ b/src/fp/getTime/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getTimeWithOptions/index.js.flow
+++ b/src/fp/getTimeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getUnixTime/index.js.flow
+++ b/src/fp/getUnixTime/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getUnixTimeWithOptions/index.js.flow
+++ b/src/fp/getUnixTimeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeek/index.js.flow
+++ b/src/fp/getWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeekOfMonth/index.js.flow
+++ b/src/fp/getWeekOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeekOfMonthWithOptions/index.js.flow
+++ b/src/fp/getWeekOfMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeekWithOptions/index.js.flow
+++ b/src/fp/getWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeekYear/index.js.flow
+++ b/src/fp/getWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeekYearWithOptions/index.js.flow
+++ b/src/fp/getWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeeksInMonth/index.js.flow
+++ b/src/fp/getWeeksInMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getWeeksInMonthWithOptions/index.js.flow
+++ b/src/fp/getWeeksInMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getYear/index.js.flow
+++ b/src/fp/getYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/getYearWithOptions/index.js.flow
+++ b/src/fp/getYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isAfter/index.js.flow
+++ b/src/fp/isAfter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isAfterWithOptions/index.js.flow
+++ b/src/fp/isAfterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isBefore/index.js.flow
+++ b/src/fp/isBefore/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isBeforeWithOptions/index.js.flow
+++ b/src/fp/isBeforeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isDate/index.js.flow
+++ b/src/fp/isDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isDateWithOptions/index.js.flow
+++ b/src/fp/isDateWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isEqual/index.js.flow
+++ b/src/fp/isEqual/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isEqualWithOptions/index.js.flow
+++ b/src/fp/isEqualWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isFirstDayOfMonth/index.js.flow
+++ b/src/fp/isFirstDayOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isFirstDayOfMonthWithOptions/index.js.flow
+++ b/src/fp/isFirstDayOfMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isFriday/index.js.flow
+++ b/src/fp/isFriday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isFridayWithOptions/index.js.flow
+++ b/src/fp/isFridayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isLastDayOfMonth/index.js.flow
+++ b/src/fp/isLastDayOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isLastDayOfMonthWithOptions/index.js.flow
+++ b/src/fp/isLastDayOfMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isLeapYear/index.js.flow
+++ b/src/fp/isLeapYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isLeapYearWithOptions/index.js.flow
+++ b/src/fp/isLeapYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isMonday/index.js.flow
+++ b/src/fp/isMonday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isMondayWithOptions/index.js.flow
+++ b/src/fp/isMondayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameDay/index.js.flow
+++ b/src/fp/isSameDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameDayWithOptions/index.js.flow
+++ b/src/fp/isSameDayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameHour/index.js.flow
+++ b/src/fp/isSameHour/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameHourWithOptions/index.js.flow
+++ b/src/fp/isSameHourWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameISOWeek/index.js.flow
+++ b/src/fp/isSameISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameISOWeekWithOptions/index.js.flow
+++ b/src/fp/isSameISOWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameISOWeekYear/index.js.flow
+++ b/src/fp/isSameISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameISOWeekYearWithOptions/index.js.flow
+++ b/src/fp/isSameISOWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameMinute/index.js.flow
+++ b/src/fp/isSameMinute/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameMinuteWithOptions/index.js.flow
+++ b/src/fp/isSameMinuteWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameMonth/index.js.flow
+++ b/src/fp/isSameMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameMonthWithOptions/index.js.flow
+++ b/src/fp/isSameMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameQuarter/index.js.flow
+++ b/src/fp/isSameQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameQuarterWithOptions/index.js.flow
+++ b/src/fp/isSameQuarterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameSecond/index.js.flow
+++ b/src/fp/isSameSecond/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameSecondWithOptions/index.js.flow
+++ b/src/fp/isSameSecondWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameWeek/index.js.flow
+++ b/src/fp/isSameWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameWeekWithOptions/index.js.flow
+++ b/src/fp/isSameWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameYear/index.js.flow
+++ b/src/fp/isSameYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSameYearWithOptions/index.js.flow
+++ b/src/fp/isSameYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSaturday/index.js.flow
+++ b/src/fp/isSaturday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSaturdayWithOptions/index.js.flow
+++ b/src/fp/isSaturdayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSunday/index.js.flow
+++ b/src/fp/isSunday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isSundayWithOptions/index.js.flow
+++ b/src/fp/isSundayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isThursday/index.js.flow
+++ b/src/fp/isThursday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isThursdayWithOptions/index.js.flow
+++ b/src/fp/isThursdayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isTuesday/index.js.flow
+++ b/src/fp/isTuesday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isTuesdayWithOptions/index.js.flow
+++ b/src/fp/isTuesdayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isValid/index.js.flow
+++ b/src/fp/isValid/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isValidWithOptions/index.js.flow
+++ b/src/fp/isValidWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isWednesday/index.js.flow
+++ b/src/fp/isWednesday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isWednesdayWithOptions/index.js.flow
+++ b/src/fp/isWednesdayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isWeekend/index.js.flow
+++ b/src/fp/isWeekend/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isWeekendWithOptions/index.js.flow
+++ b/src/fp/isWeekendWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isWithinInterval/index.js.flow
+++ b/src/fp/isWithinInterval/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/isWithinIntervalWithOptions/index.js.flow
+++ b/src/fp/isWithinIntervalWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfDecade/index.js.flow
+++ b/src/fp/lastDayOfDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfDecadeWithOptions/index.js.flow
+++ b/src/fp/lastDayOfDecadeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfISOWeek/index.js.flow
+++ b/src/fp/lastDayOfISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfISOWeekWithOptions/index.js.flow
+++ b/src/fp/lastDayOfISOWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfISOWeekYear/index.js.flow
+++ b/src/fp/lastDayOfISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfISOWeekYearWithOptions/index.js.flow
+++ b/src/fp/lastDayOfISOWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfMonth/index.js.flow
+++ b/src/fp/lastDayOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfMonthWithOptions/index.js.flow
+++ b/src/fp/lastDayOfMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfQuarter/index.js.flow
+++ b/src/fp/lastDayOfQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfQuarterWithOptions/index.js.flow
+++ b/src/fp/lastDayOfQuarterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfWeek/index.js.flow
+++ b/src/fp/lastDayOfWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfWeekWithOptions/index.js.flow
+++ b/src/fp/lastDayOfWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfYear/index.js.flow
+++ b/src/fp/lastDayOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/lastDayOfYearWithOptions/index.js.flow
+++ b/src/fp/lastDayOfYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/max/index.js.flow
+++ b/src/fp/max/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/maxWithOptions/index.js.flow
+++ b/src/fp/maxWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/min/index.js.flow
+++ b/src/fp/min/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/minWithOptions/index.js.flow
+++ b/src/fp/minWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/parse/index.js.flow
+++ b/src/fp/parse/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/parseWithOptions/index.js.flow
+++ b/src/fp/parseWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setDate/index.js.flow
+++ b/src/fp/setDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setDateWithOptions/index.js.flow
+++ b/src/fp/setDateWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setDay/index.js.flow
+++ b/src/fp/setDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setDayOfYear/index.js.flow
+++ b/src/fp/setDayOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setDayOfYearWithOptions/index.js.flow
+++ b/src/fp/setDayOfYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setDayWithOptions/index.js.flow
+++ b/src/fp/setDayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setHours/index.js.flow
+++ b/src/fp/setHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setHoursWithOptions/index.js.flow
+++ b/src/fp/setHoursWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setISODay/index.js.flow
+++ b/src/fp/setISODay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setISODayWithOptions/index.js.flow
+++ b/src/fp/setISODayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setISOWeek/index.js.flow
+++ b/src/fp/setISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setISOWeekWithOptions/index.js.flow
+++ b/src/fp/setISOWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setISOWeekYear/index.js.flow
+++ b/src/fp/setISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setISOWeekYearWithOptions/index.js.flow
+++ b/src/fp/setISOWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setMilliseconds/index.js.flow
+++ b/src/fp/setMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setMillisecondsWithOptions/index.js.flow
+++ b/src/fp/setMillisecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setMinutes/index.js.flow
+++ b/src/fp/setMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setMinutesWithOptions/index.js.flow
+++ b/src/fp/setMinutesWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setMonth/index.js.flow
+++ b/src/fp/setMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setMonthWithOptions/index.js.flow
+++ b/src/fp/setMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setQuarter/index.js.flow
+++ b/src/fp/setQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setQuarterWithOptions/index.js.flow
+++ b/src/fp/setQuarterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setSeconds/index.js.flow
+++ b/src/fp/setSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setSecondsWithOptions/index.js.flow
+++ b/src/fp/setSecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setWeek/index.js.flow
+++ b/src/fp/setWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setWeekWithOptions/index.js.flow
+++ b/src/fp/setWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setWeekYear/index.js.flow
+++ b/src/fp/setWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setWeekYearWithOptions/index.js.flow
+++ b/src/fp/setWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setYear/index.js.flow
+++ b/src/fp/setYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/setYearWithOptions/index.js.flow
+++ b/src/fp/setYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfDay/index.js.flow
+++ b/src/fp/startOfDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfDayWithOptions/index.js.flow
+++ b/src/fp/startOfDayWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfDecade/index.js.flow
+++ b/src/fp/startOfDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfDecadeWithOptions/index.js.flow
+++ b/src/fp/startOfDecadeWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfHour/index.js.flow
+++ b/src/fp/startOfHour/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfHourWithOptions/index.js.flow
+++ b/src/fp/startOfHourWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfISOWeek/index.js.flow
+++ b/src/fp/startOfISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfISOWeekWithOptions/index.js.flow
+++ b/src/fp/startOfISOWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfISOWeekYear/index.js.flow
+++ b/src/fp/startOfISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfISOWeekYearWithOptions/index.js.flow
+++ b/src/fp/startOfISOWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfMinute/index.js.flow
+++ b/src/fp/startOfMinute/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfMinuteWithOptions/index.js.flow
+++ b/src/fp/startOfMinuteWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfMonth/index.js.flow
+++ b/src/fp/startOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfMonthWithOptions/index.js.flow
+++ b/src/fp/startOfMonthWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfQuarter/index.js.flow
+++ b/src/fp/startOfQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfQuarterWithOptions/index.js.flow
+++ b/src/fp/startOfQuarterWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfSecond/index.js.flow
+++ b/src/fp/startOfSecond/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfSecondWithOptions/index.js.flow
+++ b/src/fp/startOfSecondWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfWeek/index.js.flow
+++ b/src/fp/startOfWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfWeekWithOptions/index.js.flow
+++ b/src/fp/startOfWeekWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfWeekYear/index.js.flow
+++ b/src/fp/startOfWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfWeekYearWithOptions/index.js.flow
+++ b/src/fp/startOfWeekYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfYear/index.js.flow
+++ b/src/fp/startOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/startOfYearWithOptions/index.js.flow
+++ b/src/fp/startOfYearWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subDays/index.js.flow
+++ b/src/fp/subDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subDaysWithOptions/index.js.flow
+++ b/src/fp/subDaysWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subHours/index.js.flow
+++ b/src/fp/subHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subHoursWithOptions/index.js.flow
+++ b/src/fp/subHoursWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subISOWeekYears/index.js.flow
+++ b/src/fp/subISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subISOWeekYearsWithOptions/index.js.flow
+++ b/src/fp/subISOWeekYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subMilliseconds/index.js.flow
+++ b/src/fp/subMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subMillisecondsWithOptions/index.js.flow
+++ b/src/fp/subMillisecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subMinutes/index.js.flow
+++ b/src/fp/subMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subMinutesWithOptions/index.js.flow
+++ b/src/fp/subMinutesWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subMonths/index.js.flow
+++ b/src/fp/subMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subMonthsWithOptions/index.js.flow
+++ b/src/fp/subMonthsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subQuarters/index.js.flow
+++ b/src/fp/subQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subQuartersWithOptions/index.js.flow
+++ b/src/fp/subQuartersWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subSeconds/index.js.flow
+++ b/src/fp/subSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subSecondsWithOptions/index.js.flow
+++ b/src/fp/subSecondsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subWeeks/index.js.flow
+++ b/src/fp/subWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subWeeksWithOptions/index.js.flow
+++ b/src/fp/subWeeksWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subYears/index.js.flow
+++ b/src/fp/subYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/subYearsWithOptions/index.js.flow
+++ b/src/fp/subYearsWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/toDate/index.js.flow
+++ b/src/fp/toDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/fp/toDateWithOptions/index.js.flow
+++ b/src/fp/toDateWithOptions/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getDate/index.js.flow
+++ b/src/getDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getDay/index.js.flow
+++ b/src/getDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getDayOfYear/index.js.flow
+++ b/src/getDayOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getDaysInMonth/index.js.flow
+++ b/src/getDaysInMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getDaysInYear/index.js.flow
+++ b/src/getDaysInYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getDecade/index.js.flow
+++ b/src/getDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getHours/index.js.flow
+++ b/src/getHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getISODay/index.js.flow
+++ b/src/getISODay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getISOWeek/index.js.flow
+++ b/src/getISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getISOWeekYear/index.js.flow
+++ b/src/getISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getISOWeeksInYear/index.js.flow
+++ b/src/getISOWeeksInYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getMilliseconds/index.js.flow
+++ b/src/getMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getMinutes/index.js.flow
+++ b/src/getMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getMonth/index.js.flow
+++ b/src/getMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getOverlappingDaysInIntervals/index.js.flow
+++ b/src/getOverlappingDaysInIntervals/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getQuarter/index.js.flow
+++ b/src/getQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getSeconds/index.js.flow
+++ b/src/getSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getTime/index.js.flow
+++ b/src/getTime/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getUnixTime/index.js.flow
+++ b/src/getUnixTime/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getWeek/index.js.flow
+++ b/src/getWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getWeekOfMonth/index.js.flow
+++ b/src/getWeekOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getWeekYear/index.js.flow
+++ b/src/getWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getWeeksInMonth/index.js.flow
+++ b/src/getWeeksInMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/getYear/index.js.flow
+++ b/src/getYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isAfter/index.js.flow
+++ b/src/isAfter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isBefore/index.js.flow
+++ b/src/isBefore/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isDate/index.js.flow
+++ b/src/isDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isEqual/index.js.flow
+++ b/src/isEqual/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isFirstDayOfMonth/index.js.flow
+++ b/src/isFirstDayOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isFriday/index.js.flow
+++ b/src/isFriday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isLastDayOfMonth/index.js.flow
+++ b/src/isLastDayOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isLeapYear/index.js.flow
+++ b/src/isLeapYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isMonday/index.js.flow
+++ b/src/isMonday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameDay/index.js.flow
+++ b/src/isSameDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameHour/index.js.flow
+++ b/src/isSameHour/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameISOWeek/index.js.flow
+++ b/src/isSameISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameISOWeekYear/index.js.flow
+++ b/src/isSameISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameMinute/index.js.flow
+++ b/src/isSameMinute/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameMonth/index.js.flow
+++ b/src/isSameMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameQuarter/index.js.flow
+++ b/src/isSameQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameSecond/index.js.flow
+++ b/src/isSameSecond/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameWeek/index.js.flow
+++ b/src/isSameWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSameYear/index.js.flow
+++ b/src/isSameYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSaturday/index.js.flow
+++ b/src/isSaturday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isSunday/index.js.flow
+++ b/src/isSunday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isThursday/index.js.flow
+++ b/src/isThursday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isTuesday/index.js.flow
+++ b/src/isTuesday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isValid/index.js.flow
+++ b/src/isValid/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isWednesday/index.js.flow
+++ b/src/isWednesday/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isWeekend/index.js.flow
+++ b/src/isWeekend/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/isWithinInterval/index.js.flow
+++ b/src/isWithinInterval/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfDecade/index.js.flow
+++ b/src/lastDayOfDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfISOWeek/index.js.flow
+++ b/src/lastDayOfISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfISOWeekYear/index.js.flow
+++ b/src/lastDayOfISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfMonth/index.js.flow
+++ b/src/lastDayOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfQuarter/index.js.flow
+++ b/src/lastDayOfQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfWeek/index.js.flow
+++ b/src/lastDayOfWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/lastDayOfYear/index.js.flow
+++ b/src/lastDayOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/max/index.js.flow
+++ b/src/max/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/min/index.js.flow
+++ b/src/min/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -4,6 +4,7 @@ import toDate from '../toDate/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
 import defaultLocale from '../locale/en-US/index.js'
 import parsers from './_lib/parsers/index.js'
+import { isProtectedToken, throwProtectedError } from '../_lib/protectedTokens'
 
 var TIMEZONE_UNIT_PRIORITY = 20
 
@@ -33,6 +34,9 @@ var notWhitespaceRegExp = /\S/
  * @description
  * Return the date parsed from string using the given format string.
  *
+ * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
+ * > See: https://git.io/fxCyr
+ *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
  *
@@ -54,9 +58,9 @@ var notWhitespaceRegExp = /\S/
  * |                                 |     | yyyyy   | ...                               | 2,4   |
  * | Local week-numbering year       | 130 | Y       | 44, 1, 1900, 2017, 9000           | 4     |
  * |                                 |     | Yo      | 44th, 1st, 1900th, 9999999th      | 4,5   |
- * |                                 |     | YY      | 44, 01, 00, 17                    | 4     |
+ * |                                 |     | YY      | 44, 01, 00, 17                    | 4,6   |
  * |                                 |     | YYY     | 044, 001, 123, 999                | 4     |
- * |                                 |     | YYYY    | 0044, 0001, 1900, 2017            | 4     |
+ * |                                 |     | YYYY    | 0044, 0001, 1900, 2017            | 4,6   |
  * |                                 |     | YYYYY   | ...                               | 2,4   |
  * | ISO week-numbering year         | 130 | R       | -43, 1, 1900, 2017, 9999, -9999   | 4,5   |
  * |                                 |     | RR      | -43, 01, 00, 17                   | 4,5   |
@@ -101,9 +105,9 @@ var notWhitespaceRegExp = /\S/
  * | Day of month                    |  90 | d       | 1, 2, ..., 31                     |       |
  * |                                 |     | do      | 1st, 2nd, ..., 31st               | 5     |
  * |                                 |     | dd      | 01, 02, ..., 31                   |       |
- * | Day of year                     |  90 | D       | 1, 2, ..., 365, 366               |       |
+ * | Day of year                     |  90 | D       | 1, 2, ..., 365, 366               | 6     |
  * |                                 |     | Do      | 1st, 2nd, ..., 365th, 366th       | 5     |
- * |                                 |     | DD      | 01, 02, ..., 365, 366             |       |
+ * |                                 |     | DD      | 01, 02, ..., 365, 366             | 6     |
  * |                                 |     | DDD     | 001, 002, ..., 365, 366           |       |
  * |                                 |     | DDDD    | ...                               | 2     |
  * | Day of week (formatting)        |  90 | E..EEE  | Mon, Tue, Wed, ..., Su            |       |
@@ -231,6 +235,8 @@ var notWhitespaceRegExp = /\S/
  *    - `R`: ISO week-numbering year
  *    - `o`: ordinal number modifier
  *
+ * 6. These tokens are often confused with others. See: https://git.io/fxCyr
+ *
  * Values will be assigned to the date in the descending order of its unit's priority.
  * Units of an equal priority overwrite each other in the order of appearance.
  *
@@ -260,12 +266,17 @@ var notWhitespaceRegExp = /\S/
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
+ * @param {Boolean} [options.awareOfUnicodeTokens=false] - if true, allows usage of Unicode tokens causes confusion:
+ *   - Some of the day of year tokens (`D`, `DD`) that are confused with the day of month tokens (`d`, `dd`).
+ *   - Some of the local week-numbering year tokens (`YY`, `YYYY`) that are confused with the calendar year tokens (`yy`, `yyyy`).
+ *   See: https://git.io/fxCyr
  * @returns {Date} the parsed date
  * @throws {TypeError} 3 arguments required
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
  * @throws {RangeError} `options.locale` must contain `match` property
+ * @throws {RangeError} `options.awareOfUnicodeTokens` must be set to `true` to use `XX` token; see: https://git.io/fxCyr
  *
  * @example
  * // Parse 11 February 2014 from middle-endian format:
@@ -287,9 +298,16 @@ var notWhitespaceRegExp = /\S/
  * )
  * //=> Sun Feb 28 2010 00:00:00
  */
-export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate, dirtyOptions) {
+export default function parse(
+  dirtyDateString,
+  dirtyFormatString,
+  dirtyBaseDate,
+  dirtyOptions
+) {
   if (arguments.length < 3) {
-    throw new TypeError('3 arguments required, but only ' + arguments.length + ' present')
+    throw new TypeError(
+      '3 arguments required, but only ' + arguments.length + ' present'
+    )
   }
 
   var dateString = String(dirtyDateString)
@@ -303,8 +321,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   }
 
   var localeFirstWeekContainsDate =
-    locale.options &&
-    locale.options.firstWeekContainsDate
+    locale.options && locale.options.firstWeekContainsDate
   var defaultFirstWeekContainsDate =
     localeFirstWeekContainsDate == null
       ? 1
@@ -316,12 +333,18 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
 
   // Test if weekStartsOn is between 1 and 7 _and_ is not NaN
   if (!(firstWeekContainsDate >= 1 && firstWeekContainsDate <= 7)) {
-    throw new RangeError('firstWeekContainsDate must be between 1 and 7 inclusively')
+    throw new RangeError(
+      'firstWeekContainsDate must be between 1 and 7 inclusively'
+    )
   }
 
   var localeWeekStartsOn = locale.options && locale.options.weekStartsOn
-  var defaultWeekStartsOn = localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
-  var weekStartsOn = options.weekStartsOn == null ? defaultWeekStartsOn : toInteger(options.weekStartsOn)
+  var defaultWeekStartsOn =
+    localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn =
+    options.weekStartsOn == null
+      ? defaultWeekStartsOn
+      : toInteger(options.weekStartsOn)
 
   // Test if weekStartsOn is between 0 and 6 _and_ is not NaN
   if (!(weekStartsOn >= 0 && weekStartsOn <= 6)) {
@@ -343,21 +366,34 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   }
 
   // If timezone isn't specified, it will be set to the system timezone
-  var setters = [{
-    priority: TIMEZONE_UNIT_PRIORITY,
-    set: dateToSystemTimezone,
-    index: 0
-  }]
+  var setters = [
+    {
+      priority: TIMEZONE_UNIT_PRIORITY,
+      set: dateToSystemTimezone,
+      index: 0
+    }
+  ]
 
   var i
 
   var tokens = formatString.match(formattingTokensRegExp)
+
   for (i = 0; i < tokens.length; i++) {
     var token = tokens[i]
+
+    if (!options.awareOfUnicodeTokens && isProtectedToken(token)) {
+      throwProtectedError(token)
+    }
+
     var firstCharacter = token[0]
     var parser = parsers[firstCharacter]
     if (parser) {
-      var parseResult = parser.parse(dateString, token, locale.match, subFnOptions)
+      var parseResult = parser.parse(
+        dateString,
+        token,
+        locale.match,
+        subFnOptions
+      )
 
       if (!parseResult) {
         return new Date(NaN)
@@ -395,23 +431,23 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   }
 
   var uniquePrioritySetters = setters
-    .map(function (setter) {
+    .map(function(setter) {
       return setter.priority
     })
-    .sort(function (a, b) {
+    .sort(function(a, b) {
       return b - a
     })
-    .filter(function (priority, index, array) {
+    .filter(function(priority, index, array) {
       return array.indexOf(priority) === index
     })
-    .map(function (priority) {
+    .map(function(priority) {
       return setters
-        .filter(function (setter) {
+        .filter(function(setter) {
           return setter.priority === priority
         })
         .reverse()
     })
-    .map(function (setterArray) {
+    .map(function(setterArray) {
       return setterArray[0]
     })
 
@@ -429,7 +465,10 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   for (i = 0; i < uniquePrioritySetters.length; i++) {
     var setter = uniquePrioritySetters[i]
 
-    if (setter.validate && !setter.validate(utcDate, setter.value, subFnOptions)) {
+    if (
+      setter.validate &&
+      !setter.validate(utcDate, setter.value, subFnOptions)
+    ) {
       return new Date(NaN)
     }
 
@@ -439,7 +478,7 @@ export default function parse (dirtyDateString, dirtyFormatString, dirtyBaseDate
   return utcDate
 }
 
-function dateToSystemTimezone (date) {
+function dateToSystemTimezone(date) {
   var convertedDate = new Date(0)
   convertedDate.setFullYear(
     date.getUTCFullYear(),
@@ -455,6 +494,6 @@ function dateToSystemTimezone (date) {
   return convertedDate
 }
 
-function cleanEscapedString (input) {
+function cleanEscapedString(input) {
   return input.match(escapedStringRegExp)[1].replace(doubleQuoteRegExp, "'")
 }

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -4,7 +4,10 @@ import toDate from '../toDate/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
 import defaultLocale from '../locale/en-US/index.js'
 import parsers from './_lib/parsers/index.js'
-import { isProtectedToken, throwProtectedError } from '../_lib/protectedTokens'
+import {
+  isProtectedToken,
+  throwProtectedError
+} from '../_lib/protectedTokens/index.js'
 
 var TIMEZONE_UNIT_PRIORITY = 20
 

--- a/src/parse/index.js.flow
+++ b/src/parse/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -1351,12 +1351,12 @@ describe('parse', function() {
     })
 
     it('throws `RangeError` if `options.locale` does not contain `match` property', function() {
-      // $ExpectedMistake
       var block = parse.bind(
         null,
         '2016-11-25 04 AM',
         'yyyy-MM-dd hh a',
         baseDate,
+        // $ExpectedMistake
         { locale: {} }
       )
       assert.throws(block, RangeError)

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -4,77 +4,81 @@
 import assert from 'power-assert'
 import parse from '.'
 
-describe('parse', function () {
+describe('parse', function() {
   var baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900)
 
-  it('escapes characters between the single quote characters', function () {
-    var result = parse('2018 hello world July 2nd', "yyyy 'hello world' MMMM do", baseDate)
+  it('escapes characters between the single quote characters', function() {
+    var result = parse(
+      '2018 hello world July 2nd',
+      "yyyy 'hello world' MMMM do",
+      baseDate
+    )
     assert.deepEqual(result, new Date(2018, 6 /* Jul */, 2))
   })
 
-  it('two single quote characters are transformed into a "real" single quote', function () {
+  it('two single quote characters are transformed into a "real" single quote', function() {
     var result = parse("'5 o'clock'", "''h 'o''clock'''", baseDate)
     assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 5))
   })
 
-  describe('era', function () {
-    it('abbreviated', function () {
+  describe('era', function() {
+    it('abbreviated', function() {
       var result = parse('10000 BC', 'yyyyy G', baseDate)
       assert.deepEqual(result, new Date(-9999, 0 /* Jan */, 1))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('2018 Anno Domini', 'yyyy GGGG', baseDate)
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('44 B', 'y GGGGG', baseDate)
       assert.deepEqual(result, new Date(-43, 0 /* Jan */, 1))
     })
 
-    it('with week-numbering year', function () {
+    it('with week-numbering year', function() {
       var result = parse('44 B', 'Y GGGGG', baseDate)
       assert.deepEqual(result, new Date(-44, 11 /* Dec */, 30))
     })
   })
 
-  describe('calendar year', function () {
-    it('numeric', function () {
+  describe('calendar year', function() {
+    it('numeric', function() {
       var result = parse('2017', 'y', baseDate)
       assert.deepEqual(result, new Date(2017, 0 /* Jan */, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('2017th', 'yo', baseDate)
       assert.deepEqual(result, new Date(2017, 0 /* Jan */, 1))
     })
 
-    describe('two-digit numeric year', function () {
-      it('works as expected', function () {
+    describe('two-digit numeric year', function() {
+      it('works as expected', function() {
         var result = parse('02', 'yy', baseDate)
         assert.deepEqual(result, new Date(2002, 0 /* Jan */, 1))
       })
 
-      it('gets the 100 year range from `baseDate`', function () {
+      it('gets the 100 year range from `baseDate`', function() {
         var result = parse('02', 'yy', new Date(1860, 6 /* Jul */, 2))
         assert.deepEqual(result, new Date(1902, 0 /* Jan */, 1))
       })
     })
 
-    it('three-digit zero-padding', function () {
+    it('three-digit zero-padding', function() {
       var result = parse('123', 'yyy', baseDate)
       assert.deepEqual(result, new Date(123, 0 /* Jan */, 1))
     })
 
-    it('four-digit zero-padding', function () {
+    it('four-digit zero-padding', function() {
       var result = parse('0044', 'yyyy', baseDate)
       var expectedResult = new Date(44, 0 /* Jan */, 1)
       expectedResult.setFullYear(44)
       assert.deepEqual(result, expectedResult)
     })
 
-    it('specified amount of digits', function () {
+    it('specified amount of digits', function() {
       var result = parse('000001', 'yyyyyy', baseDate)
       var expectedResult = new Date(1, 0 /* Jan */, 1)
       expectedResult.setFullYear(1)
@@ -82,40 +86,44 @@ describe('parse', function () {
     })
   })
 
-  describe('local week-numbering year', function () {
-    it('numeric', function () {
+  describe('local week-numbering year', function() {
+    it('numeric', function() {
       var result = parse('2002', 'Y', baseDate)
       assert.deepEqual(result, new Date(2001, 11 /* Dec */, 30))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('12345th', 'Yo', baseDate)
       assert.deepEqual(result, new Date(12344, 11 /* Dec */, 31))
     })
 
-    describe('two-digit numeric year', function () {
-      it('works as expected', function () {
-        var result = parse('02', 'YY', baseDate)
+    describe('two-digit numeric year', function() {
+      it('works as expected', function() {
+        var result = parse('02', 'YY', baseDate, { awareOfUnicodeTokens: true })
         assert.deepEqual(result, new Date(2001, 11 /* Dec */, 30))
       })
 
-      it('gets the 100 year range from `baseDate`', function () {
-        var result = parse('02', 'YY', new Date(1860, 6 /* Jul */, 2))
+      it('gets the 100 year range from `baseDate`', function() {
+        var result = parse('02', 'YY', new Date(1860, 6 /* Jul */, 2), {
+          awareOfUnicodeTokens: true
+        })
         assert.deepEqual(result, new Date(1901, 11 /* Dec */, 29))
       })
     })
 
-    it('three-digit zero-padding', function () {
+    it('three-digit zero-padding', function() {
       var result = parse('123', 'YYY', baseDate)
       assert.deepEqual(result, new Date(122, 11 /* Dec */, 27))
     })
 
-    it('four-digit zero-padding', function () {
-      var result = parse('2018', 'YYYY', baseDate)
+    it('four-digit zero-padding', function() {
+      var result = parse('2018', 'YYYY', baseDate, {
+        awareOfUnicodeTokens: true
+      })
       assert.deepEqual(result, new Date(2017, 11 /* Dec */, 31))
     })
 
-    it('specified amount of digits', function () {
+    it('specified amount of digits', function() {
       var result = parse('000001', 'YYYYYY', baseDate)
       var expectedResult = new Date(0)
       expectedResult.setFullYear(0, 11 /* Dec */, 31)
@@ -123,34 +131,37 @@ describe('parse', function () {
       assert.deepEqual(result, expectedResult)
     })
 
-    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
-      var result = parse('2018', 'Y', baseDate, {weekStartsOn: 1 /* Mon */, firstWeekContainsDate: 4})
+    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+      var result = parse('2018', 'Y', baseDate, {
+        weekStartsOn: 1 /* Mon */,
+        firstWeekContainsDate: 4
+      })
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
   })
 
-  describe('ISO week-numbering year', function () {
-    it('numeric', function () {
+  describe('ISO week-numbering year', function() {
+    it('numeric', function() {
       var result = parse('-1234', 'R', baseDate)
       assert.deepEqual(result, new Date(-1234, 0 /* Jan */, 3))
     })
 
-    it('two-digit zero-padding', function () {
+    it('two-digit zero-padding', function() {
       var result = parse('-02', 'RR', baseDate)
       assert.deepEqual(result, new Date(-3, 11 /* Dec */, 29))
     })
 
-    it('three-digit zero-padding', function () {
+    it('three-digit zero-padding', function() {
       var result = parse('123', 'RRR', baseDate)
       assert.deepEqual(result, new Date(123, 0 /* Jan */, 4))
     })
 
-    it('four-digit zero-padding', function () {
+    it('four-digit zero-padding', function() {
       var result = parse('2018', 'RRRR', baseDate)
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('specified amount of digits', function () {
+    it('specified amount of digits', function() {
       var result = parse('000001', 'RRRRRR', baseDate)
       var expectedResult = new Date(1, 0 /* Jan */, 1)
       expectedResult.setFullYear(1)
@@ -158,28 +169,28 @@ describe('parse', function () {
     })
   })
 
-  describe('extended year', function () {
-    it('numeric', function () {
+  describe('extended year', function() {
+    it('numeric', function() {
       var result = parse('-1234', 'u', baseDate)
       assert.deepEqual(result, new Date(-1234, 0 /* Jan */, 1))
     })
 
-    it('two-digit zero-padding', function () {
+    it('two-digit zero-padding', function() {
       var result = parse('-02', 'uu', baseDate)
       assert.deepEqual(result, new Date(-2, 0 /* Jan */, 1))
     })
 
-    it('three-digit zero-padding', function () {
+    it('three-digit zero-padding', function() {
       var result = parse('123', 'uuu', baseDate)
       assert.deepEqual(result, new Date(123, 0 /* Jan */, 1))
     })
 
-    it('four-digit zero-padding', function () {
+    it('four-digit zero-padding', function() {
       var result = parse('2018', 'uuuu', baseDate)
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('specified amount of digits', function () {
+    it('specified amount of digits', function() {
       var result = parse('000001', 'uuuuuu', baseDate)
       var expectedResult = new Date(1, 0 /* Jan */, 1)
       expectedResult.setFullYear(1)
@@ -187,785 +198,902 @@ describe('parse', function () {
     })
   })
 
-  describe('quarter (formatting)', function () {
-    it('numeric', function () {
+  describe('quarter (formatting)', function() {
+    it('numeric', function() {
       var result = parse('1', 'Q', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('1st', 'Qo', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('02', 'QQ', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Q3', 'QQQ', baseDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 1))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('4st quarter', 'QQQQ', baseDate)
       assert.deepEqual(result, new Date(1986, 9 /* Oct */, 1))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('1', 'QQQQQ', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
   })
 
-  describe('quarter (stand-alone)', function () {
-    it('numeric', function () {
+  describe('quarter (stand-alone)', function() {
+    it('numeric', function() {
       var result = parse('1', 'q', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('1th', 'qo', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('02', 'qq', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Q3', 'qqq', baseDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 1))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('4th quarter', 'qqqq', baseDate)
       assert.deepEqual(result, new Date(1986, 9 /* Oct */, 1))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('1', 'qqqqq', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
   })
 
-  describe('month (formatting)', function () {
-    it('numeric', function () {
+  describe('month (formatting)', function() {
+    it('numeric', function() {
       var result = parse('6', 'M', baseDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('6th', 'Mo', baseDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('01', 'MM', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Nov', 'MMM', baseDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 1))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('February', 'MMMM', baseDate)
       assert.deepEqual(result, new Date(1986, 1 /* Feb */, 1))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('J', 'MMMMM', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
   })
 
-  describe('month (stand-alone)', function () {
-    it('numeric', function () {
+  describe('month (stand-alone)', function() {
+    it('numeric', function() {
       var result = parse('6', 'L', baseDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('6th', 'Lo', baseDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('01', 'LL', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Nov', 'LLL', baseDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 1))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('February', 'LLLL', baseDate)
       assert.deepEqual(result, new Date(1986, 1 /* Feb */, 1))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('J', 'LLLLL', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
   })
 
-  describe('local week of year', function () {
-    it('numeric', function () {
+  describe('local week of year', function() {
+    it('numeric', function() {
       var result = parse('49', 'w', baseDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 30))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('49th', 'wo', baseDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 30))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('01', 'ww', baseDate)
       assert.deepEqual(result, new Date(1985, 11 /* Dec */, 29))
     })
 
-    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
-      var result = parse('49', 'w', baseDate, {weekStartsOn: 1 /* Mon */, firstWeekContainsDate: 4})
+    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+      var result = parse('49', 'w', baseDate, {
+        weekStartsOn: 1 /* Mon */,
+        firstWeekContainsDate: 4
+      })
       assert.deepEqual(result, new Date(1986, 11 /* Dec */, 1))
     })
   })
 
-  describe('ISO week of year', function () {
-    it('numeric', function () {
+  describe('ISO week of year', function() {
+    it('numeric', function() {
       var result = parse('49', 'I', baseDate)
       assert.deepEqual(result, new Date(1986, 11 /* Dec */, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('49th', 'Io', baseDate)
       assert.deepEqual(result, new Date(1986, 11 /* Dec */, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('01', 'II', baseDate)
       assert.deepEqual(result, new Date(1985, 11 /* Dec */, 30))
     })
   })
 
-  describe('day of month', function () {
-    it('numeric', function () {
+  describe('day of month', function() {
+    it('numeric', function() {
       var result = parse('28', 'd', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 28))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('28th', 'do', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 28))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('01', 'dd', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
   })
 
-  describe('day of year', function () {
-    it('numeric', function () {
-      var result = parse('200', 'D', baseDate)
+  describe('day of year', function() {
+    it('numeric', function() {
+      var result = parse('200', 'D', baseDate, { awareOfUnicodeTokens: true })
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('200th', 'Do', baseDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
 
-    it('two-digit zero-padding', function () {
-      var result = parse('01', 'DD', baseDate)
+    it('two-digit zero-padding', function() {
+      var result = parse('01', 'DD', baseDate, { awareOfUnicodeTokens: true })
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('three-digit zero-padding', function () {
+    it('three-digit zero-padding', function() {
       var result = parse('001', 'DDD', baseDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('specified amount of digits', function () {
+    it('specified amount of digits', function() {
       var result = parse('000200', 'DDDDDD', baseDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
   })
 
-  describe('day of week (formatting)', function () {
-    it('abbreviated', function () {
+  describe('day of week (formatting)', function() {
+    it('abbreviated', function() {
       var result = parse('Mon', 'E', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('Tuesday', 'EEEE', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('W', 'EEEEE', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('short', function () {
+    it('short', function() {
       var result = parse('Th', 'EEEEEE', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('allows to specify which day is the first day of the week', function () {
-      var result = parse('Thursday', 'EEEE', baseDate, {weekStartsOn: /* Fri */ 5})
+    it('allows to specify which day is the first day of the week', function() {
+      var result = parse('Thursday', 'EEEE', baseDate, {
+        weekStartsOn: /* Fri */ 5
+      })
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 10))
     })
   })
 
-  describe('ISO day of week (formatting)', function () {
-    it('numeric', function () {
+  describe('ISO day of week (formatting)', function() {
+    it('numeric', function() {
       var result = parse('1', 'i', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('1st', 'io', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('02', 'ii', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Wed', 'iii', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('Thursday', 'iiii', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('S', 'iiiii', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 6))
     })
 
-    it('short', function () {
+    it('short', function() {
       var result = parse('Fr', 'iiiiii', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4))
     })
   })
 
-  describe('local day of week (formatting)', function () {
-    it('numeric', function () {
+  describe('local day of week (formatting)', function() {
+    it('numeric', function() {
       var result = parse('2', 'e', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('2nd', 'eo', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('03', 'ee', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Wed', 'eee', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('Thursday', 'eeee', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('S', 'eeeee', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 30))
     })
 
-    it('short', function () {
+    it('short', function() {
       var result = parse('Fr', 'eeeeee', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4))
     })
 
-    it('allows to specify which day is the first day of the week', function () {
-      var result = parse('7th', 'eo', baseDate, {weekStartsOn: /* Fri */ 5})
+    it('allows to specify which day is the first day of the week', function() {
+      var result = parse('7th', 'eo', baseDate, { weekStartsOn: /* Fri */ 5 })
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 10))
     })
   })
 
-  describe('local day of week (stand-alone)', function () {
-    it('numeric', function () {
+  describe('local day of week (stand-alone)', function() {
+    it('numeric', function() {
       var result = parse('2', 'c', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('2nd', 'co', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('03', 'cc', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function () {
+    it('abbreviated', function() {
       var result = parse('Wed', 'ccc', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('Thursday', 'cccc', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('S', 'ccccc', baseDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 30))
     })
 
-    it('short', function () {
+    it('short', function() {
       var result = parse('Fr', 'cccccc', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4))
     })
 
-    it('allows to specify which day is the first day of the week', function () {
-      var result = parse('7th', 'co', baseDate, {weekStartsOn: /* Fri */ 5})
+    it('allows to specify which day is the first day of the week', function() {
+      var result = parse('7th', 'co', baseDate, { weekStartsOn: /* Fri */ 5 })
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 10))
     })
   })
 
-  describe('AM, PM', function () {
-    it('abbreviated', function () {
+  describe('AM, PM', function() {
+    it('abbreviated', function() {
       var result = parse('5 AM', 'h a', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 5))
     })
 
-    it('12 AM', function () {
+    it('12 AM', function() {
       var result = parse('12 AM', 'h aa', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
 
-    it('12 PM', function () {
+    it('12 PM', function() {
       var result = parse('12 PM', 'h aaa', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('5 p.m.', 'h aaaa', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 17))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('11 a', 'h aaaaa', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 11))
     })
   })
 
-  describe('AM, PM, noon, midnight', function () {
-    it('abbreviated', function () {
+  describe('AM, PM, noon, midnight', function() {
+    it('abbreviated', function() {
       var result = parse('noon', 'b', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('midnight', 'bbbb', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('mi', 'bbbbb', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
   })
 
-  describe('flexible day period', function () {
-    it('abbreviated', function () {
+  describe('flexible day period', function() {
+    it('abbreviated', function() {
       var result = parse('2 at night', 'h B', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 2))
     })
 
-    it('wide', function () {
+    it('wide', function() {
       var result = parse('12 in the afternoon', 'h BBBB', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('narrow', function () {
+    it('narrow', function() {
       var result = parse('5 in the evening', 'h BBBBB', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 17))
     })
   })
 
-  describe('hour [1-12]', function () {
-    it('numeric', function () {
+  describe('hour [1-12]', function() {
+    it('numeric', function() {
       var result = parse('1', 'h', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('1st', 'ho', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('01', 'hh', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
   })
 
-  describe('hour [0-23]', function () {
-    it('numeric', function () {
+  describe('hour [0-23]', function() {
+    it('numeric', function() {
       var result = parse('12', 'H', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('12th', 'Ho', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('00', 'HH', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
   })
 
-  describe('hour [0-11]', function () {
-    it('numeric', function () {
+  describe('hour [0-11]', function() {
+    it('numeric', function() {
       var result = parse('1', 'K', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('1st', 'Ko', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('1', 'KK', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
   })
 
-  describe('hour [1-24]', function () {
-    it('numeric', function () {
+  describe('hour [1-24]', function() {
+    it('numeric', function() {
       var result = parse('12', 'k', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('12th', 'ko', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('24', 'kk', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
   })
 
-  describe('minute', function () {
-    it('numeric', function () {
+  describe('minute', function() {
+    it('numeric', function() {
       var result = parse('25', 'm', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 25))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('25th', 'mo', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 25))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('05', 'mm', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 5))
     })
   })
 
-  describe('second', function () {
-    it('numeric', function () {
+  describe('second', function() {
+    it('numeric', function() {
       var result = parse('25', 's', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 25))
     })
 
-    it('ordinal', function () {
+    it('ordinal', function() {
       var result = parse('25th', 'so', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 25))
     })
 
-    it('zero-padding', function () {
+    it('zero-padding', function() {
       var result = parse('05', 'ss', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 5))
     })
   })
 
-  describe('fraction of second', function () {
-    it('1/10 of second', function () {
+  describe('fraction of second', function() {
+    it('1/10 of second', function() {
       var result = parse('1', 'S', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 100))
     })
 
-    it('1/100 of second', function () {
+    it('1/100 of second', function() {
       var result = parse('12', 'SS', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 120))
     })
 
-    it('millisecond', function () {
+    it('millisecond', function() {
       var result = parse('123', 'SSS', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 123))
     })
 
-    it('specified amount of digits', function () {
+    it('specified amount of digits', function() {
       var result = parse('567890', 'SSSSSS', baseDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 567))
     })
   })
 
-  describe('timezone (ISO-8601 w/ Z)', function () {
-    describe('X', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-0530', "yyyy-MM-dd'T'HH:mm:ss.SSSX", baseDate)
+  describe('timezone (ISO-8601 w/ Z)', function() {
+    describe('X', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-0530',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123Z', "yyyy-MM-dd'T'HH:mm:ss.SSSX", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123Z',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours', function () {
-        var result = parse('2016-11-25T16:38:38.123+05', "yyyy-MM-dd'T'HH:mm:ss.SSSX", baseDate)
+      it('hours', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+05',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123+05:00'))
       })
     })
 
-    describe('XX', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-0530', "yyyy-MM-dd'T'HH:mm:ss.SSSXX", baseDate)
+    describe('XX', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-0530',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123Z', "yyyy-MM-dd'T'HH:mm:ss.SSSXX", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123Z',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
     })
 
-    describe('XXX', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-05:30', "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", baseDate)
+    describe('XXX', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-05:30',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123Z', "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123Z',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
     })
 
-    describe('XXXX', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-0530', "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX", baseDate)
+    describe('XXXX', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-0530',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123Z', "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123Z',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function () {
-        var result = parse('2016-11-25T16:38:38.123+053045', "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX", baseDate)
+      it('hours, minutes and seconds', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+053045',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:37:53.123+05:30'))
       })
     })
 
-    describe('XXXXX', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-05:30', "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX", baseDate)
+    describe('XXXXX', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-05:30',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123Z', "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123Z',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function () {
-        var result = parse('2016-11-25T16:38:38.123+05:30:45', "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX", baseDate)
+      it('hours, minutes and seconds', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+05:30:45',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:37:53.123+05:30'))
       })
     })
   })
 
-  describe('timezone (ISO-8601 w/o Z)', function () {
-    describe('x', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-0530', "yyyy-MM-dd'T'HH:mm:ss.SSSx", baseDate)
+  describe('timezone (ISO-8601 w/o Z)', function() {
+    describe('x', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-0530',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123+0000', "yyyy-MM-dd'T'HH:mm:ss.SSSx", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+0000',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours', function () {
-        var result = parse('2016-11-25T16:38:38.123+05', "yyyy-MM-dd'T'HH:mm:ss.SSSx", baseDate)
+      it('hours', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+05',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123+05:00'))
       })
     })
 
-    describe('xx', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-0530', "yyyy-MM-dd'T'HH:mm:ss.SSSxx", baseDate)
+    describe('xx', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-0530',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123+0000', "yyyy-MM-dd'T'HH:mm:ss.SSSxx", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+0000',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
     })
 
-    describe('xxx', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-05:30', "yyyy-MM-dd'T'HH:mm:ss.SSSxxx", baseDate)
+    describe('xxx', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-05:30',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123+00:00', "yyyy-MM-dd'T'HH:mm:ss.SSSxxx", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+00:00',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
     })
 
-    describe('xxxx', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-0530', "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx", baseDate)
+    describe('xxxx', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-0530',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123+0000', "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+0000',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function () {
-        var result = parse('2016-11-25T16:38:38.123+053045', "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx", baseDate)
+      it('hours, minutes and seconds', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+053045',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:37:53.123+05:30'))
       })
     })
 
-    describe('xxxxx', function () {
-      it('hours and minutes', function () {
-        var result = parse('2016-11-25T16:38:38.123-05:30', "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx", baseDate)
+    describe('xxxxx', function() {
+      it('hours and minutes', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123-05:30',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function () {
-        var result = parse('2016-11-25T16:38:38.123+00:00', "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx", baseDate)
+      it('GMT', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+00:00',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function () {
-        var result = parse('2016-11-25T16:38:38.123+05:30:45', "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx", baseDate)
+      it('hours, minutes and seconds', function() {
+        var result = parse(
+          '2016-11-25T16:38:38.123+05:30:45',
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx",
+          baseDate
+        )
         assert.deepEqual(result, new Date('2016-11-25T16:37:53.123+05:30'))
       })
     })
   })
 
-  describe('seconds timestamp', function () {
-    it('numeric', function () {
+  describe('seconds timestamp', function() {
+    it('numeric', function() {
       var result = parse('512969520', 't', baseDate)
       assert.deepEqual(result, new Date(512969520000))
     })
 
-    it('specified amount of digits', function () {
-      var result = parse('00000000000512969520', 'tttttttttttttttttttt', baseDate)
+    it('specified amount of digits', function() {
+      var result = parse(
+        '00000000000512969520',
+        'tttttttttttttttttttt',
+        baseDate
+      )
       assert.deepEqual(result, new Date(512969520000))
     })
   })
 
-  describe('milliseconds timestamp', function () {
-    it('numeric', function () {
+  describe('milliseconds timestamp', function() {
+    it('numeric', function() {
       var result = parse('512969520900', 'T', baseDate)
       assert.deepEqual(result, new Date(512969520900))
     })
 
-    it('specified amount of digits', function () {
-      var result = parse('00000000512969520900', 'TTTTTTTTTTTTTTTTTTTT', baseDate)
+    it('specified amount of digits', function() {
+      var result = parse(
+        '00000000512969520900',
+        'TTTTTTTTTTTTTTTTTTTT',
+        baseDate
+      )
       assert.deepEqual(result, new Date(512969520900))
     })
   })
 
-  describe('common formats', function () {
-    it('ISO-8601', function () {
+  describe('common formats', function() {
+    it('ISO-8601', function() {
       var result = parse('20161105T040404', "yyyyMMdd'T'HHmmss", baseDate)
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5, 4, 4, 4, 0))
     })
 
-    it('ISO week-numbering date', function () {
+    it('ISO week-numbering date', function() {
       var result = parse('2016W474T153005', "RRRR'W'IIi'T'HHmmss", baseDate)
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 24, 15, 30, 5, 0))
     })
 
-    it('ISO day of year date', function () {
+    it('ISO day of year date', function() {
       var result = parse('2010123T235959', "yyyyDDD'T'HHmmss", baseDate)
       assert.deepEqual(result, new Date(2010, 4 /* May */, 3, 23, 59, 59, 0))
     })
 
-    it('Date.prototype.toString()', function () {
+    it('Date.prototype.toString()', function() {
       var dateString = 'Wed Jul 02 2014 05:30:15 GMT+0600'
       var formatString = "EEE MMM dd yyyy HH:mm:ss 'GMT'xx"
       var result = parse(dateString, formatString, baseDate)
       assert.deepEqual(result, new Date(dateString))
     })
 
-    it('Date.prototype.toISOString()', function () {
+    it('Date.prototype.toISOString()', function() {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       var result = parse(dateString, formatString, baseDate)
       assert.deepEqual(result, new Date(dateString))
     })
 
-    it('middle-endian', function () {
+    it('middle-endian', function() {
       var result = parse('5 a.m. 07/02/2016', 'h aaaa MM/dd/yyyy', baseDate)
       assert.deepEqual(result, new Date(2016, 6 /* Jul */, 2, 5, 0, 0, 0))
     })
 
-    it('little-endian', function () {
+    it('little-endian', function() {
       var result = parse('02.07.1995', 'dd.MM.yyyy', baseDate)
       assert.deepEqual(result, new Date(1995, 6 /* Jul */, 2, 0, 0, 0, 0))
     })
   })
 
-  describe('priority', function () {
-    it('units of lower priority don\'t overwrite values of higher priority', function () {
+  describe('priority', function() {
+    it("units of lower priority don't overwrite values of higher priority", function() {
       var dateString = '+06:00 123 15 30 05 02 07 2014'
       var formatString = 'xxx SSS ss mm HH dd MM yyyy'
       var result = parse(dateString, formatString, baseDate)
       assert.deepEqual(result, new Date('2014-07-02T05:30:15.123+06:00'))
     })
 
-    it('units of equal priority overwrite each other in order of appearance', function () {
+    it('units of equal priority overwrite each other in order of appearance', function() {
       var dateString = '25 1950 75 2000 January Feb 03 4 1 123 12'
       var formatString = 'RR RRRR yy yyyy MMMM MMM MM M d DDD dd'
       var result = parse(dateString, formatString, baseDate)
       assert.deepEqual(result, new Date(2000, 3 /* Apr */, 12))
     })
 
-    it('timestamp overwrites everything', function () {
+    it('timestamp overwrites everything', function() {
       var dateString = '512969520900 512969520 2014-07-02T05:30:15.123+06:00'
       var formatString = "T t yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       var result = parse(dateString, formatString, baseDate)
@@ -973,8 +1101,8 @@ describe('parse', function () {
     })
   })
 
-  describe('implicit conversion of arguments', function () {
-    it('`dateString`', function () {
+  describe('implicit conversion of arguments', function() {
+    it('`dateString`', function() {
       // eslint-disable-next-line no-new-wrappers
       var dateString = new String('20161105T040404')
       // $ExpectedMistake
@@ -982,7 +1110,7 @@ describe('parse', function () {
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5, 4, 4, 4, 0))
     })
 
-    it('`formatString`', function () {
+    it('`formatString`', function() {
       // eslint-disable-next-line no-new-wrappers
       var formatString = new String("yyyyMMdd'T'HHmmss")
       // $ExpectedMistake
@@ -990,214 +1118,224 @@ describe('parse', function () {
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5, 4, 4, 4, 0))
     })
 
-    it('`options.weekStartsOn`', function () {
+    it('`options.weekStartsOn`', function() {
       // $ExpectedMistake
-      var result = parse('2018', 'Y', baseDate, {weekStartsOn: '1' /* Mon */, firstWeekContainsDate: 4})
+      var result = parse('2018', 'Y', baseDate, {
+        weekStartsOn: '1' /* Mon */,
+        firstWeekContainsDate: 4
+      })
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('`options.firstWeekContainsDate`', function () {
+    it('`options.firstWeekContainsDate`', function() {
       // $ExpectedMistake
-      var result = parse('2018', 'Y', baseDate, {weekStartsOn: 1 /* Mon */, firstWeekContainsDate: '4'})
+      var result = parse('2018', 'Y', baseDate, {
+        weekStartsOn: 1 /* Mon */,
+        firstWeekContainsDate: '4'
+      })
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
   })
 
-  describe('with `options.strictValidation` = true', function () {
-    describe('calendar year', function () {
-      it('returns `Invalid Date` for year zero', function () {
+  describe('with `options.strictValidation` = true', function() {
+    describe('calendar year', function() {
+      it('returns `Invalid Date` for year zero', function() {
         var result = parse('0', 'y', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('works correctly for two-digit year zero', function () {
+      it('works correctly for two-digit year zero', function() {
         var result = parse('00', 'yy', baseDate)
         assert.deepEqual(result, new Date(2000, 0 /* Jan */, 1))
       })
     })
 
-    describe('local week-numbering year', function () {
-      it('returns `Invalid Date` for year zero', function () {
+    describe('local week-numbering year', function() {
+      it('returns `Invalid Date` for year zero', function() {
         var result = parse('0', 'Y', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('works correctly for two-digit year zero', function () {
-        var result = parse('00', 'YY', baseDate)
+      it('works correctly for two-digit year zero', function() {
+        var result = parse('00', 'YY', baseDate, { awareOfUnicodeTokens: true })
         assert.deepEqual(result, new Date(1999, 11 /* Dec */, 26))
       })
     })
 
-    describe('quarter (formatting)', function () {
-      it('returns `Invalid Date` for invalid quarter', function () {
+    describe('quarter (formatting)', function() {
+      it('returns `Invalid Date` for invalid quarter', function() {
         var result = parse('0', 'Q', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('quarter (stand-alone)', function () {
-      it('returns `Invalid Date` for invalid quarter', function () {
+    describe('quarter (stand-alone)', function() {
+      it('returns `Invalid Date` for invalid quarter', function() {
         var result = parse('5', 'q', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('month (formatting)', function () {
-      it('returns `Invalid Date` for invalid month', function () {
+    describe('month (formatting)', function() {
+      it('returns `Invalid Date` for invalid month', function() {
         var result = parse('00', 'MM', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('month (stand-alone)', function () {
-      it('returns `Invalid Date` for invalid month', function () {
+    describe('month (stand-alone)', function() {
+      it('returns `Invalid Date` for invalid month', function() {
         var result = parse('13', 'LL', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('local week of year', function () {
-      it('returns `Invalid Date` for invalid week', function () {
+    describe('local week of year', function() {
+      it('returns `Invalid Date` for invalid week', function() {
         var result = parse('0', 'w', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('ISO week of year', function () {
-      it('returns `Invalid Date` for invalid week', function () {
+    describe('ISO week of year', function() {
+      it('returns `Invalid Date` for invalid week', function() {
         var result = parse('54', 'II', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('day of month', function () {
-      it('returns `Invalid Date` for invalid day of the month', function () {
+    describe('day of month', function() {
+      it('returns `Invalid Date` for invalid day of the month', function() {
         var result = parse('30', 'd', new Date(2012, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for 29th of February of non-leap year', function () {
+      it('returns `Invalid Date` for 29th of February of non-leap year', function() {
         var result = parse('29', 'd', new Date(2014, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('parses 29th of February of leap year', function () {
+      it('parses 29th of February of leap year', function() {
         var result = parse('29', 'd', new Date(2012, 1 /* Feb */, 1))
         assert.deepEqual(result, new Date(2012, 1 /* Feb */, 29))
       })
     })
 
-    describe('day of year', function () {
-      it('returns `Invalid Date` for invalid day of the year', function () {
-        var result = parse('0', 'D', baseDate)
+    describe('day of year', function() {
+      it('returns `Invalid Date` for invalid day of the year', function() {
+        var result = parse('0', 'D', baseDate, { awareOfUnicodeTokens: true })
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for 366th day of non-leap year', function () {
-        var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1))
+      it('returns `Invalid Date` for 366th day of non-leap year', function() {
+        var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1), {
+          awareOfUnicodeTokens: true
+        })
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('parses 366th day of leap year', function () {
-        var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1))
+      it('parses 366th day of leap year', function() {
+        var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1), {
+          awareOfUnicodeTokens: true
+        })
         assert.deepEqual(result, new Date(2012, 11 /* Dec */, 31))
       })
     })
 
-    describe('ISO day of week (formatting)', function () {
-      it('returns `Invalid Date` for day zero', function () {
+    describe('ISO day of week (formatting)', function() {
+      it('returns `Invalid Date` for day zero', function() {
         var result = parse('0', 'i', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for eight day of week', function () {
+      it('returns `Invalid Date` for eight day of week', function() {
         var result = parse('8', 'i', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('local day of week (formatting)', function () {
-      it('returns `Invalid Date` for day zero', function () {
+    describe('local day of week (formatting)', function() {
+      it('returns `Invalid Date` for day zero', function() {
         var result = parse('0', 'e', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for eight day of week', function () {
+      it('returns `Invalid Date` for eight day of week', function() {
         var result = parse('8', 'e', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('local day of week (stand-alone)', function () {
-      it('returns `Invalid Date` for day zero', function () {
+    describe('local day of week (stand-alone)', function() {
+      it('returns `Invalid Date` for day zero', function() {
         var result = parse('0', 'c', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for eight day of week', function () {
+      it('returns `Invalid Date` for eight day of week', function() {
         var result = parse('8', 'c', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [1-12]', function () {
-      it('returns `Invalid Date` for hour zero', function () {
+    describe('hour [1-12]', function() {
+      it('returns `Invalid Date` for hour zero', function() {
         var result = parse('00', 'hh', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for invalid hour', function () {
+      it('returns `Invalid Date` for invalid hour', function() {
         var result = parse('13', 'hh', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [0-23]', function () {
-      it('returns `Invalid Date` for invalid hour', function () {
+    describe('hour [0-23]', function() {
+      it('returns `Invalid Date` for invalid hour', function() {
         var result = parse('24', 'HH', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [0-11]', function () {
-      it('returns `Invalid Date` for invalid hour', function () {
+    describe('hour [0-11]', function() {
+      it('returns `Invalid Date` for invalid hour', function() {
         var result = parse('12', 'KK', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [1-24]', function () {
-      it('returns `Invalid Date` for hour zero', function () {
+    describe('hour [1-24]', function() {
+      it('returns `Invalid Date` for hour zero', function() {
         var result = parse('00', 'kk', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for invalid hour', function () {
+      it('returns `Invalid Date` for invalid hour', function() {
         var result = parse('25', 'kk', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('minute', function () {
-      it('returns `Invalid Date` for invalid minute', function () {
+    describe('minute', function() {
+      it('returns `Invalid Date` for invalid minute', function() {
         var result = parse('60', 'mm', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('second', function () {
-      it('returns `Invalid Date` for invalid second', function () {
+    describe('second', function() {
+      it('returns `Invalid Date` for invalid second', function() {
         var result = parse('60', 'ss', baseDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
   })
 
-  describe('custom locale', function () {
-    it('allows to pass a custom locale', function () {
+  describe('custom locale', function() {
+    it('allows to pass a custom locale', function() {
       var customLocale = {
         match: {
-          era: function () {
+          era: function() {
             return {
               value: 0,
               rest: ' it works!'
@@ -1206,32 +1344,40 @@ describe('parse', function () {
         }
       }
       // $ExpectedMistake
-      var result = parse('2018 foobar', "y G 'it works!'", baseDate, {locale: customLocale})
+      var result = parse('2018 foobar', "y G 'it works!'", baseDate, {
+        locale: customLocale
+      })
       assert.deepEqual(result, new Date(-2017, 0 /* Jan */, 1))
     })
 
-    it('throws `RangeError` if `options.locale` does not contain `match` property', function () {
+    it('throws `RangeError` if `options.locale` does not contain `match` property', function() {
       // $ExpectedMistake
-      var block = parse.bind(null, '2016-11-25 04 AM', 'yyyy-MM-dd hh a', baseDate, {locale: {}})
+      var block = parse.bind(
+        null,
+        '2016-11-25 04 AM',
+        'yyyy-MM-dd hh a',
+        baseDate,
+        { locale: {} }
+      )
       assert.throws(block, RangeError)
     })
   })
 
-  it('accepts a string as `baseDate`', function () {
+  it('accepts a string as `baseDate`', function() {
     var dateString = '6 p.m.'
     var formatString = 'h aaaa'
     var result = parse(dateString, formatString, baseDate.toISOString())
     assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 18))
   })
 
-  it('accepts a timestamp as `baseDate`', function () {
+  it('accepts a timestamp as `baseDate`', function() {
     var dateString = '6 p.m.'
     var formatString = 'h aaaa'
     var result = parse(dateString, formatString, baseDate.getTime())
     assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 18))
   })
 
-  it('does not mutate `baseDate`', function () {
+  it('does not mutate `baseDate`', function() {
     var baseDateClone1 = new Date(baseDate.getTime())
     var baseDateClone2 = new Date(baseDate.getTime())
     var dateString = '6 p.m.'
@@ -1240,73 +1386,79 @@ describe('parse', function () {
     assert.deepEqual(baseDateClone1, baseDateClone2)
   })
 
-  describe('failure', function () {
-    it('returns `baseDate` if `dateString` and `formatString` are empty strings', function () {
+  describe('failure', function() {
+    it('returns `baseDate` if `dateString` and `formatString` are empty strings', function() {
       var dateString = ''
       var formatString = ''
       var result = parse(dateString, formatString, baseDate)
       assert.deepEqual(result, baseDate)
     })
 
-    it('returns `baseDate` if no tokens in `formatString` are provided', function () {
+    it('returns `baseDate` if no tokens in `formatString` are provided', function() {
       var dateString = 'not a token'
       var formatString = "'not a token'"
       var result = parse(dateString, formatString, baseDate)
       assert.deepEqual(result, baseDate)
     })
 
-    it('returns `Invalid Date`  if `formatString` doesn\'t match `dateString`', function () {
+    it("returns `Invalid Date`  if `formatString` doesn't match `dateString`", function() {
       var dateString = '2017-01-01'
       var formatString = 'yyyy/MM/dd'
       var result = parse(dateString, formatString, baseDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('returns `Invalid Date`  if `formatString` tokens failed to parse a value', function () {
+    it('returns `Invalid Date`  if `formatString` tokens failed to parse a value', function() {
       var dateString = '2017-01-01'
       var formatString = 'MMMM do yyyy'
       var result = parse(dateString, formatString, baseDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('returns `Invalid Date` if `formatString` is empty string but `dateString` is not', function () {
+    it('returns `Invalid Date` if `formatString` is empty string but `dateString` is not', function() {
       var dateString = '2017-01-01'
       var formatString = ''
       var result = parse(dateString, formatString, baseDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('returns `Invalid Date` if `baseDate` is `Invalid Date`', function () {
+    it('returns `Invalid Date` if `baseDate` is `Invalid Date`', function() {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       var result = parse(dateString, formatString, new Date(NaN))
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       // $ExpectedMistake
-      var block = parse.bind(null, dateString, formatString, baseDate, {weekStartsOn: NaN})
+      var block = parse.bind(null, dateString, formatString, baseDate, {
+        weekStartsOn: NaN
+      })
       assert.throws(block, RangeError)
     })
 
-    it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function () {
+    it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function() {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       // $ExpectedMistake
-      var block = parse.bind(null, dateString, formatString, baseDate, {firstWeekContainsDate: NaN})
+      var block = parse.bind(null, dateString, formatString, baseDate, {
+        firstWeekContainsDate: NaN
+      })
       assert.throws(block, RangeError)
     })
   })
 
-  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function () {
+  it('throws `RangeError` if `options.additionalDigits` is not convertable to 0, 1, 2 or undefined`', function() {
     // $ExpectedMistake
-    var block = parse.bind(null, '16', 'yy', baseDate, {additionalDigits: NaN})
+    var block = parse.bind(null, '16', 'yy', baseDate, {
+      additionalDigits: NaN
+    })
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 3 arguments', function () {
+  it('throws TypeError exception if passed less than 3 arguments', function() {
     assert.throws(parse.bind(null), TypeError)
     // $ExpectedMistake
     assert.throws(parse.bind(null, 1), TypeError)
@@ -1314,15 +1466,81 @@ describe('parse', function () {
     assert.throws(parse.bind(null, 1, 2), TypeError)
   })
 
-  describe('edge cases', function () {
-    it('returns Invalid Date if the string contains some remaining input after parsing', function () {
+  describe('edge cases', function() {
+    it('returns Invalid Date if the string contains some remaining input after parsing', function() {
       var result = parse('2016-11-05T040404', 'yyyy-MM-dd', baseDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('parses normally if the remaining input is just whitespace', function () {
+    it('parses normally if the remaining input is just whitespace', function() {
       var result = parse('2016-11-05   \n', 'yyyy-MM-dd', baseDate)
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5))
+    })
+  })
+
+  describe('awareOfUnicodeTokens option', () => {
+    it('throws an error if D token is used', () => {
+      const block = parse.bind(null, '2016-11-5', 'yyyy-MM-D', baseDate)
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `D` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows D token if awareOfUnicodeTokens is set to true', () => {
+      const result = parse('2016-11-5', 'yyyy-MM-D', new Date(1987, 1, 11), {
+        awareOfUnicodeTokens: true
+      })
+      assert.deepEqual(result, new Date(2016, 0, 5))
+    })
+
+    it('throws an error if DD token is used', () => {
+      const block = parse.bind(null, '2016-11-05', 'yyyy-MM-DD', baseDate)
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `DD` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows DD token if awareOfUnicodeTokens is set to true', () => {
+      const result = parse('2016-11-05', 'yyyy-MM-DD', new Date(1987, 1, 11), {
+        awareOfUnicodeTokens: true
+      })
+      assert.deepEqual(result, new Date(2016, 0, 5))
+    })
+
+    it('throws an error if YY token is used', () => {
+      const block = parse.bind(null, '16-11-05', 'YY-MM-dd', baseDate)
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows YY token if awareOfUnicodeTokens is set to true', () => {
+      const result = parse('16-11-05', 'YY-MM-dd', new Date(1987, 1, 11), {
+        awareOfUnicodeTokens: true
+      })
+      assert.deepEqual(result, new Date(2015, 10, 5))
+    })
+
+    it('throws an error if YYYY token is used', () => {
+      const block = parse.bind(null, '2016-11-05', 'YYYY-MM-dd', baseDate)
+      assert.throws(block, RangeError)
+      assert.throws(
+        block,
+        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+      )
+    })
+
+    it('allows YYYY token if awareOfUnicodeTokens is set to true', () => {
+      const result = parse('2016-11-05', 'YYYY-MM-dd', new Date(1987, 1, 11), {
+        awareOfUnicodeTokens: true
+      })
+      assert.deepEqual(result, new Date(2015, 10, 5))
     })
   })
 })

--- a/src/setDate/index.js.flow
+++ b/src/setDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setDay/index.js.flow
+++ b/src/setDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setDayOfYear/index.js.flow
+++ b/src/setDayOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setHours/index.js.flow
+++ b/src/setHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setISODay/index.js.flow
+++ b/src/setISODay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setISOWeek/index.js.flow
+++ b/src/setISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setISOWeekYear/index.js.flow
+++ b/src/setISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setMilliseconds/index.js.flow
+++ b/src/setMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setMinutes/index.js.flow
+++ b/src/setMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setMonth/index.js.flow
+++ b/src/setMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setQuarter/index.js.flow
+++ b/src/setQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setSeconds/index.js.flow
+++ b/src/setSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setWeek/index.js.flow
+++ b/src/setWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setWeekYear/index.js.flow
+++ b/src/setWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/setYear/index.js.flow
+++ b/src/setYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfDay/index.js.flow
+++ b/src/startOfDay/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfDecade/index.js.flow
+++ b/src/startOfDecade/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfHour/index.js.flow
+++ b/src/startOfHour/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfISOWeek/index.js.flow
+++ b/src/startOfISOWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfISOWeekYear/index.js.flow
+++ b/src/startOfISOWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfMinute/index.js.flow
+++ b/src/startOfMinute/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfMonth/index.js.flow
+++ b/src/startOfMonth/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfQuarter/index.js.flow
+++ b/src/startOfQuarter/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfSecond/index.js.flow
+++ b/src/startOfSecond/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfWeek/index.js.flow
+++ b/src/startOfWeek/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfWeekYear/index.js.flow
+++ b/src/startOfWeekYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/startOfYear/index.js.flow
+++ b/src/startOfYear/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subDays/index.js.flow
+++ b/src/subDays/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subHours/index.js.flow
+++ b/src/subHours/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subISOWeekYears/index.js.flow
+++ b/src/subISOWeekYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subMilliseconds/index.js.flow
+++ b/src/subMilliseconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subMinutes/index.js.flow
+++ b/src/subMinutes/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subMonths/index.js.flow
+++ b/src/subMonths/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subQuarters/index.js.flow
+++ b/src/subQuarters/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subSeconds/index.js.flow
+++ b/src/subSeconds/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subWeeks/index.js.flow
+++ b/src/subWeeks/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/subYears/index.js.flow
+++ b/src/subYears/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/src/toDate/index.js.flow
+++ b/src/toDate/index.js.flow
@@ -14,7 +14,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -39,7 +39,8 @@ type Options = {
   includeSeconds?: boolean,
   addSuffix?: boolean,
   unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
-  roundingMethod?: 'floor' | 'ceil' | 'round'
+  roundingMethod?: 'floor' | 'ceil' | 'round',
+  awareOfUnicodeTokens?: boolean
 }
 
 type Locale = {


### PR DESCRIPTION
- Throw an exception when `D`, `DD`, `YY` or `YYYY` tokens are used in `parse` and `format`.
- Introduce `awareOfUnicodeTokens` option that enables usage of the given tokens.
- Add Unicode Tokens document
- Add warnings and notes to `parse` and `format` documentation.
- Print v2 warning using `postinstall`