### PR TITLE
Add v2.0.0 breaking changes section to docs to every changed function [part 1] (see #957)

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -97,6 +97,14 @@ module.exports = {
     },
     {
       type: 'markdown',
+      urlId: 'v2-Behaviour-Changes',
+      category: 'General',
+      title: 'v2.0.0 behaviour changes',
+      description: 'Changes common for all functions',
+      path: path.join(__dirname, 'v2BehaviourChanges.md')
+    },
+    {
+      type: 'markdown',
       urlId: 'License',
       category: 'General',
       title: 'License',

--- a/docs/index.js
+++ b/docs/index.js
@@ -97,11 +97,11 @@ module.exports = {
     },
     {
       type: 'markdown',
-      urlId: 'v2-Behaviour-Changes',
+      urlId: 'Upgrade-Guide',
       category: 'General',
-      title: 'v2.0.0 behaviour changes',
-      description: 'Changes common for all functions',
-      path: path.join(__dirname, 'v2BehaviourChanges.md')
+      title: 'Upgrade guide',
+      description: 'Changes from v1 to v2',
+      path: path.join(__dirname, 'upgradeGuide.md')
     },
     {
       type: 'markdown',

--- a/docs/upgradeGuide.md
+++ b/docs/upgradeGuide.md
@@ -1,6 +1,8 @@
-Changes in v2 that are common for all functions:
+# v2 Upgrade Guide
 
-- **BREAKING**: function submodules now use camelCase naming schema:
+## Common changes
+
+- Function submodules now use camelCase naming schema:
 
   ```javascript
   // Before v2.0.0
@@ -10,12 +12,12 @@ Changes in v2 that are common for all functions:
   import differenceInCalendarISOYears from 'date-fns/differenceInCalendarISOYears'
   ```
 
-- **BREAKING**: functions now throw `RangeError` if optional values passed to `options`
+- Functions now throw `RangeError` if optional values passed to `options`
   are not `undefined` or have expected values.
   This change is introduced for consistency with ECMAScript standard library which does the same.
   See [docs/Options.js](https://github.com/date-fns/date-fns/blob/master/docs/Options.js)
 
-- **BREAKING**: all functions now implicitly convert arguments by following rules:
+- All functions now implicitly convert arguments by following rules:
 
   |           | date          | number | string      | boolean |
   |-----------|---------------|--------|-------------|---------|
@@ -50,17 +52,17 @@ Changes in v2 that are common for all functions:
   See tests and PRs [#460](https://github.com/date-fns/date-fns/pull/460) and
   [#765](https://github.com/date-fns/date-fns/pull/765) for exact behavior.
 
-- **BREAKING**: `null` now is not a valid date. `isValid(null)` returns `false`;
+- `null` now is not a valid date. `isValid(null)` returns `false`;
   `toDate(null)` returns an invalid date. Since `toDate` is used internally
   by all the functions, operations over `null` will also return an invalid date.
   [See #537](https://github.com/date-fns/date-fns/issues/537) for the reasoning.
 
-- **BREAKING**: all functions now check if the passed number of arguments is less
+- All functions now check if the passed number of arguments is less
   than the number of required arguments and throw `TypeError` exception if so.
 
-- **BREAKING**: The Bower & UMD/CDN package versions are no longer supported.
+- The Bower & UMD/CDN package versions are no longer supported.
 
-- **BREAKING**: new locale format.
+- New locale format.
   See [docs/Locale](https://date-fns.org/docs/Locale).
   Locales renamed:
 

--- a/docs/v2BehaviourChanges.md
+++ b/docs/v2BehaviourChanges.md
@@ -1,0 +1,77 @@
+Changes in v2 that are common for all functions:
+
+- **BREAKING**: function submodules now use camelCase naming schema:
+
+  ```javascript
+  // Before v2.0.0
+  import differenceInCalendarISOYears from 'date-fns/difference_in_calendar_iso_years'
+
+  // v2.0.0 onward
+  import differenceInCalendarISOYears from 'date-fns/differenceInCalendarISOYears'
+  ```
+
+- **BREAKING**: functions now throw `RangeError` if optional values passed to `options`
+  are not `undefined` or have expected values.
+  This change is introduced for consistency with ECMAScript standard library which does the same.
+  See [docs/Options.js](https://github.com/date-fns/date-fns/blob/master/docs/Options.js)
+
+- **BREAKING**: all functions now implicitly convert arguments by following rules:
+
+  |           | date          | number | string      | boolean |
+  |-----------|---------------|--------|-------------|---------|
+  | 0         | new Date(0)   | 0      | '0'         | false   |
+  | '0'       | Invalid Date  | 0      | '0'         | false   |
+  | 1         | new Date(1)   | 1      | '1'         | true    |
+  | '1'       | Invalid Date  | 1      | '1'         | true    |
+  | true      | Invalid Date  | NaN    | 'true'      | true    |
+  | false     | Invalid Date  | NaN    | 'false'     | false   |
+  | null      | Invalid Date  | NaN    | 'null'      | false   |
+  | undefined | Invalid Date  | NaN    | 'undefined' | false   |
+  | NaN       | Invalid Date  | NaN    | 'NaN'       | false   |
+
+  Notes:
+  - as before, arguments expected to be `Date` are converted to `Date` using *date-fns'* `toDate` function;
+  - arguments expected to be numbers are converted to integer numbers using our custom `toInteger` implementation
+    (see [#765](https://github.com/date-fns/date-fns/pull/765));
+  - arguments expected to be strings arguments are converted to strings using JavaScript's `String` function;
+  - arguments expected to be booleans are converted to strings using JavaScript's `Boolean` function.
+
+  `null` and `undefined` passed to optional arguments (i.e. properties of `options` argument)
+  are ignored as if no argument was passed.
+
+  If any of resulting arguments is invalid (i.e. `NaN` for numbers and `Invalid Date` for dates),
+  an invalid value will be returned:
+
+  - `false` for functions that return booleans (expect `isValid`);
+  - `Invalid Date` for functions that return dates;
+  - `NaN` for functions that return numbers;
+  - and `String('Invalid Date')` for functions that return strings.
+
+  See tests and PRs [#460](https://github.com/date-fns/date-fns/pull/460) and
+  [#765](https://github.com/date-fns/date-fns/pull/765) for exact behavior.
+
+- **BREAKING**: `null` now is not a valid date. `isValid(null)` returns `false`;
+  `toDate(null)` returns an invalid date. Since `toDate` is used internally
+  by all the functions, operations over `null` will also return an invalid date.
+  [See #537](https://github.com/date-fns/date-fns/issues/537) for the reasoning.
+
+- **BREAKING**: all functions now check if the passed number of arguments is less
+  than the number of required arguments and throw `TypeError` exception if so.
+
+- **BREAKING**: The Bower & UMD/CDN package versions are no longer supported.
+
+- **BREAKING**: new locale format.
+  See [docs/Locale](https://date-fns.org/docs/Locale).
+  Locales renamed:
+
+  - `en` → `en-US`
+  - `zh_cn` → `zh-CN`
+  - `zh_tw` → `zh-TW`
+
+  ```javascript
+  // Before v2.0.0
+  import locale from 'date-fns/locale/zh_cn'
+
+  // v2.0.0 onward
+  import locale from 'date-fns/locale/zh-CN'
+  ```

--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of days to be added

--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Add the specified number of days to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of days to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Add the specified number of days to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addHours/index.js
+++ b/src/addHours/index.js
@@ -11,6 +11,7 @@ var MILLISECONDS_IN_HOUR = 3600000
  * @description
  * Add the specified number of hours to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addHours/index.js
+++ b/src/addHours/index.js
@@ -14,9 +14,7 @@ var MILLISECONDS_IN_HOUR = 3600000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of hours to be added

--- a/src/addHours/index.js
+++ b/src/addHours/index.js
@@ -11,6 +11,12 @@ var MILLISECONDS_IN_HOUR = 3600000
  * @description
  * Add the specified number of hours to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of hours to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addISOWeekYears/index.js
+++ b/src/addISOWeekYears/index.js
@@ -12,6 +12,7 @@ import setISOWeekYear from '../setISOWeekYear/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addISOWeekYears/index.js
+++ b/src/addISOWeekYears/index.js
@@ -12,6 +12,12 @@ import setISOWeekYear from '../setISOWeekYear/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of ISO week-numbering years to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addISOWeekYears/index.js
+++ b/src/addISOWeekYears/index.js
@@ -15,9 +15,7 @@ import setISOWeekYear from '../setISOWeekYear/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of ISO week-numbering years to be added

--- a/src/addMilliseconds/index.js
+++ b/src/addMilliseconds/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Add the specified number of milliseconds to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of milliseconds to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addMilliseconds/index.js
+++ b/src/addMilliseconds/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of milliseconds to be added

--- a/src/addMilliseconds/index.js
+++ b/src/addMilliseconds/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Add the specified number of milliseconds to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addMinutes/index.js
+++ b/src/addMinutes/index.js
@@ -11,6 +11,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  * @description
  * Add the specified number of minutes to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addMinutes/index.js
+++ b/src/addMinutes/index.js
@@ -11,6 +11,12 @@ var MILLISECONDS_IN_MINUTE = 60000
  * @description
  * Add the specified number of minutes to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of minutes to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addMinutes/index.js
+++ b/src/addMinutes/index.js
@@ -14,9 +14,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of minutes to be added

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -10,6 +10,7 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  * @description
  * Add the specified number of months to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -13,9 +13,7 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of months to be added

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -10,6 +10,12 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  * @description
  * Add the specified number of months to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of months to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addQuarters/index.js
+++ b/src/addQuarters/index.js
@@ -12,9 +12,7 @@ import addMonths from '../addMonths/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of quarters to be added

--- a/src/addQuarters/index.js
+++ b/src/addQuarters/index.js
@@ -9,6 +9,12 @@ import addMonths from '../addMonths/index.js'
  * @description
  * Add the specified number of year quarters to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of quarters to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addQuarters/index.js
+++ b/src/addQuarters/index.js
@@ -9,6 +9,7 @@ import addMonths from '../addMonths/index.js'
  * @description
  * Add the specified number of year quarters to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addSeconds/index.js
+++ b/src/addSeconds/index.js
@@ -12,9 +12,7 @@ import addMilliseconds from '../addMilliseconds/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of seconds to be added

--- a/src/addSeconds/index.js
+++ b/src/addSeconds/index.js
@@ -9,6 +9,12 @@ import addMilliseconds from '../addMilliseconds/index.js'
  * @description
  * Add the specified number of seconds to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of seconds to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addSeconds/index.js
+++ b/src/addSeconds/index.js
@@ -9,6 +9,7 @@ import addMilliseconds from '../addMilliseconds/index.js'
  * @description
  * Add the specified number of seconds to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addWeeks/index.js
+++ b/src/addWeeks/index.js
@@ -12,9 +12,7 @@ import addDays from '../addDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of weeks to be added

--- a/src/addWeeks/index.js
+++ b/src/addWeeks/index.js
@@ -9,6 +9,7 @@ import addDays from '../addDays/index.js'
  * @description
  * Add the specified number of week to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/addWeeks/index.js
+++ b/src/addWeeks/index.js
@@ -9,6 +9,12 @@ import addDays from '../addDays/index.js'
  * @description
  * Add the specified number of week to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of weeks to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addYears/index.js
+++ b/src/addYears/index.js
@@ -12,9 +12,7 @@ import addMonths from '../addMonths/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of years to be added

--- a/src/addYears/index.js
+++ b/src/addYears/index.js
@@ -9,6 +9,12 @@ import addMonths from '../addMonths/index.js'
  * @description
  * Add the specified number of years to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of years to be added
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/addYears/index.js
+++ b/src/addYears/index.js
@@ -9,6 +9,7 @@ import addMonths from '../addMonths/index.js'
  * @description
  * Add the specified number of years to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/areIntervalsOverlapping/index.js
+++ b/src/areIntervalsOverlapping/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Interval} intervalLeft - the first interval to compare. See [Interval]{@link docs/types/Interval}
  * @param {Interval} intervalRight - the second interval to compare. See [Interval]{@link docs/types/Interval}

--- a/src/areIntervalsOverlapping/index.js
+++ b/src/areIntervalsOverlapping/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given time interval overlapping with another time interval?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/areIntervalsOverlapping/index.js
+++ b/src/areIntervalsOverlapping/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given time interval overlapping with another time interval?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Interval} intervalLeft - the first interval to compare. See [Interval]{@link docs/types/Interval}
  * @param {Interval} intervalRight - the second interval to compare. See [Interval]{@link docs/types/Interval}
  * @param {Options} [options] - the object with options. See [Options]{@link docs/types/Options}

--- a/src/closestIndexTo/index.js
+++ b/src/closestIndexTo/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return an index of the closest date from the array comparing to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateToCompare - the date to compare with
  * @param {Date[]|String[]|Number[]} datesArray - the array to search
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/closestIndexTo/index.js
+++ b/src/closestIndexTo/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return an index of the closest date from the array comparing to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/closestIndexTo/index.js
+++ b/src/closestIndexTo/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateToCompare - the date to compare with
  * @param {Date[]|String[]|Number[]} datesArray - the array to search

--- a/src/closestTo/index.js
+++ b/src/closestTo/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return a date from the array closest to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateToCompare - the date to compare with
  * @param {Date[]|String[]|Number[]} datesArray - the array to search
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/closestTo/index.js
+++ b/src/closestTo/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return a date from the array closest to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/closestTo/index.js
+++ b/src/closestTo/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateToCompare - the date to compare with
  * @param {Date[]|String[]|Number[]} datesArray - the array to search

--- a/src/compareAsc/index.js
+++ b/src/compareAsc/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to compare
  * @param {Date|String|Number} dateRight - the second date to compare

--- a/src/compareAsc/index.js
+++ b/src/compareAsc/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Compare the two dates and return 1 if the first date is after the second,
  * -1 if the first date is before the second or 0 if dates are equal.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to compare
  * @param {Date|String|Number} dateRight - the second date to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/compareAsc/index.js
+++ b/src/compareAsc/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Compare the two dates and return 1 if the first date is after the second,
  * -1 if the first date is before the second or 0 if dates are equal.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/compareDesc/index.js
+++ b/src/compareDesc/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Compare the two dates and return -1 if the first date is after the second,
  * 1 if the first date is before the second or 0 if dates are equal.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/compareDesc/index.js
+++ b/src/compareDesc/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Compare the two dates and return -1 if the first date is after the second,
  * 1 if the first date is before the second or 0 if dates are equal.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to compare
  * @param {Date|String|Number} dateRight - the second date to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/compareDesc/index.js
+++ b/src/compareDesc/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to compare
  * @param {Date|String|Number} dateRight - the second date to compare

--- a/src/differenceInCalendarDays/index.js
+++ b/src/differenceInCalendarDays/index.js
@@ -15,9 +15,7 @@ var MILLISECONDS_IN_DAY = 86400000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarDays/index.js
+++ b/src/differenceInCalendarDays/index.js
@@ -12,6 +12,7 @@ var MILLISECONDS_IN_DAY = 86400000
  * Get the number of calendar days between the given dates. This means that the times are removed
  * from the dates and then the difference in days is calculated.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInCalendarDays/index.js
+++ b/src/differenceInCalendarDays/index.js
@@ -12,6 +12,12 @@ var MILLISECONDS_IN_DAY = 86400000
  * Get the number of calendar days between the given dates. This means that the times are removed
  * from the dates and then the difference in days is calculated.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarISOWeekYears/index.js
+++ b/src/differenceInCalendarISOWeekYears/index.js
@@ -10,6 +10,12 @@ import getISOWeekYear from '../getISOWeekYear/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarISOWeekYears/index.js
+++ b/src/differenceInCalendarISOWeekYears/index.js
@@ -13,9 +13,7 @@ import getISOWeekYear from '../getISOWeekYear/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarISOWeekYears/index.js
+++ b/src/differenceInCalendarISOWeekYears/index.js
@@ -10,6 +10,7 @@ import getISOWeekYear from '../getISOWeekYear/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInCalendarISOWeeks/index.js
+++ b/src/differenceInCalendarISOWeeks/index.js
@@ -16,9 +16,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarISOWeeks/index.js
+++ b/src/differenceInCalendarISOWeeks/index.js
@@ -13,6 +13,12 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarISOWeeks/index.js
+++ b/src/differenceInCalendarISOWeeks/index.js
@@ -13,6 +13,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInCalendarMonths/index.js
+++ b/src/differenceInCalendarMonths/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of calendar months between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInCalendarMonths/index.js
+++ b/src/differenceInCalendarMonths/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarMonths/index.js
+++ b/src/differenceInCalendarMonths/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of calendar months between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarQuarters/index.js
+++ b/src/differenceInCalendarQuarters/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of calendar quarters between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarQuarters/index.js
+++ b/src/differenceInCalendarQuarters/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of calendar quarters between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInCalendarQuarters/index.js
+++ b/src/differenceInCalendarQuarters/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarWeeks/index.js
+++ b/src/differenceInCalendarWeeks/index.js
@@ -14,9 +14,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarWeeks/index.js
+++ b/src/differenceInCalendarWeeks/index.js
@@ -11,6 +11,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  * @description
  * Get the number of calendar weeks between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInCalendarWeeks/index.js
+++ b/src/differenceInCalendarWeeks/index.js
@@ -11,6 +11,12 @@ var MILLISECONDS_IN_WEEK = 604800000
  * @description
  * Get the number of calendar weeks between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarYears/index.js
+++ b/src/differenceInCalendarYears/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of calendar years between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInCalendarYears/index.js
+++ b/src/differenceInCalendarYears/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInCalendarYears/index.js
+++ b/src/differenceInCalendarYears/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of calendar years between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInDays/index.js
+++ b/src/differenceInDays/index.js
@@ -10,6 +10,12 @@ import compareAsc from '../compareAsc/index.js'
  * @description
  * Get the number of full day periods between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInDays/index.js
+++ b/src/differenceInDays/index.js
@@ -10,6 +10,7 @@ import compareAsc from '../compareAsc/index.js'
  * @description
  * Get the number of full day periods between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInDays/index.js
+++ b/src/differenceInDays/index.js
@@ -13,9 +13,7 @@ import compareAsc from '../compareAsc/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInHours/index.js
+++ b/src/differenceInHours/index.js
@@ -10,6 +10,12 @@ var MILLISECONDS_IN_HOUR = 3600000
  * @description
  * Get the number of hours between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInHours/index.js
+++ b/src/differenceInHours/index.js
@@ -10,6 +10,7 @@ var MILLISECONDS_IN_HOUR = 3600000
  * @description
  * Get the number of hours between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInHours/index.js
+++ b/src/differenceInHours/index.js
@@ -13,9 +13,7 @@ var MILLISECONDS_IN_HOUR = 3600000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInISOWeekYears/index.js
+++ b/src/differenceInISOWeekYears/index.js
@@ -13,6 +13,12 @@ import subISOWeekYears from '../subISOWeekYears/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInISOWeekYears/index.js
+++ b/src/differenceInISOWeekYears/index.js
@@ -16,9 +16,7 @@ import subISOWeekYears from '../subISOWeekYears/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInISOWeekYears/index.js
+++ b/src/differenceInISOWeekYears/index.js
@@ -13,6 +13,7 @@ import subISOWeekYears from '../subISOWeekYears/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInMilliseconds/index.js
+++ b/src/differenceInMilliseconds/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInMilliseconds/index.js
+++ b/src/differenceInMilliseconds/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of milliseconds between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInMilliseconds/index.js
+++ b/src/differenceInMilliseconds/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of milliseconds between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInMinutes/index.js
+++ b/src/differenceInMinutes/index.js
@@ -10,6 +10,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  * @description
  * Get the number of minutes between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInMinutes/index.js
+++ b/src/differenceInMinutes/index.js
@@ -10,6 +10,12 @@ var MILLISECONDS_IN_MINUTE = 60000
  * @description
  * Get the number of minutes between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInMinutes/index.js
+++ b/src/differenceInMinutes/index.js
@@ -13,9 +13,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInMonths/index.js
+++ b/src/differenceInMonths/index.js
@@ -10,6 +10,12 @@ import compareAsc from '../compareAsc/index.js'
  * @description
  * Get the number of full months between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInMonths/index.js
+++ b/src/differenceInMonths/index.js
@@ -10,6 +10,7 @@ import compareAsc from '../compareAsc/index.js'
  * @description
  * Get the number of full months between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInMonths/index.js
+++ b/src/differenceInMonths/index.js
@@ -13,9 +13,7 @@ import compareAsc from '../compareAsc/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInQuarters/index.js
+++ b/src/differenceInQuarters/index.js
@@ -8,6 +8,12 @@ import differenceInMonths from '../differenceInMonths/index.js'
  * @description
  * Get the number of full quarters between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInQuarters/index.js
+++ b/src/differenceInQuarters/index.js
@@ -8,6 +8,7 @@ import differenceInMonths from '../differenceInMonths/index.js'
  * @description
  * Get the number of full quarters between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInQuarters/index.js
+++ b/src/differenceInQuarters/index.js
@@ -11,9 +11,7 @@ import differenceInMonths from '../differenceInMonths/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInSeconds/index.js
+++ b/src/differenceInSeconds/index.js
@@ -8,6 +8,7 @@ import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
  * @description
  * Get the number of seconds between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInSeconds/index.js
+++ b/src/differenceInSeconds/index.js
@@ -8,6 +8,12 @@ import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
  * @description
  * Get the number of seconds between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInSeconds/index.js
+++ b/src/differenceInSeconds/index.js
@@ -11,9 +11,7 @@ import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInWeeks/index.js
+++ b/src/differenceInWeeks/index.js
@@ -8,6 +8,7 @@ import differenceInDays from '../differenceInDays/index.js'
  * @description
  * Get the number of full weeks between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/differenceInWeeks/index.js
+++ b/src/differenceInWeeks/index.js
@@ -8,6 +8,12 @@ import differenceInDays from '../differenceInDays/index.js'
  * @description
  * Get the number of full weeks between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInWeeks/index.js
+++ b/src/differenceInWeeks/index.js
@@ -11,9 +11,7 @@ import differenceInDays from '../differenceInDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInYears/index.js
+++ b/src/differenceInYears/index.js
@@ -10,6 +10,12 @@ import compareAsc from '../compareAsc/index.js'
  * @description
  * Get the number of full years between the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/differenceInYears/index.js
+++ b/src/differenceInYears/index.js
@@ -13,9 +13,7 @@ import compareAsc from '../compareAsc/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the later date
  * @param {Date|String|Number} dateRight - the earlier date

--- a/src/differenceInYears/index.js
+++ b/src/differenceInYears/index.js
@@ -10,6 +10,7 @@ import compareAsc from '../compareAsc/index.js'
  * @description
  * Get the number of full years between the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/eachDayOfInterval/index.js
+++ b/src/eachDayOfInterval/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the array of dates within the specified time interval.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/eachDayOfInterval/index.js
+++ b/src/eachDayOfInterval/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Interval} interval - the interval. See [Interval]{@link docs/types/Interval}
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/eachDayOfInterval/index.js
+++ b/src/eachDayOfInterval/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the array of dates within the specified time interval.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Interval} interval - the interval. See [Interval]{@link docs/types/Interval}
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/eachWeekOfInterval/index.js
+++ b/src/eachWeekOfInterval/index.js
@@ -10,6 +10,7 @@ import addWeeks from '../addWeeks/index.js'
  * @description
  * Return the array of weeks within the specified time interval.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/eachWeekOfInterval/index.js
+++ b/src/eachWeekOfInterval/index.js
@@ -13,9 +13,7 @@ import addWeeks from '../addWeeks/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Interval} interval - the interval. See [Interval]{@link docs/types/Interval}
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/eachWeekOfInterval/index.js
+++ b/src/eachWeekOfInterval/index.js
@@ -10,6 +10,12 @@ import addWeeks from '../addWeeks/index.js'
  * @description
  * Return the array of weeks within the specified time interval.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Interval} interval - the interval. See [Interval]{@link docs/types/Interval}
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfDay/index.js
+++ b/src/endOfDay/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a day for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfDay/index.js
+++ b/src/endOfDay/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfDay/index.js
+++ b/src/endOfDay/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a day for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfDecade/index.js
+++ b/src/endOfDecade/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the end of a decade for the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @returns {Date} the end of a decade
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfDecade/index.js
+++ b/src/endOfDecade/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @returns {Date} the end of a decade

--- a/src/endOfDecade/index.js
+++ b/src/endOfDecade/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the end of a decade for the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfHour/index.js
+++ b/src/endOfHour/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of an hour for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfHour/index.js
+++ b/src/endOfHour/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfHour/index.js
+++ b/src/endOfHour/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of an hour for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfISOWeek/index.js
+++ b/src/endOfISOWeek/index.js
@@ -15,9 +15,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfISOWeek/index.js
+++ b/src/endOfISOWeek/index.js
@@ -12,6 +12,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfISOWeek/index.js
+++ b/src/endOfISOWeek/index.js
@@ -12,6 +12,12 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfISOWeekYear/index.js
+++ b/src/endOfISOWeekYear/index.js
@@ -13,6 +13,12 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfISOWeekYear/index.js
+++ b/src/endOfISOWeekYear/index.js
@@ -16,9 +16,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfISOWeekYear/index.js
+++ b/src/endOfISOWeekYear/index.js
@@ -13,6 +13,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfMinute/index.js
+++ b/src/endOfMinute/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a minute for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfMinute/index.js
+++ b/src/endOfMinute/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfMinute/index.js
+++ b/src/endOfMinute/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a minute for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfMonth/index.js
+++ b/src/endOfMonth/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfMonth/index.js
+++ b/src/endOfMonth/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a month for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfMonth/index.js
+++ b/src/endOfMonth/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a month for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfQuarter/index.js
+++ b/src/endOfQuarter/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a year quarter for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfQuarter/index.js
+++ b/src/endOfQuarter/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfQuarter/index.js
+++ b/src/endOfQuarter/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a year quarter for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfSecond/index.js
+++ b/src/endOfSecond/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a second for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfSecond/index.js
+++ b/src/endOfSecond/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a second for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfSecond/index.js
+++ b/src/endOfSecond/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfWeek/index.js
+++ b/src/endOfWeek/index.js
@@ -10,6 +10,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a week for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfWeek/index.js
+++ b/src/endOfWeek/index.js
@@ -10,6 +10,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a week for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfWeek/index.js
+++ b/src/endOfWeek/index.js
@@ -13,9 +13,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/endOfYear/index.js
+++ b/src/endOfYear/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the end of a year for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/endOfYear/index.js
+++ b/src/endOfYear/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the end of a year for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/endOfYear/index.js
+++ b/src/endOfYear/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -278,9 +278,7 @@ var doubleQuoteRegExp = /''/g
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {String} format - the string of tokens

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -275,6 +275,7 @@ var doubleQuoteRegExp = /''/g
  *
  * 8. These tokens are often confused with others. See: https://git.io/fxCyr
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -275,6 +275,12 @@ var doubleQuoteRegExp = /''/g
  *
  * 8. These tokens are often confused with others. See: https://git.io/fxCyr
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {String} format - the string of tokens
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/formatDistance/index.js
+++ b/src/formatDistance/index.js
@@ -48,6 +48,12 @@ var MINUTES_IN_TWO_MONTHS = 86400
  * | 40 secs ... 60 secs    | less than a minute   |
  * | 60 secs ... 90 secs    | 1 minute             |
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date
  * @param {Date|String|Number} baseDate - the date to compare with
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/formatDistance/index.js
+++ b/src/formatDistance/index.js
@@ -51,9 +51,7 @@ var MINUTES_IN_TWO_MONTHS = 86400
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date
  * @param {Date|String|Number} baseDate - the date to compare with

--- a/src/formatDistance/index.js
+++ b/src/formatDistance/index.js
@@ -48,6 +48,7 @@ var MINUTES_IN_TWO_MONTHS = 86400
  * | 40 secs ... 60 secs    | less than a minute   |
  * | 60 secs ... 90 secs    | 1 minute             |
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -28,6 +28,7 @@ var MINUTES_IN_YEAR = 525600
  * | 1 ... 11 months        | [1..11] months      |
  * | 1 ... N years          | [1..N]  years       |
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -28,6 +28,12 @@ var MINUTES_IN_YEAR = 525600
  * | 1 ... 11 months        | [1..11] months      |
  * | 1 ... N years          | [1..N]  years       |
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date
  * @param {Date|String|Number} baseDate - the date to compare with
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -31,9 +31,7 @@ var MINUTES_IN_YEAR = 525600
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date
  * @param {Date|String|Number} baseDate - the date to compare with

--- a/src/formatRelative/index.js
+++ b/src/formatRelative/index.js
@@ -22,6 +22,12 @@ import subMilliseconds from '../subMilliseconds/index.js'
  * | Next 6 days               | Sunday at 04:30 AM        |
  * | Other                     | 12/31/2017                |
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to format
  * @param {Date|String|Number} baseDate - the date to compare with
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/formatRelative/index.js
+++ b/src/formatRelative/index.js
@@ -25,9 +25,7 @@ import subMilliseconds from '../subMilliseconds/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to format
  * @param {Date|String|Number} baseDate - the date to compare with

--- a/src/formatRelative/index.js
+++ b/src/formatRelative/index.js
@@ -22,6 +22,7 @@ import subMilliseconds from '../subMilliseconds/index.js'
  * | Next 6 days               | Sunday at 04:30 AM        |
  * | Other                     | 12/31/2017                |
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/fromUnixTime/index.js
+++ b/src/fromUnixTime/index.js
@@ -9,6 +9,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * @description
  * Create a date from a Unix timestamp.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/fromUnixTime/index.js
+++ b/src/fromUnixTime/index.js
@@ -12,9 +12,7 @@ import toInteger from '../_lib/toInteger/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Number} unixTime - the given Unix timestamp
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/fromUnixTime/index.js
+++ b/src/fromUnixTime/index.js
@@ -9,6 +9,12 @@ import toInteger from '../_lib/toInteger/index.js'
  * @description
  * Create a date from a Unix timestamp.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Number} unixTime - the given Unix timestamp
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDate/index.js
+++ b/src/getDate/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the day of the month of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDate/index.js
+++ b/src/getDate/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getDate/index.js
+++ b/src/getDate/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the day of the month of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the day of the week of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the day of the week of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDayOfYear/index.js
+++ b/src/getDayOfYear/index.js
@@ -13,9 +13,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getDayOfYear/index.js
+++ b/src/getDayOfYear/index.js
@@ -10,6 +10,12 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  * @description
  * Get the day of the year of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDayOfYear/index.js
+++ b/src/getDayOfYear/index.js
@@ -10,6 +10,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  * @description
  * Get the day of the year of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getDaysInMonth/index.js
+++ b/src/getDaysInMonth/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getDaysInMonth/index.js
+++ b/src/getDaysInMonth/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of days in a month of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getDaysInMonth/index.js
+++ b/src/getDaysInMonth/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the number of days in a month of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDaysInYear/index.js
+++ b/src/getDaysInYear/index.js
@@ -12,9 +12,7 @@ import isLeapYear from '../isLeapYear/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getDaysInYear/index.js
+++ b/src/getDaysInYear/index.js
@@ -9,6 +9,12 @@ import isLeapYear from '../isLeapYear/index.js'
  * @description
  * Get the number of days in a year of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDaysInYear/index.js
+++ b/src/getDaysInYear/index.js
@@ -9,6 +9,7 @@ import isLeapYear from '../isLeapYear/index.js'
  * @description
  * Get the number of days in a year of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getDecade/index.js
+++ b/src/getDecade/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getDecade/index.js
+++ b/src/getDecade/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the decade of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getDecade/index.js
+++ b/src/getDecade/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the decade of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getHours/index.js
+++ b/src/getHours/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getHours/index.js
+++ b/src/getHours/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the hours of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getHours/index.js
+++ b/src/getHours/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the hours of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getISODay/index.js
+++ b/src/getISODay/index.js
@@ -14,9 +14,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getISODay/index.js
+++ b/src/getISODay/index.js
@@ -11,6 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getISODay/index.js
+++ b/src/getISODay/index.js
@@ -11,6 +11,12 @@ import toDate from '../toDate/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getISOWeek/index.js
+++ b/src/getISOWeek/index.js
@@ -17,9 +17,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getISOWeek/index.js
+++ b/src/getISOWeek/index.js
@@ -14,6 +14,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getISOWeek/index.js
+++ b/src/getISOWeek/index.js
@@ -14,6 +14,12 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getISOWeekYear/index.js
+++ b/src/getISOWeekYear/index.js
@@ -12,6 +12,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getISOWeekYear/index.js
+++ b/src/getISOWeekYear/index.js
@@ -15,9 +15,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getISOWeekYear/index.js
+++ b/src/getISOWeekYear/index.js
@@ -12,6 +12,12 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getISOWeeksInYear/index.js
+++ b/src/getISOWeeksInYear/index.js
@@ -13,6 +13,12 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getISOWeeksInYear/index.js
+++ b/src/getISOWeeksInYear/index.js
@@ -13,6 +13,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getISOWeeksInYear/index.js
+++ b/src/getISOWeeksInYear/index.js
@@ -16,9 +16,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getMilliseconds/index.js
+++ b/src/getMilliseconds/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the milliseconds of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getMilliseconds/index.js
+++ b/src/getMilliseconds/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getMilliseconds/index.js
+++ b/src/getMilliseconds/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the milliseconds of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getMinutes/index.js
+++ b/src/getMinutes/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the minutes of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getMinutes/index.js
+++ b/src/getMinutes/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getMinutes/index.js
+++ b/src/getMinutes/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the minutes of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getMonth/index.js
+++ b/src/getMonth/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the month of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getMonth/index.js
+++ b/src/getMonth/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the month of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getMonth/index.js
+++ b/src/getMonth/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getOverlappingDaysInIntervals/index.js
+++ b/src/getOverlappingDaysInIntervals/index.js
@@ -10,6 +10,7 @@ var MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
  * @description
  * Get the number of days that overlap in two time intervals
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getOverlappingDaysInIntervals/index.js
+++ b/src/getOverlappingDaysInIntervals/index.js
@@ -10,6 +10,12 @@ var MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
  * @description
  * Get the number of days that overlap in two time intervals
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Interval} intervalLeft - the first interval to compare. See [Interval]{@link docs/Interval}
  * @param {Interval} intervalRight - the second interval to compare. See [Interval]{@link docs/Interval}
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getOverlappingDaysInIntervals/index.js
+++ b/src/getOverlappingDaysInIntervals/index.js
@@ -13,9 +13,7 @@ var MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Interval} intervalLeft - the first interval to compare. See [Interval]{@link docs/Interval}
  * @param {Interval} intervalRight - the second interval to compare. See [Interval]{@link docs/Interval}

--- a/src/getQuarter/index.js
+++ b/src/getQuarter/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getQuarter/index.js
+++ b/src/getQuarter/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the year quarter of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getQuarter/index.js
+++ b/src/getQuarter/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the year quarter of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getSeconds/index.js
+++ b/src/getSeconds/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getSeconds/index.js
+++ b/src/getSeconds/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the seconds of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getSeconds/index.js
+++ b/src/getSeconds/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the seconds of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getTime/index.js
+++ b/src/getTime/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getTime/index.js
+++ b/src/getTime/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the milliseconds timestamp of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getTime/index.js
+++ b/src/getTime/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the milliseconds timestamp of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getUnixTime/index.js
+++ b/src/getUnixTime/index.js
@@ -11,9 +11,7 @@ import getTime from '../getTime/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getUnixTime/index.js
+++ b/src/getUnixTime/index.js
@@ -8,6 +8,12 @@ import getTime from '../getTime/index.js'
  * @description
  * Get the seconds timestamp of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getUnixTime/index.js
+++ b/src/getUnixTime/index.js
@@ -8,6 +8,7 @@ import getTime from '../getTime/index.js'
  * @description
  * Get the seconds timestamp of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getWeek/index.js
+++ b/src/getWeek/index.js
@@ -21,9 +21,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getWeek/index.js
+++ b/src/getWeek/index.js
@@ -18,6 +18,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getWeek/index.js
+++ b/src/getWeek/index.js
@@ -18,6 +18,12 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -11,6 +11,7 @@ import getDay from '../getDay/index.js'
  * @description
  * Get the week of the month of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -14,9 +14,7 @@ import getDay from '../getDay/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -11,6 +11,12 @@ import getDay from '../getDay/index.js'
  * @description
  * Get the week of the month of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getWeekYear/index.js
+++ b/src/getWeekYear/index.js
@@ -16,6 +16,12 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getWeekYear/index.js
+++ b/src/getWeekYear/index.js
@@ -16,6 +16,7 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getWeekYear/index.js
+++ b/src/getWeekYear/index.js
@@ -19,9 +19,7 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getWeeksInMonth/index.js
+++ b/src/getWeeksInMonth/index.js
@@ -13,9 +13,7 @@ import startOfMonth from '../startOfMonth/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/getWeeksInMonth/index.js
+++ b/src/getWeeksInMonth/index.js
@@ -10,6 +10,12 @@ import startOfMonth from '../startOfMonth/index.js'
  * @description
  * Get the number of calendar weeks the month in the given date spans.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getWeeksInMonth/index.js
+++ b/src/getWeeksInMonth/index.js
@@ -10,6 +10,7 @@ import startOfMonth from '../startOfMonth/index.js'
  * @description
  * Get the number of calendar weeks the month in the given date spans.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getYear/index.js
+++ b/src/getYear/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the year of the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/getYear/index.js
+++ b/src/getYear/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Get the year of the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/getYear/index.js
+++ b/src/getYear/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the given date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isAfter/index.js
+++ b/src/isAfter/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the first date after the second one?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date that should be after the other one to return true
  * @param {Date|String|Number} dateToCompare - the date to compare with
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isAfter/index.js
+++ b/src/isAfter/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the first date after the second one?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isAfter/index.js
+++ b/src/isAfter/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date that should be after the other one to return true
  * @param {Date|String|Number} dateToCompare - the date to compare with

--- a/src/isBefore/index.js
+++ b/src/isBefore/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the first date before the second one?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isBefore/index.js
+++ b/src/isBefore/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the first date before the second one?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date that should be before the other one to return true
  * @param {Date|String|Number} dateToCompare - the date to compare with
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isBefore/index.js
+++ b/src/isBefore/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date that should be before the other one to return true
  * @param {Date|String|Number} dateToCompare - the date to compare with

--- a/src/isDate/index.js
+++ b/src/isDate/index.js
@@ -6,6 +6,12 @@
  * @description
  * Returns true if the given value is an instance of Date. The function works for dates transferred across iframes.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {*} value - the value to check
  * @param {Options} [options] - the object with options. Unused; present for FP submodule compatibility sake. See [Options]{@link https://date-fns.org/docs/Options}
  * @returns {boolean} true if the given value is a date

--- a/src/isDate/index.js
+++ b/src/isDate/index.js
@@ -9,9 +9,7 @@
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {*} value - the value to check
  * @param {Options} [options] - the object with options. Unused; present for FP submodule compatibility sake. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isDate/index.js
+++ b/src/isDate/index.js
@@ -6,6 +6,7 @@
  * @description
  * Returns true if the given value is an instance of Date. The function works for dates transferred across iframes.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isEqual/index.js
+++ b/src/isEqual/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Are the given dates equal?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isEqual/index.js
+++ b/src/isEqual/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to compare
  * @param {Date|String|Number} dateRight - the second date to compare

--- a/src/isEqual/index.js
+++ b/src/isEqual/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Are the given dates equal?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to compare
  * @param {Date|String|Number} dateRight - the second date to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isFirstDayOfMonth/index.js
+++ b/src/isFirstDayOfMonth/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isFirstDayOfMonth/index.js
+++ b/src/isFirstDayOfMonth/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date the first day of a month?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isFirstDayOfMonth/index.js
+++ b/src/isFirstDayOfMonth/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date the first day of a month?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isFriday/index.js
+++ b/src/isFriday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isFriday/index.js
+++ b/src/isFriday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Friday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isFriday/index.js
+++ b/src/isFriday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Friday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isLastDayOfMonth/index.js
+++ b/src/isLastDayOfMonth/index.js
@@ -13,9 +13,7 @@ import endOfMonth from '../endOfMonth/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isLastDayOfMonth/index.js
+++ b/src/isLastDayOfMonth/index.js
@@ -10,6 +10,12 @@ import endOfMonth from '../endOfMonth/index.js'
  * @description
  * Is the given date the last day of a month?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isLastDayOfMonth/index.js
+++ b/src/isLastDayOfMonth/index.js
@@ -10,6 +10,7 @@ import endOfMonth from '../endOfMonth/index.js'
  * @description
  * Is the given date the last day of a month?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isLeapYear/index.js
+++ b/src/isLeapYear/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date in the leap year?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isLeapYear/index.js
+++ b/src/isLeapYear/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isLeapYear/index.js
+++ b/src/isLeapYear/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date in the leap year?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isMonday/index.js
+++ b/src/isMonday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Monday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isMonday/index.js
+++ b/src/isMonday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isMonday/index.js
+++ b/src/isMonday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Monday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameDay/index.js
+++ b/src/isSameDay/index.js
@@ -8,6 +8,12 @@ import startOfDay from '../startOfDay/index.js'
  * @description
  * Are the given dates in the same day?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameDay/index.js
+++ b/src/isSameDay/index.js
@@ -8,6 +8,7 @@ import startOfDay from '../startOfDay/index.js'
  * @description
  * Are the given dates in the same day?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameDay/index.js
+++ b/src/isSameDay/index.js
@@ -11,9 +11,7 @@ import startOfDay from '../startOfDay/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameHour/index.js
+++ b/src/isSameHour/index.js
@@ -8,6 +8,12 @@ import startOfHour from '../startOfHour/index.js'
  * @description
  * Are the given dates in the same hour?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameHour/index.js
+++ b/src/isSameHour/index.js
@@ -8,6 +8,7 @@ import startOfHour from '../startOfHour/index.js'
  * @description
  * Are the given dates in the same hour?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameHour/index.js
+++ b/src/isSameHour/index.js
@@ -11,9 +11,7 @@ import startOfHour from '../startOfHour/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameISOWeek/index.js
+++ b/src/isSameISOWeek/index.js
@@ -11,6 +11,12 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameISOWeek/index.js
+++ b/src/isSameISOWeek/index.js
@@ -11,6 +11,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameISOWeek/index.js
+++ b/src/isSameISOWeek/index.js
@@ -14,9 +14,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameISOWeekYear/index.js
+++ b/src/isSameISOWeekYear/index.js
@@ -10,6 +10,12 @@ import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameISOWeekYear/index.js
+++ b/src/isSameISOWeekYear/index.js
@@ -10,6 +10,7 @@ import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameISOWeekYear/index.js
+++ b/src/isSameISOWeekYear/index.js
@@ -13,9 +13,7 @@ import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameMinute/index.js
+++ b/src/isSameMinute/index.js
@@ -11,9 +11,7 @@ import startOfMinute from '../startOfMinute/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameMinute/index.js
+++ b/src/isSameMinute/index.js
@@ -8,6 +8,7 @@ import startOfMinute from '../startOfMinute/index.js'
  * @description
  * Are the given dates in the same minute?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameMinute/index.js
+++ b/src/isSameMinute/index.js
@@ -8,6 +8,12 @@ import startOfMinute from '../startOfMinute/index.js'
  * @description
  * Are the given dates in the same minute?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameMonth/index.js
+++ b/src/isSameMonth/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Are the given dates in the same month?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameMonth/index.js
+++ b/src/isSameMonth/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Are the given dates in the same month?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameMonth/index.js
+++ b/src/isSameMonth/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameQuarter/index.js
+++ b/src/isSameQuarter/index.js
@@ -11,9 +11,7 @@ import startOfQuarter from '../startOfQuarter/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameQuarter/index.js
+++ b/src/isSameQuarter/index.js
@@ -8,6 +8,7 @@ import startOfQuarter from '../startOfQuarter/index.js'
  * @description
  * Are the given dates in the same year quarter?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameQuarter/index.js
+++ b/src/isSameQuarter/index.js
@@ -8,6 +8,12 @@ import startOfQuarter from '../startOfQuarter/index.js'
  * @description
  * Are the given dates in the same year quarter?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameSecond/index.js
+++ b/src/isSameSecond/index.js
@@ -8,6 +8,12 @@ import startOfSecond from '../startOfSecond/index.js'
  * @description
  * Are the given dates in the same second?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameSecond/index.js
+++ b/src/isSameSecond/index.js
@@ -11,9 +11,7 @@ import startOfSecond from '../startOfSecond/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameSecond/index.js
+++ b/src/isSameSecond/index.js
@@ -8,6 +8,7 @@ import startOfSecond from '../startOfSecond/index.js'
  * @description
  * Are the given dates in the same second?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameWeek/index.js
+++ b/src/isSameWeek/index.js
@@ -11,9 +11,7 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSameWeek/index.js
+++ b/src/isSameWeek/index.js
@@ -8,6 +8,7 @@ import startOfWeek from '../startOfWeek/index.js'
  * @description
  * Are the given dates in the same week?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameWeek/index.js
+++ b/src/isSameWeek/index.js
@@ -8,6 +8,12 @@ import startOfWeek from '../startOfWeek/index.js'
  * @description
  * Are the given dates in the same week?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameYear/index.js
+++ b/src/isSameYear/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Are the given dates in the same year?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSameYear/index.js
+++ b/src/isSameYear/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Are the given dates in the same year?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSameYear/index.js
+++ b/src/isSameYear/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} dateLeft - the first date to check
  * @param {Date|String|Number} dateRight - the second date to check

--- a/src/isSaturday/index.js
+++ b/src/isSaturday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Saturday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isSaturday/index.js
+++ b/src/isSaturday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSaturday/index.js
+++ b/src/isSaturday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Saturday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isSunday/index.js
+++ b/src/isSunday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Sunday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isSunday/index.js
+++ b/src/isSunday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isSunday/index.js
+++ b/src/isSunday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Sunday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isThursday/index.js
+++ b/src/isThursday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Thursday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isThursday/index.js
+++ b/src/isThursday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isThursday/index.js
+++ b/src/isThursday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Thursday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isTuesday/index.js
+++ b/src/isTuesday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isTuesday/index.js
+++ b/src/isTuesday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Tuesday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isTuesday/index.js
+++ b/src/isTuesday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Tuesday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -15,9 +15,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {*} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -12,6 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * Time value of Date: http://es5.github.io/#x15.9.1.1
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -12,6 +12,12 @@ import toDate from '../toDate/index.js'
  *
  * Time value of Date: http://es5.github.io/#x15.9.1.1
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {*} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isWednesday/index.js
+++ b/src/isWednesday/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Wednesday?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isWednesday/index.js
+++ b/src/isWednesday/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isWednesday/index.js
+++ b/src/isWednesday/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date Wednesday?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isWeekend/index.js
+++ b/src/isWeekend/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Does the given date fall on a weekend?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isWeekend/index.js
+++ b/src/isWeekend/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isWeekend/index.js
+++ b/src/isWeekend/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Does the given date fall on a weekend?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/isWithinInterval/index.js
+++ b/src/isWithinInterval/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date within the interval?
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to check
  * @param {Interval} interval - the interval to check
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/isWithinInterval/index.js
+++ b/src/isWithinInterval/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Is the given date within the interval?
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/isWithinInterval/index.js
+++ b/src/isWithinInterval/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to check
  * @param {Interval} interval - the interval to check

--- a/src/lastDayOfDecade/index.js
+++ b/src/lastDayOfDecade/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @returns {Date} the last day of a decade

--- a/src/lastDayOfDecade/index.js
+++ b/src/lastDayOfDecade/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the last day of a decade for the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/lastDayOfDecade/index.js
+++ b/src/lastDayOfDecade/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the last day of a decade for the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @returns {Date} the last day of a decade
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfISOWeek/index.js
+++ b/src/lastDayOfISOWeek/index.js
@@ -15,9 +15,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfISOWeek/index.js
+++ b/src/lastDayOfISOWeek/index.js
@@ -12,6 +12,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/lastDayOfISOWeek/index.js
+++ b/src/lastDayOfISOWeek/index.js
@@ -12,6 +12,12 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/lastDayOfISOWeekYear/index.js
+++ b/src/lastDayOfISOWeekYear/index.js
@@ -13,6 +13,12 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/lastDayOfISOWeekYear/index.js
+++ b/src/lastDayOfISOWeekYear/index.js
@@ -16,9 +16,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfISOWeekYear/index.js
+++ b/src/lastDayOfISOWeekYear/index.js
@@ -13,6 +13,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/lastDayOfMonth/index.js
+++ b/src/lastDayOfMonth/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the last day of a month for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/lastDayOfMonth/index.js
+++ b/src/lastDayOfMonth/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfMonth/index.js
+++ b/src/lastDayOfMonth/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the last day of a month for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/lastDayOfQuarter/index.js
+++ b/src/lastDayOfQuarter/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the last day of a year quarter for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/lastDayOfQuarter/index.js
+++ b/src/lastDayOfQuarter/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the last day of a year quarter for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/lastDayOfQuarter/index.js
+++ b/src/lastDayOfQuarter/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfWeek/index.js
+++ b/src/lastDayOfWeek/index.js
@@ -10,6 +10,7 @@ import toDate from '../toDate/index.js'
  * Return the last day of a week for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/lastDayOfWeek/index.js
+++ b/src/lastDayOfWeek/index.js
@@ -13,9 +13,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfWeek/index.js
+++ b/src/lastDayOfWeek/index.js
@@ -10,6 +10,12 @@ import toDate from '../toDate/index.js'
  * Return the last day of a week for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/lastDayOfYear/index.js
+++ b/src/lastDayOfYear/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the last day of a year for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/lastDayOfYear/index.js
+++ b/src/lastDayOfYear/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/lastDayOfYear/index.js
+++ b/src/lastDayOfYear/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the last day of a year for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/max/index.js
+++ b/src/max/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the latest of the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date[]|String[]|Number[]} datesArray - the dates to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/max/index.js
+++ b/src/max/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the latest of the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/max/index.js
+++ b/src/max/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date[]|String[]|Number[]} datesArray - the dates to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/min/index.js
+++ b/src/min/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the earliest of the given dates.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/min/index.js
+++ b/src/min/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the earliest of the given dates.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date[]|String[]|Number[]} datesArray - the dates to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/min/index.js
+++ b/src/min/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date[]|String[]|Number[]} datesArray - the dates to compare
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -264,9 +264,7 @@ var notWhitespaceRegExp = /\S/
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {String} dateString - the string to parse
  * @param {String} formatString - the string of tokens

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -261,6 +261,7 @@ var notWhitespaceRegExp = /\S/
  * Invalid Date is a Date, whose time value is NaN.
  * Time value of Date: http://es5.github.io/#x15.9.1.1
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -261,6 +261,12 @@ var notWhitespaceRegExp = /\S/
  * Invalid Date is a Date, whose time value is NaN.
  * Time value of Date: http://es5.github.io/#x15.9.1.1
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {String} dateString - the string to parse
  * @param {String} formatString - the string of tokens
  * @param {Date|String|Number} baseDate - defines values missing from the parsed dateString

--- a/src/roundToNearestMinutes/index.js
+++ b/src/roundToNearestMinutes/index.js
@@ -12,9 +12,7 @@ import toInteger from '../_lib/toInteger/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to round
  * @param {Number} [nearestTo=1] - the closest minute to round to, must be between 1 and 30 inclusive

--- a/src/roundToNearestMinutes/index.js
+++ b/src/roundToNearestMinutes/index.js
@@ -9,6 +9,12 @@ import toInteger from '../_lib/toInteger/index.js'
  * @description
  * Rounds the given date to the nearest minute
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to round
  * @param {Number} [nearestTo=1] - the closest minute to round to, must be between 1 and 30 inclusive
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/roundToNearestMinutes/index.js
+++ b/src/roundToNearestMinutes/index.js
@@ -9,6 +9,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * @description
  * Rounds the given date to the nearest minute
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setDate/index.js
+++ b/src/setDate/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the day of the month to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setDate/index.js
+++ b/src/setDate/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the day of the month to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} dayOfMonth - the day of the month of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setDate/index.js
+++ b/src/setDate/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} dayOfMonth - the day of the month of the new date

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -10,6 +10,7 @@ import addDays from '../addDays/index.js'
  * @description
  * Set the day of the week to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -10,6 +10,12 @@ import addDays from '../addDays/index.js'
  * @description
  * Set the day of the week to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} day - the day of the week of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -13,9 +13,7 @@ import addDays from '../addDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} day - the day of the week of the new date

