### PR TITLE
Refactor Belarusian locale: add declensions and genitive cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This change log follows the format documented in [Keep a CHANGELOG].
 
 ## [Unreleased]
 
+- Refactor Belarusian locale: add declensions and genitive cases.
+
 ## [1.30.1] - 2018-12-10
 
 ### Fixed

--- a/src/locale/be/build_distance_in_words_locale/index.js
+++ b/src/locale/be/build_distance_in_words_locale/index.js
@@ -1,94 +1,239 @@
+function declension (scheme, count) {
+  // scheme for count=1 exists
+  if (scheme.one !== undefined && count === 1) {
+    return scheme.one
+  }
+
+  var rem10 = count % 10
+  var rem100 = count % 100
+
+  // 1, 21, 31, ...
+  if (rem10 === 1 && rem100 !== 11) {
+    return scheme.singularNominative.replace('{{count}}', count)
+
+  // 2, 3, 4, 22, 23, 24, 32 ...
+  } else if ((rem10 >= 2 && rem10 <= 4) && (rem100 < 10 || rem100 > 20)) {
+    return scheme.singularGenitive.replace('{{count}}', count)
+
+  // 5, 6, 7, 8, 9, 10, 11, ...
+  } else {
+    return scheme.pluralGenitive.replace('{{count}}', count)
+  }
+}
+
+function buildLocalizeTokenFn (scheme) {
+  return function (count, options) {
+    if (options.addSuffix) {
+      if (options.comparison > 0) {
+        if (scheme.future) {
+          return declension(scheme.future, count)
+        } else {
+          return 'праз ' + declension(scheme.regular, count)
+        }
+      } else {
+        if (scheme.past) {
+          return declension(scheme.past, count)
+        } else {
+          return declension(scheme.regular, count) + ' таму'
+        }
+      }
+    } else {
+      return declension(scheme.regular, count)
+    }
+  }
+}
+
 function buildDistanceInWordsLocale () {
   var distanceInWordsLocale = {
-    lessThanXSeconds: {
-      one: 'менш секунды',
-      other: 'менш {{count}} секунд'
+    lessThanXSeconds: buildLocalizeTokenFn({
+      regular: {
+        one: 'менш за секунду',
+        singularNominative: 'менш за {{count}} секунду',
+        singularGenitive: 'менш за {{count}} секунды',
+        pluralGenitive: 'менш за {{count}} секунд'
+      },
+      future: {
+        one: 'менш, чым праз секунду',
+        singularNominative: 'менш, чым праз {{count}} секунду',
+        singularGenitive: 'менш, чым праз {{count}} секунды',
+        pluralGenitive: 'менш, чым праз {{count}} секунд'
+      }
+    }),
+
+    xSeconds: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: '{{count}} секунда',
+        singularGenitive: '{{count}} секунды',
+        pluralGenitive: '{{count}} секунд'
+      },
+      past: {
+        singularNominative: '{{count}} секунду таму',
+        singularGenitive: '{{count}} секунды таму',
+        pluralGenitive: '{{count}} секунд таму'
+      },
+      future: {
+        singularNominative: 'праз {{count}} секунду',
+        singularGenitive: 'праз {{count}} секунды',
+        pluralGenitive: 'праз {{count}} секунд'
+      }
+    }),
+
+    halfAMinute: function (_, options) {
+      if (options.addSuffix) {
+        if (options.comparison > 0) {
+          return 'праз паўхвіліны'
+        } else {
+          return 'паўхвіліны таму'
+        }
+      }
+
+      return 'паўхвіліны'
     },
 
-    xSeconds: {
-      one: '1 секунда',
-      other: '{{count}} секунд(-ы)'
-    },
+    lessThanXMinutes: buildLocalizeTokenFn({
+      regular: {
+        one: 'менш за хвіліну',
+        singularNominative: 'менш за {{count}} хвіліну',
+        singularGenitive: 'менш за {{count}} хвіліны',
+        pluralGenitive: 'менш за {{count}} хвілін'
+      },
+      future: {
+        one: 'менш, чым праз хвіліну',
+        singularNominative: 'менш, чым праз {{count}} хвіліну',
+        singularGenitive: 'менш, чым праз {{count}} хвіліны',
+        pluralGenitive: 'менш, чым праз {{count}} хвілін'
+      }
+    }),
 
-    halfAMinute: 'паўхвіліны',
+    xMinutes: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: '{{count}} хвіліна',
+        singularGenitive: '{{count}} хвіліны',
+        pluralGenitive: '{{count}} хвілін'
+      },
+      past: {
+        singularNominative: '{{count}} хвіліну таму',
+        singularGenitive: '{{count}} хвіліны таму',
+        pluralGenitive: '{{count}} хвілін таму'
+      },
+      future: {
+        singularNominative: 'праз {{count}} хвіліну',
+        singularGenitive: 'праз {{count}} хвіліны',
+        pluralGenitive: 'праз {{count}} хвілін'
+      }
+    }),
 
