### PR TITLE
fix the wrong date object in the documentation of subDays function

### DIFF
--- a/src/subDays/index.js
+++ b/src/subDays/index.js
@@ -19,7 +19,7 @@ import addDays from '../addDays/index.js'
  *
  * @example
  * // Subtract 10 days from 1 September 2014:
- * var result = subDays(new Date(2014, 8, 1), 10)
+ * var result = subDays(new Date(2014, 9, 1), 10)
  * //=> Fri Aug 22 2014 00:00:00
  */
 export default function subDays (dirtyDate, dirtyAmount, dirtyOptions) {


### PR DESCRIPTION
This pull request is corresponding to the open issues #950 