--- a/src/setDayOfYear/index.js
+++ b/src/setDayOfYear/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the day of the year to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setDayOfYear/index.js
+++ b/src/setDayOfYear/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} dayOfYear - the day of the year of the new date

--- a/src/setDayOfYear/index.js
+++ b/src/setDayOfYear/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the day of the year to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} dayOfYear - the day of the year of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setHours/index.js
+++ b/src/setHours/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the hours to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} hours - the hours of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setHours/index.js
+++ b/src/setHours/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} hours - the hours of the new date

--- a/src/setHours/index.js
+++ b/src/setHours/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the hours to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setISODay/index.js
+++ b/src/setISODay/index.js
@@ -13,6 +13,12 @@ import getISODay from '../getISODay/index.js'
  * ISO week starts with Monday.
  * 7 is the index of Sunday, 1 is the index of Monday etc.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} day - the day of the ISO week of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setISODay/index.js
+++ b/src/setISODay/index.js
@@ -13,6 +13,7 @@ import getISODay from '../getISODay/index.js'
  * ISO week starts with Monday.
  * 7 is the index of Sunday, 1 is the index of Monday etc.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setISODay/index.js
+++ b/src/setISODay/index.js
@@ -16,9 +16,7 @@ import getISODay from '../getISODay/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} day - the day of the ISO week of the new date