-    lessThanXMinutes: {
-      one: 'менш хвіліны',
-      other: 'менш {{count}} хвілін'
-    },
+    aboutXHours: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: 'каля {{count}} гадзіны',
+        singularGenitive: 'каля {{count}} гадзін',
+        pluralGenitive: 'каля {{count}} гадзін'
+      },
+      future: {
+        singularNominative: 'прыблізна праз {{count}} гадзіну',
+        singularGenitive: 'прыблізна праз {{count}} гадзіны',
+        pluralGenitive: 'прыблізна праз {{count}} гадзін'
+      }
+    }),
 
-    xMinutes: {
-      one: '1 хвіліна',
-      other: '{{count}} хвілін(-ы)'
-    },
+    xHours: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: '{{count}} гадзіна',
+        singularGenitive: '{{count}} гадзіны',
+        pluralGenitive: '{{count}} гадзін'
+      },
+      past: {
+        singularNominative: '{{count}} гадзіну таму',
+        singularGenitive: '{{count}} гадзіны таму',
+        pluralGenitive: '{{count}} гадзін таму'
+      },
+      future: {
+        singularNominative: 'праз {{count}} гадзіну',
+        singularGenitive: 'праз {{count}} гадзіны',
+        pluralGenitive: 'праз {{count}} гадзін'
+      }
+    }),
 
-    aboutXHours: {
-      one: 'каля 1 гадзіны',
-      other: 'каля {{count}} гадзін'
-    },
+    xDays: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: '{{count}} дзень',
+        singularGenitive: '{{count}} дні',
+        pluralGenitive: '{{count}} дзён'
+      }
+    }),
 
-    xHours: {
-      one: '1 гадзіна',
-      other: '{{count}} гадзін(-ы)'
-    },
+    aboutXMonths: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: 'каля {{count}} месяца',
+        singularGenitive: 'каля {{count}} месяцаў',
+        pluralGenitive: 'каля {{count}} месяцаў'
+      },
+      future: {
+        singularNominative: 'прыблізна праз {{count}} месяц',
+        singularGenitive: 'прыблізна праз {{count}} месяцы',
+        pluralGenitive: 'прыблізна праз {{count}} месяцаў'
+      }
+    }),
 
-    xDays: {
-      one: '1 дзень',
-      other: '{{count}} дні (дзён)'
-    },
+    xMonths: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: '{{count}} месяц',
+        singularGenitive: '{{count}} месяцы',
+        pluralGenitive: '{{count}} месяцаў'
+      }
+    }),
 
-    aboutXMonths: {
-      one: 'каля 1 месяца',
-      other: 'каля {{count}} месяцаў'
-    },
+    aboutXYears: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: 'каля {{count}} года',
+        singularGenitive: 'каля {{count}} гадоў',
+        pluralGenitive: 'каля {{count}} гадоў'
+      },
+      future: {
+        singularNominative: 'прыблізна праз {{count}} год',
+        singularGenitive: 'прыблізна праз {{count}} гады',
+        pluralGenitive: 'прыблізна праз {{count}} гадоў'
+      }
+    }),
 
-    xMonths: {
-      one: '1 месяц',
-      other: '{{count}} месяцы(-аў)'
-    },
+    xYears: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: '{{count}} год',
+        singularGenitive: '{{count}} гады',
+        pluralGenitive: '{{count}} гадоў'
+      }
+    }),
 
-    aboutXYears: {
-      one: 'каля 1 года',
-      other: 'каля {{count}} гадоў'
-    },
+    overXYears: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: 'больш за {{count}} год',
+        singularGenitive: 'больш за {{count}} гады',
+        pluralGenitive: 'больш за {{count}} гадоў'
+      },
+      future: {
+        singularNominative: 'больш, чым праз {{count}} год',
+        singularGenitive: 'больш, чым праз {{count}} гады',
+        pluralGenitive: 'больш, чым праз {{count}} гадоў'
+      }
+    }),
 
-    xYears: {
-      one: '1 год',
-      other: '{{count}} гады(гадоў)'
-    },
-
-    overXYears: {
-      one: 'больш 1 года',
-      other: 'больш {{count}} гадоў'
-    },
-
-    almostXYears: {
-      one: 'амаль 1 год',
-      other: 'амаль {{count}} гады(-оў)'
-    }
+    almostXYears: buildLocalizeTokenFn({
+      regular: {
+        singularNominative: 'амаль {{count}} год',
+        singularGenitive: 'амаль {{count}} гады',
+        pluralGenitive: 'амаль {{count}} гадоў'
+      },
+      future: {
+        singularNominative: 'амаль праз {{count}} год',
+        singularGenitive: 'амаль праз {{count}} гады',
+        pluralGenitive: 'амаль праз {{count}} гадоў'
+      }
+    })
   }
 
   function localize (token, count, options) {
     options = options || {}
-
-    var result
-    if (typeof distanceInWordsLocale[token] === 'string') {
-      result = distanceInWordsLocale[token]
-    } else if (count === 1) {
-      result = distanceInWordsLocale[token].one
-    } else {
-      result = distanceInWordsLocale[token].other.replace('{{count}}', count)
-    }
-
-    if (options.addSuffix) {
-      if (options.comparison > 0) {
-        return 'у/праз ' + result
-      } else {
-        return result + ' таму'
-      }
-    }
-
-    return result
+    return distanceInWordsLocale[token](count, options)
   }
 
   return {

--- a/src/locale/be/build_distance_in_words_locale/test.js
+++ b/src/locale/be/build_distance_in_words_locale/test.js
@@ -14,214 +14,1352 @@ describe('be locale > buildDistanceInWordsLocale', function () {
   })
 
   describe('lessThanXSeconds', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 1) === 'менш секунды')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', 1)
