### PR TITLE
Revisit Swedish locale

### DIFF
--- a/src/locale/sv/_lib/formatRelative/index.js
+++ b/src/locale/sv/_lib/formatRelative/index.js
@@ -1,9 +1,9 @@
 var formatRelativeLocale = {
-  lastWeek: "'förra' EEEE'en kl.' p",
+  lastWeek: "'i' EEEE's kl.' p",
   yesterday: "'igår kl.' p",
   today: "'idag kl.' p",
   tomorrow: "'imorgon kl.' p",
-  nextWeek: "EEEE 'kl.' p",
+  nextWeek: "'på' EEEE 'kl.' p",
   other: 'P'
 }
 

--- a/src/locale/sv/test.js
+++ b/src/locale/sv/test.js
@@ -247,7 +247,7 @@ describe('sv locale', function () {
 
     it('last week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 1), baseDate, {locale: locale})
-      assert(result === 'förra tisdagen kl. 00:00')
+      assert(result === 'i tisdags kl. 00:00')
     })
 
     it('yesterday', function () {
@@ -267,7 +267,7 @@ describe('sv locale', function () {
 
     it('next week', function () {
       var result = formatRelative(new Date(1986, 3 /* Apr */, 6, 12, 0), baseDate, {locale: locale})
-      assert(result === 'söndag kl. 12:00')
+      assert(result === 'på söndag kl. 12:00')
     })
 
     it('after the next week', function () {


### PR DESCRIPTION
Updates Swedish locale to better reflect how relative weekdays are spoken in Swedish. [source](https://www.kotus.fi/sv/publikationer/sprakspalter/reuters_rutor_1986_2013/2010/pa_mandag)