--- a/src/setISOWeek/index.js
+++ b/src/setISOWeek/index.js
@@ -12,6 +12,12 @@ import getISOWeek from '../getISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} isoWeek - the ISO week of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setISOWeek/index.js
+++ b/src/setISOWeek/index.js
@@ -12,6 +12,7 @@ import getISOWeek from '../getISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setISOWeek/index.js
+++ b/src/setISOWeek/index.js
@@ -15,9 +15,7 @@ import getISOWeek from '../getISOWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} isoWeek - the ISO week of the new date

--- a/src/setISOWeekYear/index.js
+++ b/src/setISOWeekYear/index.js
@@ -17,9 +17,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} isoWeekYear - the ISO week-numbering year of the new date

--- a/src/setISOWeekYear/index.js
+++ b/src/setISOWeekYear/index.js
@@ -14,6 +14,12 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} isoWeekYear - the ISO week-numbering year of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setISOWeekYear/index.js
+++ b/src/setISOWeekYear/index.js
@@ -14,6 +14,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setMilliseconds/index.js
+++ b/src/setMilliseconds/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the milliseconds to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setMilliseconds/index.js
+++ b/src/setMilliseconds/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} milliseconds - the milliseconds of the new date

--- a/src/setMilliseconds/index.js
+++ b/src/setMilliseconds/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the milliseconds to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} milliseconds - the milliseconds of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setMinutes/index.js
+++ b/src/setMinutes/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the minutes to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} minutes - the minutes of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setMinutes/index.js
+++ b/src/setMinutes/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} minutes - the minutes of the new date