+          assert(result === 'менш за секунду')
+        })
+      })
+
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number)
+            assert(result === 'менш за ' + number + ' секунду')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number)
+            assert(result === 'менш за ' + number + ' секунды')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number)
+            assert(result === 'менш за ' + number + ' секунд')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXSeconds', 2) === 'менш 2 секунд')
+    describe('past suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', 1, {
+            addSuffix: true,
+            comparison: -1
+          })
+          assert(result === 'менш за секунду таму')
+        })
+      })
+
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'менш за ' + number + ' секунду таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'менш за ' + number + ' секунды таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'менш за ' + number + ' секунд таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', 1, {
+            addSuffix: true,
+            comparison: 1
+          })
+          assert(result === 'менш, чым праз секунду')
+        })
+      })
+
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'менш, чым праз ' + number + ' секунду')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'менш, чым праз ' + number + ' секунды')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXSeconds', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'менш, чым праз ' + number + ' секунд')
+          })
+        })
       })
     })
   })
 
   describe('xSeconds', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xSeconds', 1) === '1 секунда')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number)
+            assert(result === number + ' секунда')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number)
+            assert(result === number + ' секунды')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number)
+            assert(result === number + ' секунд')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xSeconds', 2) === '2 секунд(-ы)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' секунду таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' секунды таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' секунд таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' секунду')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' секунды')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xSeconds', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' секунд')
+          })
+        })
       })
     })
   })
 
   describe('halfAMinute', function () {
-    it('returns a proper string', function () {
-      assert(buildDistanceInWordsLocale().localize('halfAMinute') === 'паўхвіліны')
+    it('ignores the second argument', function () {
+      var result = buildDistanceInWordsLocale().localize('halfAMinute', 5)
+      assert(result === 'паўхвіліны')
     })
 
-    it('ignores the second argument', function () {
-      assert(buildDistanceInWordsLocale().localize('halfAMinute', 123) === 'паўхвіліны')
+    describe('no suffix', function () {
+      it('returns a proper string', function () {
+        var result = buildDistanceInWordsLocale().localize('halfAMinute')
+        assert(result === 'паўхвіліны')
+      })
+    })
+
+    describe('past suffix', function () {
+      it('returns a proper string', function () {
+        var result = buildDistanceInWordsLocale().localize('halfAMinute', null, {
+          addSuffix: true,
+          comparison: -1
+        })
+        assert(result === 'паўхвіліны таму')
+      })
+    })
+
+    describe('future suffix', function () {
+      it('returns a proper string', function () {
+        var result = buildDistanceInWordsLocale().localize('halfAMinute', null, {
+          addSuffix: true,
+          comparison: 1
+        })
+        assert(result === 'праз паўхвіліны')
+      })
     })
   })
 
   describe('lessThanXMinutes', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 1) === 'менш хвіліны')
+    describe('no suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', 1)
+          assert(result === 'менш за хвіліну')
+        })
+      })
+
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number)
+            assert(result === 'менш за ' + number + ' хвіліну')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number)
+            assert(result === 'менш за ' + number + ' хвіліны')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number)
+            assert(result === 'менш за ' + number + ' хвілін')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('lessThanXMinutes', 2) === 'менш 2 хвілін')
+    describe('past suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', 1, {
+            addSuffix: true,
+            comparison: -1
+          })
+          assert(result === 'менш за хвіліну таму')
+        })
+      })
+
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'менш за ' + number + ' хвіліну таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'менш за ' + number + ' хвіліны таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'менш за ' + number + ' хвілін таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count equals 1', function () {
+        it('returns a proper string', function () {
+          var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', 1, {
+            addSuffix: true,
+            comparison: 1
+          })
+          assert(result === 'менш, чым праз хвіліну')
+        })
+      })
+
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'менш, чым праз ' + number + ' хвіліну')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'менш, чым праз ' + number + ' хвіліны')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('lessThanXMinutes', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'менш, чым праз ' + number + ' хвілін')
+          })
+        })
       })
     })
   })
 
   describe('xMinutes', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMinutes', 1) === '1 хвіліна')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number)
+            assert(result === number + ' хвіліна')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number)
+            assert(result === number + ' хвіліны')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number)
+            assert(result === number + ' хвілін')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMinutes', 2) === '2 хвілін(-ы)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' хвіліну таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' хвіліны таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' хвілін таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' хвіліну')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' хвіліны')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMinutes', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' хвілін')
+          })
+        })
       })
     })
   })
 
   describe('aboutXHours', function () {
-    context('when the count equals 1', function () {
+    context('when a remainder from division by 10 is 1 but not 11', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXHours', 1) === 'каля 1 гадзіны')
+        [1, 21, 101, 1231].forEach(function (count) {
+          var result = buildDistanceInWordsLocale().localize('aboutXHours', count)
+          assert(result === 'каля ' + count + ' гадзіны')
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
+    context('otherwise', function () {
       it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXHours', 2) === 'каля 2 гадзін')
+        [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 20, 102, 1234].forEach(function (count) {
+          var result = buildDistanceInWordsLocale().localize('aboutXHours', count)
+          assert(result === 'каля ' + count + ' гадзін')
+        })
       })
     })
   })
 
   describe('xHours', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xHours', 1) === '1 гадзіна')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number)
+            assert(result === number + ' гадзіна')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number)
+            assert(result === number + ' гадзіны')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number)
+            assert(result === number + ' гадзін')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xHours', 2) === '2 гадзін(-ы)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' гадзіну таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' гадзіны таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' гадзін таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' гадзіну')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' гадзіны')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xHours', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' гадзін')
+          })
+        })
       })
     })
   })
 
   describe('xDays', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xDays', 1) === '1 дзень')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number)
+            assert(result === number + ' дзень')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number)
+            assert(result === number + ' дні')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number)
+            assert(result === number + ' дзён')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xDays', 2) === '2 дні (дзён)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' дзень таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' дні таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' дзён таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' дзень')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' дні')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xDays', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' дзён')
+          })
+        })
       })
     })
   })
 
   describe('aboutXMonths', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXMonths', 1) === 'каля 1 месяца')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number)
+            assert(result === 'каля ' + number + ' месяца')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 5, 6, 10, 11, 12, 22, 23, 100, 302, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number)
+            assert(result === 'каля ' + number + ' месяцаў')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXMonths', 2) === 'каля 2 месяцаў')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'каля ' + number + ' месяца таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 5, 6, 10, 11, 12, 22, 23, 100, 302, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'каля ' + number + ' месяцаў таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'прыблізна праз ' + number + ' месяц')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'прыблізна праз ' + number + ' месяцы')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXMonths', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'прыблізна праз ' + number + ' месяцаў')
+          })
+        })
       })
     })
   })
 
   describe('xMonths', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMonths', 1) === '1 месяц')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number)
+            assert(result === number + ' месяц')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number)
+            assert(result === number + ' месяцы')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number)
+            assert(result === number + ' месяцаў')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xMonths', 2) === '2 месяцы(-аў)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' месяц таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' месяцы таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' месяцаў таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' месяц')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' месяцы')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xMonths', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' месяцаў')
+          })
+        })
       })
     })
   })
 
   describe('aboutXYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXYears', 1) === 'каля 1 года')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number)
