### PR TITLE
fix(parseISO): Check for empty date after splitDateString

### DIFF
--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -103,8 +103,12 @@ export default function parseISO(argument, dirtyOptions) {
   }
 
   var dateStrings = splitDateString(argument)
-  var parseYearResult = parseYear(dateStrings.date, additionalDigits)
-  var date = parseDate(parseYearResult.restDateString, parseYearResult.year)
+
+  var date
+  if (dateStrings.date) {
+    var parseYearResult = parseYear(dateStrings.date, additionalDigits)
+    date = parseDate(parseYearResult.restDateString, parseYearResult.year)
+  }
 
   if (isNaN(date) || !date) {
     return new Date(NaN)

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -348,6 +348,12 @@ describe('parseISO', () => {
       assert(isNaN(result))
     })
 
+    it('returns Invalid Date if argument is non-date string containing a colon', () => {
+      const result = parseISO('00:00')
+      assert(result instanceof Date)
+      assert(isNaN(result))
+    })
+
     it('returns Invalid Date if argument is NaN', () => {
       // $ExpectedMistake
       const result = parseISO(NaN)


### PR DESCRIPTION
Don't crash when `splitDateString()` returns with `dateStrings.date = null`. This can happen when parsing a string containing a colon, e.g."00:00".

Fixes #1043 