--- a/src/setMinutes/index.js
+++ b/src/setMinutes/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the minutes to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setMonth/index.js
+++ b/src/setMonth/index.js
@@ -10,6 +10,7 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  * @description
  * Set the month to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setMonth/index.js
+++ b/src/setMonth/index.js
@@ -10,6 +10,12 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  * @description
  * Set the month to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} month - the month of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setMonth/index.js
+++ b/src/setMonth/index.js
@@ -13,9 +13,7 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} month - the month of the new date

--- a/src/setQuarter/index.js
+++ b/src/setQuarter/index.js
@@ -10,6 +10,12 @@ import setMonth from '../setMonth/index.js'
  * @description
  * Set the year quarter to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} quarter - the quarter of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setQuarter/index.js
+++ b/src/setQuarter/index.js
@@ -13,9 +13,7 @@ import setMonth from '../setMonth/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} quarter - the quarter of the new date

--- a/src/setQuarter/index.js
+++ b/src/setQuarter/index.js
@@ -10,6 +10,7 @@ import setMonth from '../setMonth/index.js'
  * @description
  * Set the year quarter to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setSeconds/index.js
+++ b/src/setSeconds/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} seconds - the seconds of the new date

--- a/src/setSeconds/index.js
+++ b/src/setSeconds/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the seconds to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} seconds - the seconds of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setSeconds/index.js
+++ b/src/setSeconds/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the seconds to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setWeek/index.js
+++ b/src/setWeek/index.js
@@ -16,6 +16,7 @@ import getWeek from '../getWeek/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setWeek/index.js
+++ b/src/setWeek/index.js
@@ -16,6 +16,12 @@ import getWeek from '../getWeek/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} week - the week of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setWeek/index.js
+++ b/src/setWeek/index.js
@@ -19,9 +19,7 @@ import getWeek from '../getWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} week - the week of the new date

