### PR TITLE
Update Indonesian locale for v2

### DIFF
--- a/src/locale/id/_lib/formatLong/index.js
+++ b/src/locale/id/_lib/formatLong/index.js
@@ -1,10 +1,10 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
 var dateFormats = {
-  full: 'EEEE, d MMMM YYYY',
-  long: 'd MMMM YYYY',
-  medium: 'd MMMM YYYY',
-  short: 'd/M/YYYY'
+  full: 'EEEE, d MMMM yyyy',
+  long: 'd MMMM yyyy',
+  medium: 'd MMM yyyy',
+  short: 'd/M/yyyy'
 }
 
 var timeFormats = {

--- a/src/locale/id/_lib/formatLong/index.js
+++ b/src/locale/id/_lib/formatLong/index.js
@@ -1,12 +1,41 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
-var formatLong = buildFormatLongFn({
-  LT: 'HH.mm',
-  LTS: 'HH.mm.ss',
-  L: 'DD/MM/YYYY',
-  LL: 'D MMMM YYYY',
-  LLL: 'D MMMM YYYY [pukul] HH.mm',
-  LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
-})
+var dateFormats = {
+  full: 'EEEE, d MMMM YYYY',
+  long: 'd MMMM YYYY',
+  medium: 'd MMMM YYYY',
+  short: 'd/M/YYYY'
+}
+
+var timeFormats = {
+  full: 'HH.mm.ss',
+  long: 'HH.mm.ss',
+  medium: 'HH.mm',
+  short: 'HH.mm'
+}
+
+var dateTimeFormats = {
+  full: "{{date}} 'pukul' {{time}}",
+  long: "{{date}} 'pukul' {{time}}",
+  medium: '{{date}}, {{time}}',
+  short: '{{date}}, {{time}}'
+}
+
+var formatLong = {
+  date: buildFormatLongFn({
+    formats: dateFormats,
+    defaultWidth: 'full'
+  }),
+
+  time: buildFormatLongFn({
+    formats: timeFormats,
+    defaultWidth: 'full'
+  }),
+
+  dateTime: buildFormatLongFn({
+    formats: dateTimeFormats,
+    defaultWidth: 'full'
+  })
+}
 
 export default formatLong

--- a/src/locale/id/_lib/formatRelative/index.js
+++ b/src/locale/id/_lib/formatRelative/index.js
@@ -1,12 +1,12 @@
 var formatRelativeLocale = {
-  lastWeek: 'dddd [lalu pukul] LT',
-  yesterday: '[Kemarin pukul] LT',
-  today: '[Hari ini pukul] LT',
-  tomorrow: '[Besok pukul] LT',
-  nextWeek: 'dddd [pukul] LT',
-  other: 'L'
+  lastWeek: "eeee 'lalu pukul' p",
+  yesterday: "'Kemarin pukul' p",
+  today: "'Hari ini pukul' p",
+  tomorrow: "'Besok pukul' p",
+  nextWeek: "eeee 'pukul' p",
+  other: 'P'
 }
 
-export default function formatRelative (token, date, baseDate, options) {
+export default function formatRelative(token, date, baseDate, options) {
   return formatRelativeLocale[token]
 }

--- a/src/locale/id/_lib/localize/index.js
+++ b/src/locale/id/_lib/localize/index.js
@@ -52,7 +52,7 @@ var monthValues = {
 
 var dayValues = {
   narrow: ['M', 'S', 'S', 'R', 'K', 'J', 'S'],
-  short: ['Mg', 'Sn', 'Sl', 'Rb', 'Km', 'Jm', 'Sb'],
+  short: ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'],
   abbreviated: ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'],
   wide: ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu']
 }

--- a/src/locale/id/_lib/localize/index.js
+++ b/src/locale/id/_lib/localize/index.js
@@ -1,28 +1,128 @@
 import buildLocalizeFn from '../../../_lib/buildLocalizeFn/index.js'
-import buildLocalizeArrayFn from '../../../_lib/buildLocalizeArrayFn/index.js'
+
+// All data for localization are taken from this page
+// https://www.unicode.org/cldr/charts/32/summary/id.html
+var eraValues = {
+  narrow: ['SM', 'M'],
+  abbreviated: ['SM', 'M'],
+  wide: ['Sebelum Masehi', 'Masehi']
+}
+
+var quarterValues = {
+  narrow: ['1', '2', '3', '4'],
+  abbreviated: ['K1', 'K2', 'K3', 'K4'],
+  wide: ['Kuartal ke-1', 'Kuartal ke-2', 'Kuartal ke-3', 'Kuartal ke-4']
+}
 
 // Note: in Indonesian, the names of days of the week and months are capitalized.
 // If you are making a new locale based on this one, check if the same is true for the language you're working on.
 // Generally, formatted dates should look like they are in the middle of a sentence,
 // e.g. in Spanish language the weekdays and months should be in the lowercase.
-var weekdayValues = {
-  narrow: ['Mg', 'Sn', 'Sl', 'Rb', 'Km', 'Jm', 'Sb'],
-  short: ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'],
-  long: ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu']
-}
-
 var monthValues = {
-  short: ['Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun', 'Jul', 'Ags', 'Sep', 'Okt', 'Nov', 'Des'],
-  long: ['Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni', 'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember']
+  narrow: ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'],
+  abbreviated: [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'Mei',
+    'Jun',
+    'Jul',
+    'Ags',
+    'Sep',
+    'Okt',
+    'Nov',
+    'Des'
+  ],
+  wide: [
+    'Januari',
+    'Februari',
+    'Maret',
+    'April',
+    'Mei',
+    'Juni',
+    'Juli',
+    'Agustus',
+    'September',
+    'Oktober',
+    'November',
+    'Desember'
+  ]
 }
 
-var timeOfDayValues = {
-  uppercase: ['AM', 'PM'],
-  lowercase: ['am', 'pm'],
-  long: ['a.m.', 'p.m.']
+var dayValues = {
+  narrow: ['M', 'S', 'S', 'R', 'K', 'J', 'S'],
+  short: ['Mg', 'Sn', 'Sl', 'Rb', 'Km', 'Jm', 'Sb'],
+  abbreviated: ['Min', 'Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab'],
+  wide: ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu']
 }
 
-function ordinalNumber (dirtyNumber) {
+var dayPeriodValues = {
+  narrow: {
+    am: 'AM',
+    pm: 'PM',
+    midnight: 'tengah malam',
+    noon: 'tengah hari',
+    morning: 'pagi',
+    afternoon: 'siang',
+    evening: 'sore',
+    night: 'malam'
+  },
+  abbreviated: {
+    am: 'AM',
+    pm: 'PM',
+    midnight: 'tengah malam',
+    noon: 'tengah hari',
+    morning: 'pagi',
+    afternoon: 'siang',
+    evening: 'sore',
+    night: 'malam'
+  },
+  wide: {
+    am: 'AM',
+    pm: 'PM',
+    midnight: 'tengah malam',
+    noon: 'tengah hari',
+    morning: 'pagi',
+    afternoon: 'siang',
+    evening: 'sore',
+    night: 'malam'
+  }
+}
+var formattingDayPeriodValues = {
+  narrow: {
+    am: 'AM',
+    pm: 'PM',
+    midnight: 'tengah malam',
+    noon: 'tengah hari',
+    morning: 'pagi',
+    afternoon: 'siang',
+    evening: 'sore',
+    night: 'malam'
+  },
+  abbreviated: {
+    am: 'AM',
+    pm: 'PM',
+    midnight: 'tengah malam',
+    noon: 'tengah hari',
+    morning: 'pagi',
+    afternoon: 'siang',
+    evening: 'sore',
+    night: 'malam'
+  },
+  wide: {
+    am: 'AM',
+    pm: 'PM',
+    midnight: 'tengah malam',
+    noon: 'tengah hari',
+    morning: 'pagi',
+    afternoon: 'siang',
+    evening: 'sore',
+    night: 'malam'
+  }
+}
+
+function ordinalNumber(dirtyNumber, dirtyOptions) {
   var number = Number(dirtyNumber)
 
   // Can't use "pertama", "kedua" because can't be parsed
@@ -34,14 +134,36 @@ function ordinalNumber (dirtyNumber) {
 
 var localize = {
   ordinalNumber: ordinalNumber,
-  weekday: buildLocalizeFn(weekdayValues, 'long'),
-  weekdays: buildLocalizeArrayFn(weekdayValues, 'long'),
-  month: buildLocalizeFn(monthValues, 'long'),
-  months: buildLocalizeArrayFn(monthValues, 'long'),
-  timeOfDay: buildLocalizeFn(timeOfDayValues, 'long', function (hours) {
-    return (hours / 12) >= 1 ? 1 : 0
+
+  era: buildLocalizeFn({
+    values: eraValues,
+    defaultWidth: 'wide'
   }),
-  timesOfDay: buildLocalizeArrayFn(timeOfDayValues, 'long')
+
+  quarter: buildLocalizeFn({
+    values: quarterValues,
+    defaultWidth: 'wide',
+    argumentCallback: function(quarter) {
+      return Number(quarter) - 1
+    }
+  }),
+
+  month: buildLocalizeFn({
+    values: monthValues,
+    defaultWidth: 'wide'
+  }),
+
+  day: buildLocalizeFn({
+    values: dayValues,
+    defaultWidth: 'wide'
+  }),
+
+  dayPeriod: buildLocalizeFn({
+    values: dayPeriodValues,
+    defaultWidth: 'wide',
+    formattingValues: formattingDayPeriodValues,
+    defaulFormattingWidth: 'wide'
+  })
 }
 
 export default localize

--- a/src/locale/id/_lib/match/index.js
+++ b/src/locale/id/_lib/match/index.js
@@ -1,7 +1,7 @@
 import buildMatchPatternFn from '../../../_lib/buildMatchPatternFn/index.js'
 import buildMatchFn from '../../../_lib/buildMatchFn/index.js'
 
-var matchOrdinalNumbersPattern = /^ke-(\d+)?/i
+var matchOrdinalNumberPattern = /^ke-(\d+)?/i
 var parseOrdinalNumberPattern = /\d+/i
 
 var matchEraPatterns = {

--- a/src/locale/id/_lib/match/index.js
+++ b/src/locale/id/_lib/match/index.js
@@ -1,47 +1,137 @@
-import buildMatchFn from '../../../_lib/buildMatchFn/index.js'
-import buildParseFn from '../../../_lib/buildParseFn/index.js'
 import buildMatchPatternFn from '../../../_lib/buildMatchPatternFn/index.js'
-import parseDecimal from '../../../_lib/parseDecimal/index.js'
+import buildMatchFn from '../../../_lib/buildMatchFn/index.js'
 
 var matchOrdinalNumbersPattern = /^ke-(\d+)?/i
+var parseOrdinalNumberPattern = /\d+/i
 
-var matchWeekdaysPatterns = {
-  narrow: /^(mg|sn|sl|rb|km|jm|sb)/i,
-  short: /^(min|sen|sel|rab|kam|jum|sab)/i,
-  long: /^(minggu|senin|selasa|rabu|kamis|jumat|sabtu)/i
+var matchEraPatterns = {
+  narrow: /^(sm|m)/i,
+  abbreviated: /^(s\.?\s?m\.?|s\.?\s?e\.?\s?u\.?|m\.?|e\.?\s?u\.?)/i,
+  wide: /^(sebelum masehi|sebelum era umum|masehi|era umum)/i
+}
+var parseEraPatterns = {
+  any: [/^s/i, /^(m|e)/i]
 }
 
-var parseWeekdayPatterns = {
-  any: [/^m/i, /^sn/i, /^sl/i, /^r/i, /^k/i, /^j/i, /^sa/i]
+var matchQuarterPatterns = {
+  narrow: /^[1234]/i,
+  abbreviated: /^K\-?\s[1234]/i,
+  wide: /^Kuartal ke\-?\s?[1234]/i
+}
+var parseQuarterPatterns = {
+  any: [/1/i, /2/i, /3/i, /4/i]
 }
 
-var matchMonthsPatterns = {
-  short: /^(jan|feb|mar|apr|mei|jun|jul|ags|sep|okt|nov|dec)/i,
-  long: /^(januari|februari|maret|april|mei|juni|juli|agustus|september|oktober|november|desember)/i
+var matchMonthPatterns = {
+  narrow: /^[jfmasond]/i,
+  abbreviated: /^(jan|feb|mar|apr|mei|jun|jul|agt|sep|okt|nov|des)/i,
+  wide: /^(januari|februari|maret|april|mei|juni|juli|agustus|september|oktober|november|desember)/i
 }
-
 var parseMonthPatterns = {
-  any: [/^ja/i, /^f/i, /^mar/i, /^ap/i, /^mei/i, /^jun/i, /^jul/i, /^ag/i, /^s/i, /^o/i, /^n/i, /^d/i]
+  narrow: [
+    /^j/i,
+    /^f/i,
+    /^m/i,
+    /^a/i,
+    /^m/i,
+    /^j/i,
+    /^j/i,
+    /^a/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i
+  ],
+  any: [
+    /^ja/i,
+    /^f/i,
+    /^ma/i,
+    /^ap/i,
+    /^me/i,
+    /^jun/i,
+    /^jul/i,
+    /^ag/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i
+  ]
 }
 
-var matchTimesOfDayPatterns = {
-  short: /^(am|pm)/i,
-  long: /^([ap]\.?\s?m\.?)/i
+var matchDayPatterns = {
+  narrow: /^[srkjm]/i,
+  short: /^(min|sen|sel|rab|kam|jum|sab)/i,
+  abbreviated: /^(min|sen|sel|rab|kam|jum|sab)/i,
+  wide: /^(minggu|senin|selasa|rabu|kamis|jumat|sabtu)/i
+}
+var parseDayPatterns = {
+  narrow: [/^m/i, /^s/i, /^s/i, /^r/i, /^k/i, /^j/i, /^s/i],
+  any: [/^m/i, /^sen/i, /^sel/i, /^r/i, /^k/i, /^j/i, /^sa/i]
 }
 
-var parseTimeOfDayPatterns = {
-  any: [/^a/i, /^p/i]
+var matchDayPeriodPatterns = {
+  narrow: /^(a|p|tengah m|tengah h|(di(\swaktu)?) (pagi|siang|sore|malam))/i,
+  any: /^([ap]\.?\s?m\.?|tengah malam|tengah hari|(di(\swaktu)?) (pagi|siang|sore|malam))/i
+}
+var parseDayPeriodPatterns = {
+  any: {
+    am: /^a/i,
+    pm: /^pm/i,
+    midnight: /^tengah m/i,
+    noon: /^tengah h/i,
+    morning: /pagi/i,
+    afternoon: /siang/i,
+    evening: /sore/i,
+    night: /malam/i
+  }
 }
 
 var match = {
-  ordinalNumbers: buildMatchPatternFn(matchOrdinalNumbersPattern),
-  ordinalNumber: parseDecimal,
-  weekdays: buildMatchFn(matchWeekdaysPatterns, 'long'),
-  weekday: buildParseFn(parseWeekdayPatterns, 'any'),
-  months: buildMatchFn(matchMonthsPatterns, 'long'),
-  month: buildParseFn(parseMonthPatterns, 'any'),
-  timesOfDay: buildMatchFn(matchTimesOfDayPatterns, 'long'),
-  timeOfDay: buildParseFn(parseTimeOfDayPatterns, 'any')
+  ordinalNumber: buildMatchPatternFn({
+    matchPattern: matchOrdinalNumberPattern,
+    parsePattern: parseOrdinalNumberPattern,
+    valueCallback: function(value) {
+      return parseInt(value, 10)
+    }
+  }),
+
+  era: buildMatchFn({
+    matchPatterns: matchEraPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseEraPatterns,
+    defaultParseWidth: 'any'
+  }),
+
+  quarter: buildMatchFn({
+    matchPatterns: matchQuarterPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseQuarterPatterns,
+    defaultParseWidth: 'any',
+    valueCallback: function(index) {
+      return index + 1
+    }
+  }),
+
+  month: buildMatchFn({
+    matchPatterns: matchMonthPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseMonthPatterns,
+    defaultParseWidth: 'any'
+  }),
+
+  day: buildMatchFn({
+    matchPatterns: matchDayPatterns,
+    defaultMatchWidth: 'wide',
+    parsePatterns: parseDayPatterns,
+    defaultParseWidth: 'any'
+  }),
+
+  dayPeriod: buildMatchFn({
+    matchPatterns: matchDayPeriodPatterns,
+    defaultMatchWidth: 'any',
+    parsePatterns: parseDayPeriodPatterns,
+    defaultParseWidth: 'any'
+  })
 }
 
 export default match

--- a/src/locale/id/index.js
+++ b/src/locale/id/index.js
@@ -1,8 +1,8 @@
-// import formatDistance from './_lib/formatDistance/index.js'
-// import formatLong from './_lib/formatLong/index.js'
-// import formatRelative from './_lib/formatRelative/index.js'
-// import localize from './_lib/localize/index.js'
-// import match from './_lib/match/index.js'
+import formatDistance from './_lib/formatDistance/index.js'
+import formatLong from './_lib/formatLong/index.js'
+import formatRelative from './_lib/formatRelative/index.js'
+import localize from './_lib/localize/index.js'
+import match from './_lib/match/index.js'
 
 /**
  * @type {Locale}
@@ -13,19 +13,18 @@
  * @author Rahmat Budiharso [@rbudiharso]{@link https://github.com/rbudiharso}
  * @author Benget Nata [@bentinata]{@link https://github.com/bentinata}
  * @author Budi Irawan [@deerawan]{@link https://github.com/deerawan}
+ * @author Try Ajitiono [@imballinst]{@link https://github.com/imballinst}
  */
-// var locale = {
-//   formatDistance: formatDistance,
-//   formatLong: formatLong,
-//   formatRelative: formatRelative,
-//   localize: localize,
-//   match: match,
-//   options: {
-//     weekStartsOn: 1 /* Monday */,
-//     firstWeekContainsDate: 1
-//   }
-// }
+var locale = {
+  formatDistance: formatDistance,
+  formatLong: formatLong,
+  formatRelative: formatRelative,
+  localize: localize,
+  match: match,
+  options: {
+    weekStartsOn: 1 /* Monday */,
+    firstWeekContainsDate: 1
+  }
+}
 
-// export default locale
-
-throw new Error('id locale is currently unavailable. Please check the progress of converting this locale to v2.0.0 in this issue on Github: TBA')
+export default locale

--- a/src/locale/id/test.js
+++ b/src/locale/id/test.js
@@ -1,9 +1,198 @@
 // @flow
 /* eslint-env mocha */
 
-// import assert from 'power-assert'
-// import locale from '.'
+import assert from 'power-assert'
+import locale from '.'
 
-describe.skip('id locale', function () {
+import format from '../../format'
+import formatDistance from '../../formatDistance'
+import formatDistanceStrict from '../../formatDistanceStrict'
+import formatRelative from '../../formatRelative'
+import parse from '../../parse'
 
+describe('id locale', function() {
+  context('with `format`', function() {
+    var date = new Date(1986, 3 /* Apr */, 5, 10, 32, 0, 900)
+
+    it('era', function() {
+      var result = format(date, 'G, GGGG, GGGGG', { locale: locale })
+      assert(result === 'M, Masehi, M')
+    })
+
+    describe('year', function() {
+      it('ordinal regular year', function() {
+        var result = format(date, "'Tahun' yo", { locale: locale })
+        assert(result === 'Tahun ke-1986')
+      })
+
+      it('ordinal local week-numbering year', function() {
+        var result = format(date, "'Tahun relatif 1986 dalam abad: tahun' Yo", {
+          locale: locale
+        })
+        assert(result === 'Tahun relatif 1986 dalam abad: tahun ke-1986')
+      })
+    })
+
+    describe('quarter', function() {
+      it('formatting quarter', function() {
+        var result = format(date, "'Kuartal' Qo, QQQ, QQQQ, QQQQQ", {
+          locale: locale
+        })
+        assert(result === 'Kuartal ke-2, K2, Kuartal ke-2, 2')
+      })
+
+      it('stand-alone quarter', function() {
+        var result = format(date, "'Kuartal' qo, qqq, qqqq, qqqqq", {
+          locale: locale
+        })
+        assert(result === 'Kuartal ke-2, K2, Kuartal ke-2, 2')
+      })
+    })
+
+    describe('month', function() {
+      it('formatting month', function() {
+        var result = format(date, "MMMM 'hari' do", { locale: locale })
+        assert(result === 'April hari ke-5')
+      })
+
+      it('stand-alone month', function() {
+        var result = format(date, "'Bulan' Lo, LLL, LLLL, LLLLL", {
+          locale: locale
+        })
+        assert(result === 'Bulan ke-4, Apr, April, A')
+      })
+    })
+
+    describe('week', function() {
+      it('ordinal local week of year', function() {
+        var date = new Date(1986, 3 /* Apr */, 6)
+        var result = format(date, "'Minggu' wo", { locale: locale })
+        assert(result === 'Minggu ke-14')
+      })
+
+      it('ordinal ISO week of year', function() {
+        var date = new Date(1986, 3 /* Apr */, 6)
+        var result = format(date, "'Minggu ISO' Io", { locale: locale })
+        assert(result === 'Minggu ISO ke-14')
+      })
+    })
+
+    describe('day', function() {
+      it('ordinal date', function() {
+        var result = format(date, "'Hari ini hari' do", { locale: locale })
+        assert(result === 'Hari ini hari ke-5')
+      })
+
+      it('ordinal day of year', function() {
+        var result = format(date, "'Hari ini hari' Do 'di tahun ini'", {
+          locale: locale
+        })
+        assert(result === 'Hari ini hari ke-95 di tahun ini')
+      })
+    })
+
+    describe('week day', function() {
+      it('day of week', function() {
+        var result = format(date, 'E, EEEE, EEEEE, EEEEEE', { locale: locale })
+        assert(result === 'Sab, Sabtu, S, Sab')
+      })
+
+      it('ordinal day of week', function() {
+        var result = format(date, "'Hari' eo 'di minggu ini'", {
+          locale: locale
+        })
+        assert(result === 'Hari ke-6 di minggu ini')
+      })
+    })
+
+    describe('day period and hour', function() {
+      it('ordinal hour', function() {
+        var result = format(date, "'Jam' ho", { locale: locale })
+        assert(result === 'Jam ke-10')
+      })
+
+      it('AM, PM', function() {
+        var result = format(date, 'h a, h aaaa, haaaaa', { locale: locale })
+        assert(result === '10 AM, 10 AM, 10AM')
+      })
+
+      it('AM, PM, noon, midnight', function() {
+        var result = format(
+          new Date(1986, 3 /* Apr */, 6, 0),
+          'b, bbbb, bbbbb',
+          { locale: locale }
+        )
+        assert(result === 'tengah malam, tengah malam, tengah malam')
+      })
+
+      it('flexible day periods', function() {
+        it('works as expected', function() {
+          var result = format(date, "'Jam' h B", { locale: locale })
+          assert(result === 'Jam 10 di waktu pagi')
+        })
+      })
+    })
+
+    it('ordinal minute', function() {
+      var result = format(date, "'Menit' mo", { locale: locale })
+      assert(result === 'Menit ke-32')
+    })
+
+    it('ordinal second', function() {
+      var result = format(date, "'Detik' so", { locale: locale })
+      assert(result === 'Detik ke-0')
+    })
+
+    describe('long format', function() {
+      it('short date', function() {
+        var result = format(date, 'P', { locale: locale })
+        assert(result === '5/4/1986')
+      })
+
+      it('medium date', function() {
+        var result = format(date, 'PP', { locale: locale })
+        assert(result === '5 Apr 1986')
+      })
+
+      it('long date', function() {
+        var result = format(date, 'PPP', { locale: locale })
+        assert(result === '5 April 1986')
+      })
+
+      it('full date', function() {
+        var result = format(date, 'PPPP', { locale: locale })
+        assert(result === 'Sabtu, 5 April 1986')
+      })
+
+      it('short time', function() {
+        var result = format(date, 'p', { locale: locale })
+        assert(result === '10.32')
+      })
+
+      it('medium time', function() {
+        var result = format(date, 'pp', { locale: locale })
+        assert(result === '10.32')
+      })
+
+      it('short date + time', function() {
+        var result = format(date, 'Pp', { locale: locale })
+        assert(result === '5/4/1986, 10.32')
+      })
+
+      it('medium date + time', function() {
+        var result = format(date, 'PPpp', { locale: locale })
+        assert(result === '5 Apr 1986, 10.32')
+      })
+
+      it('long date + time', function() {
+        var result = format(date, 'PPPp', { locale: locale })
+        assert(result === '5 April 1986 pukul 10.32')
+      })
+
+      it('full date + time', function() {
+        var result = format(date, 'PPPPp', { locale: locale })
+        assert(result === 'Sabtu, 5 April 1986 pukul 10.32')
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/date-fns/date-fns/issues/914

In this PR, I have updated the Indonesian locale in `^v2.0.0-alpha.20` to correctly use Gregorian CLDR standard, as well as following the existing patterns (I used `locale/en-US` as the baseline, both for the functions and the tests). I modified the tests so it will match the Indonesian locale implementation.

To ensure I'm doing the right thing, I did these 2 below:

1. Executed `yarn test` in my local, all tests passed.
2. Packaged my forked repo to one of my projects that use `date-fns` with Indonesian locale. The `format` function which throws an error before, now it is working as intended.