+            assert(result === 'каля ' + number + ' года')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 5, 6, 10, 11, 12, 22, 23, 100, 302, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number)
+            assert(result === 'каля ' + number + ' гадоў')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('aboutXYears', 2) === 'каля 2 гадоў')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'каля ' + number + ' года таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 5, 6, 10, 11, 12, 22, 23, 100, 302, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'каля ' + number + ' гадоў таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'прыблізна праз ' + number + ' год')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'прыблізна праз ' + number + ' гады')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('aboutXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'прыблізна праз ' + number + ' гадоў')
+          })
+        })
       })
     })
   })
 
   describe('xYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xYears', 1) === '1 год')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number)
+            assert(result === number + ' год')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number)
+            assert(result === number + ' гады')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number)
+            assert(result === number + ' гадоў')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('xYears', 2) === '2 гады(гадоў)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' год таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' гады таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === number + ' гадоў таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' год')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' гады')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('xYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'праз ' + number + ' гадоў')
+          })
+        })
       })
     })
   })
 
   describe('overXYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('overXYears', 1) === 'больш 1 года')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number)
+            assert(result === 'больш за ' + number + ' год')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number)
+            assert(result === 'больш за ' + number + ' гады')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number)
+            assert(result === 'больш за ' + number + ' гадоў')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('overXYears', 2) === 'больш 2 гадоў')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'больш за ' + number + ' год таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'больш за ' + number + ' гады таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'больш за ' + number + ' гадоў таму')
+          })
+        })
+      })
+    })
+
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'больш, чым праз ' + number + ' год')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'больш, чым праз ' + number + ' гады')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('overXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'больш, чым праз ' + number + ' гадоў')
+          })
+        })
       })
     })
   })
 
   describe('almostXYears', function () {
-    context('when the count equals 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('almostXYears', 1) === 'амаль 1 год')
+    describe('no suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number)
+            assert(result === 'амаль ' + number + ' год')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number)
+            assert(result === 'амаль ' + number + ' гады')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number)
+            assert(result === 'амаль ' + number + ' гадоў')
+          })
+        })
       })
     })
 