--- a/src/setWeekYear/index.js
+++ b/src/setWeekYear/index.js
@@ -21,9 +21,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} weekYear - the local week-numbering year of the new date

--- a/src/setWeekYear/index.js
+++ b/src/setWeekYear/index.js
@@ -18,6 +18,12 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} weekYear - the local week-numbering year of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setWeekYear/index.js
+++ b/src/setWeekYear/index.js
@@ -18,6 +18,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setYear/index.js
+++ b/src/setYear/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the year to the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} year - the year of the new date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/setYear/index.js
+++ b/src/setYear/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Set the year to the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/setYear/index.js
+++ b/src/setYear/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} year - the year of the new date

--- a/src/startOfDay/index.js
+++ b/src/startOfDay/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a day for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfDay/index.js
+++ b/src/startOfDay/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfDay/index.js
+++ b/src/startOfDay/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a day for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfDecade/index.js
+++ b/src/startOfDecade/index.js
@@ -8,6 +8,7 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the start of a decade for the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfDecade/index.js
+++ b/src/startOfDecade/index.js
@@ -8,6 +8,12 @@ import toDate from '../toDate/index.js'
  * @description
  * Return the start of a decade for the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfDecade/index.js
+++ b/src/startOfDecade/index.js
@@ -11,9 +11,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfHour/index.js
+++ b/src/startOfHour/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of an hour for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfHour/index.js
+++ b/src/startOfHour/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of an hour for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfHour/index.js
+++ b/src/startOfHour/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfISOWeek/index.js
+++ b/src/startOfISOWeek/index.js
@@ -15,9 +15,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfISOWeek/index.js
+++ b/src/startOfISOWeek/index.js
@@ -12,6 +12,7 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfISOWeek/index.js
+++ b/src/startOfISOWeek/index.js
@@ -12,6 +12,12 @@ import cloneObject from '../_lib/cloneObject/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfISOWeekYear/index.js
+++ b/src/startOfISOWeekYear/index.js
@@ -13,6 +13,12 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfISOWeekYear/index.js
+++ b/src/startOfISOWeekYear/index.js
@@ -16,9 +16,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfISOWeekYear/index.js
+++ b/src/startOfISOWeekYear/index.js
@@ -13,6 +13,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfMinute/index.js
+++ b/src/startOfMinute/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a minute for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfMinute/index.js
+++ b/src/startOfMinute/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a minute for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfMinute/index.js
+++ b/src/startOfMinute/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfMonth/index.js
+++ b/src/startOfMonth/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a month for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfMonth/index.js
+++ b/src/startOfMonth/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a month for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfMonth/index.js
+++ b/src/startOfMonth/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfQuarter/index.js
+++ b/src/startOfQuarter/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a year quarter for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfQuarter/index.js
+++ b/src/startOfQuarter/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a year quarter for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfQuarter/index.js
+++ b/src/startOfQuarter/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfSecond/index.js
+++ b/src/startOfSecond/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a second for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfSecond/index.js
+++ b/src/startOfSecond/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfSecond/index.js
+++ b/src/startOfSecond/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a second for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfWeek/index.js
+++ b/src/startOfWeek/index.js
@@ -10,6 +10,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a week for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfWeek/index.js
+++ b/src/startOfWeek/index.js
@@ -10,6 +10,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a week for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfWeek/index.js
+++ b/src/startOfWeek/index.js
@@ -13,9 +13,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -19,9 +19,7 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -16,6 +16,12 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -16,6 +16,7 @@ import startOfWeek from '../startOfWeek/index.js'
  *
  * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfYear/index.js
