### PR TITLE
Remove ES6 'const' from bn locale

### DIFF
--- a/src/locale/bn/_lib/localize/index.js
+++ b/src/locale/bn/_lib/localize/index.js
@@ -138,7 +138,7 @@ function dateOrdinalNumber (number, localeNumber) {
 function ordinalNumber (dirtyNumber, dirtyOptions) {
   var number = localize.localeToNumber(dirtyNumber)
   var localeNumber = localize.numberToLocale(number)
-  const { unit } = dirtyOptions
+  var unit = dirtyOptions.unit
 
   if (unit === 'date') {
     return dateOrdinalNumber(number, localeNumber)


### PR DESCRIPTION
When using locales webpack/uglify fails with 

```
[webpack] errors:                                                               
app/6ec78c4b5b.js from UglifyJs
Unexpected token: keyword (const) [../wa-storybook/node_modules/date-fns/esm/locale/bn/_lib/localize/index.js:141,0][app/6ec78c4b5b.js:98206,2]
```

This patch changes const to var.