-    context('when the count is more than 1', function () {
-      it('returns a proper string', function () {
-        assert(buildDistanceInWordsLocale().localize('almostXYears', 2) === 'амаль 2 гады(-оў)')
+    describe('past suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'амаль ' + number + ' год таму')
+          })
+        })
+      })
+
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'амаль ' + number + ' гады таму')
+          })
+        })
+      })
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number, {
+              addSuffix: true,
+              comparison: -1
+            })
+            assert(result === 'амаль ' + number + ' гадоў таму')
+          })
+        })
       })
     })
-  })
 
-  context('with a past suffix', function () {
-    it('adds `ago` to a string', function () {
-      var result = buildDistanceInWordsLocale().localize('aboutXYears', 1, {
-        addSuffix: true,
-        comparison: -1
+    describe('future suffix', function () {
+      context('when the count ends with 1 but not with 11', function () {
+        it('returns a proper string', function () {
+          [1, 21, 31, 301, 321].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'амаль праз ' + number + ' год')
+          })
+        })
       })
-      assert(result === 'каля 1 года таму')
-    })
-  })
 
-  context('with a future suffix', function () {
-    it('adds `in` to a string', function () {
-      var result = buildDistanceInWordsLocale().localize('halfAMinute', null, {
-        addSuffix: true,
-        comparison: 1
+      context('when the count ends with 2, 3 or 4 but not with 12, 13 or 14', function () {
+        it('returns a proper string', function () {
+          [2, 3, 4, 22, 23, 302].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'амаль праз ' + number + ' гады')
+          })
+        })
       })
-      assert(result === 'у/праз паўхвіліны')
+
+      context('when the count is any other number', function () {
+        it('returns a proper string', function () {
+          [5, 6, 10, 11, 12, 100, 311, 1000].forEach(function (number) {
+            var result = buildDistanceInWordsLocale().localize('almostXYears', number, {
+              addSuffix: true,
+              comparison: 1
+            })
+            assert(result === 'амаль праз ' + number + ' гадоў')
+          })
+        })
+      })
     })
   })
 })

--- a/src/locale/be/build_format_locale/index.js
+++ b/src/locale/be/build_format_locale/index.js
@@ -1,73 +1,97 @@
 var buildFormattingTokensRegExp = require('../../_lib/build_formatting_tokens_reg_exp/index.js')
 
 function buildFormatLocale () {
-  var months3char = ['студз', 'лют', 'сак', 'крас', 'май', 'чэрв', 'ліп', 'жн', 'вер', 'кастр', 'ліст', 'снеж']
+  var monthsShort = ['студз', 'лют', 'сак', 'крас', 'май', 'чэрв', 'ліп', 'жн', 'вер', 'кастр', 'ліст', 'снеж']
   var monthsFull = ['студзень', 'люты', 'сакавік', 'красавік', 'май', 'чэрвень', 'ліпень', 'жнівень', 'верасень', 'кастрычнік', 'лістапад', 'снежань']
+  var monthsShortGenitive = ['студз', 'лют', 'сак', 'крас', 'мая', 'чэрв', 'ліп', 'жн', 'вер', 'кастр', 'ліст', 'снеж']
+  var monthsGenitive = ['студзеня', 'лютага', 'сакавіка', 'красавіка', 'мая', 'чэрвеня', 'ліпеня', 'жніўня', 'верасня', 'кастрычніка', 'лістапада', 'снежня']
   var weekdays2char = ['нд', 'пн', 'аў', 'ср', 'чц', 'пт', 'сб']
   var weekdays3char = ['нядз', 'пан', 'аўт', 'сер', 'чац', 'пят', 'суб']
   var weekdaysFull = ['нядзеля', 'панядзелак', 'аўторак', 'серада', 'чацвер', 'пятніца', 'субота']
-  var meridiemUppercase = ['AM', 'PM']
-  var meridiemLowercase = ['am', 'pm']
-  var meridiemFull = ['a.m.', 'p.m.']
+  var meridiem = ['ночы', 'раніцы', 'дня', 'вечара']
 
   var formatters = {
-    // Month: Jan, Feb, ..., Dec
+    // Month: студз, лют, ..., снеж
     'MMM': function (date) {
-      return months3char[date.getMonth()]
+      return monthsShort[date.getMonth()]
     },
 
-    // Month: January, February, ..., December
+    // Month: студзень, люты, ..., снежань
     'MMMM': function (date) {
       return monthsFull[date.getMonth()]
     },
 
-    // Day of week: Su, Mo, ..., Sa
+    // Day of week: нд, пн, ..., сб
     'dd': function (date) {
       return weekdays2char[date.getDay()]
     },
 
-    // Day of week: Sun, Mon, ..., Sat
+    // Day of week: нядз, пан, ..., суб
     'ddd': function (date) {
       return weekdays3char[date.getDay()]
     },
 
-    // Day of week: Sunday, Monday, ..., Saturday
+    // Day of week: нядзеля, панядзелак, ..., субота
     'dddd': function (date) {
       return weekdaysFull[date.getDay()]
     },
 
-    // AM, PM
+    // Time of day: ночы, раніцы, дня, вечара
     'A': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemUppercase[1] : meridiemUppercase[0]
-    },
-
-    // am, pm
-    'a': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemLowercase[1] : meridiemLowercase[0]
-    },
-
-    // a.m., p.m.
-    'aa': function (date) {
-      return (date.getHours() / 12) >= 1 ? meridiemFull[1] : meridiemFull[0]
+      var hours = date.getHours()
+      if (hours >= 17) {
+        return meridiem[3]
+      } else if (hours >= 12) {
+        return meridiem[2]
+      } else if (hours >= 4) {
+        return meridiem[1]
+      } else {
+        return meridiem[0]
+      }
     }
   }