+++ b/src/startOfYear/index.js
@@ -9,6 +9,7 @@ import toDate from '../toDate/index.js'
  * Return the start of a year for the given date.
  * The result will be in the local timezone.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/startOfYear/index.js
+++ b/src/startOfYear/index.js
@@ -9,6 +9,12 @@ import toDate from '../toDate/index.js'
  * Return the start of a year for the given date.
  * The result will be in the local timezone.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link https://date-fns.org/docs/toDate}

--- a/src/startOfYear/index.js
+++ b/src/startOfYear/index.js
@@ -12,9 +12,7 @@ import toDate from '../toDate/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the original date
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subDays/index.js
+++ b/src/subDays/index.js
@@ -9,6 +9,12 @@ import addDays from '../addDays/index.js'
  * @description
  * Subtract the specified number of days from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of days to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subDays/index.js
+++ b/src/subDays/index.js
@@ -9,6 +9,7 @@ import addDays from '../addDays/index.js'
  * @description
  * Subtract the specified number of days from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subDays/index.js
+++ b/src/subDays/index.js
@@ -12,9 +12,7 @@ import addDays from '../addDays/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of days to be subtracted

--- a/src/subHours/index.js
+++ b/src/subHours/index.js
@@ -9,6 +9,12 @@ import addHours from '../addHours/index.js'
  * @description
  * Subtract the specified number of hours from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of hours to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subHours/index.js
