### PR TITLE
fixed issue: options.weekStartsOn set to 1 doesn't work for Sundays

### DIFF
--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -50,12 +50,25 @@ export default function getWeekOfMonth(date, dirtyOptions) {
     throw new RangeError('weekStartsOn must be between 0 and 6 inclusively')
   }
 
+  var currentDayOfMonth = getDate(date)
+  if (isNaN(currentDayOfMonth)) {
+    return currentDayOfMonth
+  }
+
   var startWeekDay = getDay(startOfMonth(date))
-  var currentWeekDay = getDay(date)
+  var lastDayOfFirstWeek = 0
 
-  var startWeekDayWithOptions =
-    startWeekDay < weekStartsOn ? 7 - weekStartsOn : startWeekDay
-  var diff = startWeekDayWithOptions > currentWeekDay ? 7 - weekStartsOn : 0
+  if (startWeekDay >= weekStartsOn) {
+    lastDayOfFirstWeek = weekStartsOn + 7 - startWeekDay
+  } else {
+    lastDayOfFirstWeek = weekStartsOn - startWeekDay
+  }
 
-  return Math.ceil((getDate(date) + diff) / 7)
+  var weekNumber = 1
+
+  if (currentDayOfMonth > lastDayOfFirstWeek) {
+    var remainingDaysAfterFirstWeek = currentDayOfMonth - lastDayOfFirstWeek
+    weekNumber = weekNumber + Math.ceil(remainingDaysAfterFirstWeek / 7)
+  }
+  return weekNumber
 }

--- a/src/getWeekOfMonth/test.js
+++ b/src/getWeekOfMonth/test.js
@@ -74,4 +74,11 @@ describe('getWeekOfMonth', function() {
   it('throws TypeError exception if passed less than 1 argument', function() {
     assert.throws(getWeekOfMonth.bind(null), TypeError)
   })
+
+  it('returns the week of the month of the given date, when the given date is sunday', function() {
+    var result = getWeekOfMonth(new Date(2019, 4 /* May */, 5), {
+      weekStartsOn: 1
+    })
+    assert(result === 1)
+  })
 })


### PR DESCRIPTION
fixed issue: #1040 

When executing `getWeekOfMonth(new Date(2019, 4, 5), { weekStartsOn: 1 })` it returns `2` while I expect it to be 1. It seems `getWeekOfMonth()` is always a week off when executed with a day set to `Sunday` and `options.weekStartsOn set to > 0`.