+
+  formatters.a = formatters.A
+  formatters.aa = formatters.A
 
   // Generate ordinal version of formatters: M -> Mo, D -> Do, etc.
   var ordinalFormatters = ['M', 'D', 'DDD', 'd', 'Q', 'W']
   ordinalFormatters.forEach(function (formatterToken) {
     formatters[formatterToken + 'o'] = function (date, formatters) {
-      return ordinal(formatters[formatterToken](date))
+      var number = formatters[formatterToken](date)
+      var suffix = (number % 10 === 2 || number % 10 === 3) && (number % 100 !== 12 && number % 100 !== 13) ? '-і' : '-ы'
+      return number + suffix
     }
   })
+
+  // Generate formatters like 'D MMMM' and 'D MMM',
+  // where month is in the genitive case: студзеня, лютага, ..., снежня (and in a shortened form).
+  var monthsGenitiveFormatters = ['D', 'DD']
+  monthsGenitiveFormatters.forEach(function (formatterToken) {
+    formatters[formatterToken + ' MMMM'] = function (date, commonFormatters) {
+      var formatter = formatters[formatterToken] || commonFormatters[formatterToken]
+      return formatter(date, commonFormatters) + ' ' + monthsGenitive[date.getMonth()]
+    }
+    formatters[formatterToken + ' MMM'] = function (date, commonFormatters) {
+      var formatter = formatters[formatterToken] || commonFormatters[formatterToken]
+      return formatter(date, commonFormatters) + ' ' + monthsShortGenitive[date.getMonth()]
+    }
+  })
+
+  // Ordinal day of month in the genitive case
+  formatters['Do MMMM'] = function (date, formatters) {
+    return formatters.D(date) + '-га' + ' ' + monthsGenitive[date.getMonth()]
+  }
+
+  // Ordinal day of month in a short form
+  formatters['Do MMM'] = function (date, formatters) {
+    return formatters.D(date) + '-га' + ' ' + monthsShortGenitive[date.getMonth()]
+  }
 
   return {
     formatters: formatters,
     formattingTokensRegExp: buildFormattingTokensRegExp(formatters)
   }
-}
-
-function ordinal (number) {
-  return number + '.'
 }
 
 module.exports = buildFormatLocale

--- a/src/locale/be/build_format_locale/test.js
+++ b/src/locale/be/build_format_locale/test.js
@@ -205,122 +205,266 @@ describe('be locale > buildFormatLocale', function () {
     })
 
     describe('A', function () {
-      it('returns the correct string for 1-11 a.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 1)) === 'AM')
+      it('returns the correct string for 12-3 a.m.', function () {
+        [0, 1, 2, 3].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, hours)) === 'ночы')
+        })
       })
 
-      it('returns the correct string for 12 a.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 0)) === 'AM')
+      it('returns the correct string for 4-11 a.m.', function () {
+        [4, 5, 6, 7, 8, 9, 10, 11].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, hours)) === 'раніцы')
+        })
       })
 
-      it('returns the correct string for 1-11 p.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 13)) === 'PM')
+      it('returns the correct string for 12-4 p.m.', function () {
+        [12, 13, 14, 15, 16].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, hours)) === 'дня')
+        })
       })
 
-      it('returns the correct string for 12 p.m.', function () {
-        assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, 12)) === 'PM')
+      it('returns the correct string for 5-11 p.m.', function () {
+        [17, 18, 19, 20, 21, 22, 23].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.A(new Date(2016, 1 /* Feb */, 11, hours)) === 'вечара')
+        })
       })
     })
 
     describe('a', function () {
-      it('returns the correct string for 1-11 a.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 1)) === 'am')
+      it('returns the correct string for 12-3 a.m.', function () {
+        [0, 1, 2, 3].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, hours)) === 'ночы')
+        })
       })
 
-      it('returns the correct string for 12 a.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 0)) === 'am')
+      it('returns the correct string for 4-11 a.m.', function () {
+        [4, 5, 6, 7, 8, 9, 10, 11].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, hours)) === 'раніцы')
+        })
       })
 
-      it('returns the correct string for 1-11 p.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 13)) === 'pm')
+      it('returns the correct string for 12-4 p.m.', function () {
+        [12, 13, 14, 15, 16].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, hours)) === 'дня')
+        })
       })
 