+++ b/src/subHours/index.js
@@ -12,9 +12,7 @@ import addHours from '../addHours/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of hours to be subtracted

--- a/src/subHours/index.js
+++ b/src/subHours/index.js
@@ -9,6 +9,7 @@ import addHours from '../addHours/index.js'
  * @description
  * Subtract the specified number of hours from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subISOWeekYears/index.js
+++ b/src/subISOWeekYears/index.js
@@ -11,6 +11,7 @@ import addISOWeekYears from '../addISOWeekYears/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subISOWeekYears/index.js
+++ b/src/subISOWeekYears/index.js
@@ -11,6 +11,12 @@ import addISOWeekYears from '../addISOWeekYears/index.js'
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of ISO week-numbering years to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subISOWeekYears/index.js
+++ b/src/subISOWeekYears/index.js
@@ -14,9 +14,7 @@ import addISOWeekYears from '../addISOWeekYears/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of ISO week-numbering years to be subtracted

--- a/src/subMilliseconds/index.js
+++ b/src/subMilliseconds/index.js
@@ -12,9 +12,7 @@ import addMilliseconds from '../addMilliseconds/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of milliseconds to be subtracted

--- a/src/subMilliseconds/index.js
+++ b/src/subMilliseconds/index.js
@@ -9,6 +9,12 @@ import addMilliseconds from '../addMilliseconds/index.js'
  * @description
  * Subtract the specified number of milliseconds from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of milliseconds to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subMilliseconds/index.js
+++ b/src/subMilliseconds/index.js
@@ -9,6 +9,7 @@ import addMilliseconds from '../addMilliseconds/index.js'
  * @description
  * Subtract the specified number of milliseconds from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subMinutes/index.js
+++ b/src/subMinutes/index.js
@@ -9,6 +9,7 @@ import addMinutes from '../addMinutes/index.js'
  * @description
  * Subtract the specified number of minutes from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subMinutes/index.js
+++ b/src/subMinutes/index.js
@@ -12,9 +12,7 @@ import addMinutes from '../addMinutes/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of minutes to be subtracted

--- a/src/subMinutes/index.js
+++ b/src/subMinutes/index.js
@@ -9,6 +9,12 @@ import addMinutes from '../addMinutes/index.js'
  * @description
  * Subtract the specified number of minutes from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of minutes to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subMonths/index.js
+++ b/src/subMonths/index.js
@@ -12,9 +12,7 @@ import addMonths from '../addMonths/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of months to be subtracted

--- a/src/subMonths/index.js
+++ b/src/subMonths/index.js
@@ -9,6 +9,7 @@ import addMonths from '../addMonths/index.js'
  * @description
  * Subtract the specified number of months from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subMonths/index.js
+++ b/src/subMonths/index.js
@@ -9,6 +9,12 @@ import addMonths from '../addMonths/index.js'
  * @description
  * Subtract the specified number of months from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of months to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subQuarters/index.js
+++ b/src/subQuarters/index.js
@@ -9,6 +9,12 @@ import addQuarters from '../addQuarters/index.js'
  * @description
  * Subtract the specified number of year quarters from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of quarters to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subQuarters/index.js
+++ b/src/subQuarters/index.js
@@ -9,6 +9,7 @@ import addQuarters from '../addQuarters/index.js'
  * @description
  * Subtract the specified number of year quarters from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subQuarters/index.js
+++ b/src/subQuarters/index.js
@@ -12,9 +12,7 @@ import addQuarters from '../addQuarters/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of quarters to be subtracted

--- a/src/subSeconds/index.js
+++ b/src/subSeconds/index.js
@@ -9,6 +9,7 @@ import addSeconds from '../addSeconds/index.js'
  * @description
  * Subtract the specified number of seconds from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subSeconds/index.js
+++ b/src/subSeconds/index.js
@@ -9,6 +9,12 @@ import addSeconds from '../addSeconds/index.js'
  * @description
  * Subtract the specified number of seconds from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of seconds to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subSeconds/index.js
+++ b/src/subSeconds/index.js
@@ -12,9 +12,7 @@ import addSeconds from '../addSeconds/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of seconds to be subtracted

--- a/src/subWeeks/index.js
+++ b/src/subWeeks/index.js
@@ -9,6 +9,12 @@ import addWeeks from '../addWeeks/index.js'
  * @description
  * Subtract the specified number of weeks from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of weeks to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subWeeks/index.js
+++ b/src/subWeeks/index.js
@@ -12,9 +12,7 @@ import addWeeks from '../addWeeks/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of weeks to be subtracted

--- a/src/subWeeks/index.js
+++ b/src/subWeeks/index.js
@@ -9,6 +9,7 @@ import addWeeks from '../addWeeks/index.js'
  * @description
  * Subtract the specified number of weeks from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subYears/index.js
+++ b/src/subYears/index.js
@@ -9,6 +9,7 @@ import addYears from '../addYears/index.js'
  * @description
  * Subtract the specified number of years from the given date.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/subYears/index.js
+++ b/src/subYears/index.js
@@ -9,6 +9,12 @@ import addYears from '../addYears/index.js'
  * @description
  * Subtract the specified number of years from the given date.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of years to be subtracted
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}

--- a/src/subYears/index.js
+++ b/src/subYears/index.js
@@ -12,9 +12,7 @@ import addYears from '../addYears/index.js'
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} date - the date to be changed
  * @param {Number} amount - the amount of years to be subtracted

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -64,6 +64,12 @@ var patterns = {
  * **Note**: *all* Date arguments passed to any *date-fns* function is processed by `toDate`.
  * All *date-fns* functions will throw `RangeError` if `options.additionalDigits` is not 0, 1, 2 or undefined.
  *
+ * ### v2.0.0 breaking changes:
+ * 
+ * - Some changes are common for whole library.
+ *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
+ *   for more details.
+ *
  * @param {Date|String|Number} argument - the value to convert
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - the additional number of digits in the extended year format

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -64,6 +64,7 @@ var patterns = {
  * **Note**: *all* Date arguments passed to any *date-fns* function is processed by `toDate`.
  * All *date-fns* functions will throw `RangeError` if `options.additionalDigits` is not 0, 1, 2 or undefined.
  *
+ *
  * ### v2.0.0 breaking changes:
  * 
  * - Some changes are common for whole library.

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -67,9 +67,7 @@ var patterns = {
  *
  * ### v2.0.0 breaking changes:
  * 
- * - Some changes are common for whole library.
- *   See [docs/v2BehaviourChanges.md](https://github.com/date-fns/date-fns/blob/master/docs/v2BehaviourChanges.md)
- *   for more details.
+ * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|String|Number} argument - the value to convert
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}


### PR DESCRIPTION
This PR is going to be divided to 5 parts for no particular reason.

Issue #957: Add a "breaking changes" section to doc of every function. For website visitors, so they see what changed in that exact function right when they visit the page of that function.

This PR adds a common doc "behaviour changes" which lists the changes common for all functions.
In docs of every function, added little link to that "behaviour changes" doc.