-      it('returns the correct string for 12 p.m.', function () {
-        assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, 12)) === 'pm')
+      it('returns the correct string for 5-11 p.m.', function () {
+        [17, 18, 19, 20, 21, 22, 23].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.a(new Date(2016, 1 /* Feb */, 11, hours)) === 'вечара')
+        })
       })
     })
 
     describe('aa', function () {
-      it('returns the correct string for 1-11 a.m.', function () {
-        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 1)) === 'a.m.')
+      it('returns the correct string for 12-3 a.m.', function () {
+        [0, 1, 2, 3].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, hours)) === 'ночы')
+        })
       })
 
-      it('returns the correct string for 12 a.m.', function () {
-        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 0)) === 'a.m.')
+      it('returns the correct string for 4-11 a.m.', function () {
+        [4, 5, 6, 7, 8, 9, 10, 11].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, hours)) === 'раніцы')
+        })
       })
 
-      it('returns the correct string for 1-11 p.m.', function () {
-        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 13)) === 'p.m.')
+      it('returns the correct string for 12-4 p.m.', function () {
+        [12, 13, 14, 15, 16].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, hours)) === 'дня')
+        })
       })
 
-      it('returns the correct string for 12 p.m.', function () {
-        assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, 12)) === 'p.m.')
+      it('returns the correct string for 5-11 p.m.', function () {
+        [17, 18, 19, 20, 21, 22, 23].forEach(function (hours) {
+          assert(buildFormatLocale().formatters.aa(new Date(2016, 1 /* Feb */, 11, hours)) === 'вечара')
+        })
       })
     })
 
     describe('Mo', function () {
       it('returns ordinal result of M formatter', function () {
-        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 1 }}) === '1.')
-        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 2 }}) === '2.')
-        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 3 }}) === '3.')
-        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 11 }}) === '11.')
-        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 101 }}) === '101.')
-        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 111 }}) === '111.')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 1 }}) === '1-ы')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 2 }}) === '2-і')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 3 }}) === '3-і')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 11 }}) === '11-ы')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 12 }}) === '12-ы')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 21 }}) === '21-ы')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 22 }}) === '22-і')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 101 }}) === '101-ы')
+        assert(buildFormatLocale().formatters.Mo(null, {M: function () { return 111 }}) === '111-ы')
       })
     })
 
     describe('Do', function () {
       it('returns ordinal result of D formatter', function () {
-        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 1 }}) === '1.')
-        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 2 }}) === '2.')
-        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 3 }}) === '3.')
-        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 11 }}) === '11.')
-        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 101 }}) === '101.')
-        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 111 }}) === '111.')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 1 }}) === '1-ы')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 2 }}) === '2-і')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 3 }}) === '3-і')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 11 }}) === '11-ы')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 12 }}) === '12-ы')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 21 }}) === '21-ы')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 22 }}) === '22-і')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 101 }}) === '101-ы')
+        assert(buildFormatLocale().formatters.Do(null, {D: function () { return 111 }}) === '111-ы')
       })
     })
 
     describe('DDDo', function () {
       it('returns ordinal result of DDD formatter', function () {
-        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 1 }}) === '1.')
-        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 2 }}) === '2.')
-        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 3 }}) === '3.')
-        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 11 }}) === '11.')
-        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 101 }}) === '101.')
-        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 111 }}) === '111.')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 1 }}) === '1-ы')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 2 }}) === '2-і')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 3 }}) === '3-і')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 11 }}) === '11-ы')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 12 }}) === '12-ы')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 21 }}) === '21-ы')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 22 }}) === '22-і')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 101 }}) === '101-ы')
+        assert(buildFormatLocale().formatters.DDDo(null, {DDD: function () { return 111 }}) === '111-ы')
       })
     })
 
     describe('do', function () {
       it('returns ordinal result of d formatter', function () {
-        assert(buildFormatLocale().formatters.do(null, {d: function () { return 1 }}) === '1.')
-        assert(buildFormatLocale().formatters.do(null, {d: function () { return 2 }}) === '2.')
-        assert(buildFormatLocale().formatters.do(null, {d: function () { return 3 }}) === '3.')
-        assert(buildFormatLocale().formatters.do(null, {d: function () { return 11 }}) === '11.')
-        assert(buildFormatLocale().formatters.do(null, {d: function () { return 101 }}) === '101.')
-        assert(buildFormatLocale().formatters.do(null, {d: function () { return 111 }}) === '111.')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 1 }}) === '1-ы')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 2 }}) === '2-і')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 3 }}) === '3-і')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 11 }}) === '11-ы')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 12 }}) === '12-ы')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 21 }}) === '21-ы')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 22 }}) === '22-і')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 101 }}) === '101-ы')
+        assert(buildFormatLocale().formatters.do(null, {d: function () { return 111 }}) === '111-ы')
       })
     })
 
     describe('Qo', function () {
       it('returns ordinal result of Q formatter', function () {
-        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 1 }}) === '1.')
-        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 2 }}) === '2.')
-        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 3 }}) === '3.')
-        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 11 }}) === '11.')
-        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 101 }}) === '101.')
-        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 111 }}) === '111.')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 1 }}) === '1-ы')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 2 }}) === '2-і')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 3 }}) === '3-і')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 11 }}) === '11-ы')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 12 }}) === '12-ы')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 21 }}) === '21-ы')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 22 }}) === '22-і')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 101 }}) === '101-ы')
+        assert(buildFormatLocale().formatters.Qo(null, {Q: function () { return 111 }}) === '111-ы')
       })
     })
 
     describe('Wo', function () {
       it('returns ordinal result of W formatter', function () {
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 1 }}) === '1.')
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 2 }}) === '2.')
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 3 }}) === '3.')
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 11 }}) === '11.')
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 101 }}) === '101.')
-        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 111 }}) === '111.')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 1 }}) === '1-ы')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 2 }}) === '2-і')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 3 }}) === '3-і')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 11 }}) === '11-ы')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 12 }}) === '12-ы')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 21 }}) === '21-ы')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 22 }}) === '22-і')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 101 }}) === '101-ы')
+        assert(buildFormatLocale().formatters.Wo(null, {W: function () { return 111 }}) === '111-ы')
+      })
+    })
+
+    describe('D MMMM', function () {
+      it('returns a day and a month in the genitive case', function () {
+        var months = [
+          'студзеня', 'лютага', 'сакавіка', 'красавіка', 'мая', 'чэрвеня',
+          'ліпеня', 'жніўня', 'верасня', 'кастрычніка', 'лістапада', 'снежня'
+        ]
+        var formatters = {
+          D: function () {
+            return 5
+          }
+        }
+        months.forEach(function (month, index) {
+          assert(buildFormatLocale().formatters['D MMMM'](new Date(2015, index, 5), formatters) === '5 ' + month)
+        })
+      })
+    })
+
+    describe('D MMM', function () {
+      it('returns a day and a month in a shortened form in the genitive case ', function () {
+        var months = [
+          'студз', 'лют', 'сак', 'крас', 'мая', 'чэрв',
+          'ліп', 'жн', 'вер', 'кастр', 'ліст', 'снеж'
+        ]
+        var formatters = {
+          D: function () {
+            return 5
+          }
+        }
+        months.forEach(function (month, index) {
+          assert(buildFormatLocale().formatters['D MMM'](new Date(2015, index, 5), formatters) === '5 ' + month)
+        })
+      })
+    })
+
+    describe('Do MMMM', function () {
+      it('returns an ordinal day and a month in the genitive case', function () {
+        var months = [
+          'студзеня', 'лютага', 'сакавіка', 'красавіка', 'мая', 'чэрвеня',
+          'ліпеня', 'жніўня', 'верасня', 'кастрычніка', 'лістапада', 'снежня'
+        ]
+        var formatters = {
+          D: function () {
+            return 3
+          }
+        }
+        months.forEach(function (month, index) {
+          assert(buildFormatLocale().formatters['Do MMMM'](new Date(2016, index, 3), formatters) === '3-га ' + month)
+        })
+      })
+    })
+
+    describe('Do MMM', function () {
+      it('returns an ordinal day and a month in a shortened form in the genitive case', function () {
+        var months = [
+          'студз', 'лют', 'сак', 'крас', 'мая', 'чэрв',
+          'ліп', 'жн', 'вер', 'кастр', 'ліст', 'снеж'
+        ]
+        var formatters = {
+          D: function () {
+            return 3
+          }
+        }
+        months.forEach(function (month, index) {
+          assert(buildFormatLocale().formatters['Do MMM'](new Date(2016, index, 3), formatters) === '3-га ' + month)
+        })
+      })
+    })
+
+    describe('DD MMMM', function () {
+      it('returns a day and a month in the genitive case', function () {
+        var months = [
+          'студзеня', 'лютага', 'сакавіка', 'красавіка', 'мая', 'чэрвеня',
+          'ліпеня', 'жніўня', 'верасня', 'кастрычніка', 'лістапада', 'снежня'
+        ]
+        var formatters = {
+          DD: function () {
+            return '07'
+          }
+        }
+        months.forEach(function (month, index) {
+          assert(buildFormatLocale().formatters['DD MMMM'](new Date(2016, index, 7), formatters) === '07 ' + month)
+        })
+      })
+    })
+
+    describe('DD MMM', function () {
+      it('returns a day and a month in the genitive case', function () {
+        var months = [
+          'студз', 'лют', 'сак', 'крас', 'мая', 'чэрв',
+          'ліп', 'жн', 'вер', 'кастр', 'ліст', 'снеж'
+        ]
+        var formatters = {
+          DD: function () {
+            return '07'
+          }
+        }
+        months.forEach(function (month, index) {
+          assert(buildFormatLocale().formatters['DD MMM'](new Date(2016, index, 7), formatters) === '07 ' + month)
+        })
       })
     })
   })


### PR DESCRIPTION
Recently added version of `be` locale has syntactical errors and doesn't reflect an actual language use. It was based on `en` locale structure but, in fact, Belarusian is much closer to Russian and Polish. So I have refactored it and added several improvements: declensions, genitive cases, a distinction between standalone and combined (with month) versions of ordinal day.