### PR TITLE
Improve japanese translation of formatDistance with addSuffix option

### DIFF
--- a/src/locale/ja/_lib/formatDistance/index.js
+++ b/src/locale/ja/_lib/formatDistance/index.js
@@ -1,7 +1,9 @@
 var formatDistanceLocale = {
   lessThanXSeconds: {
     one: '1秒未満',
-    other: '{{count}}秒未満'
+    other: '{{count}}秒未満',
+    oneWithSuffix: '約1秒',
+    otherWithSuffix: '約{{count}}秒'
   },
 
   xSeconds: {
@@ -13,7 +15,9 @@ var formatDistanceLocale = {
 
   lessThanXMinutes: {
     one: '1分未満',
-    other: '{{count}}分未満'
+    other: '{{count}}分未満',
+    oneWithSuffix: '約1分',
+    otherWithSuffix: '約{{count}}分'
   },
 
   xMinutes: {
@@ -74,9 +78,17 @@ export default function formatDistance (token, count, options) {
   if (typeof formatDistanceLocale[token] === 'string') {
     result = formatDistanceLocale[token]
   } else if (count === 1) {
-    result = formatDistanceLocale[token].one
+    if (options.addSuffix && formatDistanceLocale[token].oneWithSuffix) {
+      result = formatDistanceLocale[token].oneWithSuffix
+    } else {
+      result = formatDistanceLocale[token].one
+    }
   } else {
-    result = formatDistanceLocale[token].other.replace('{{count}}', count)
+    if (options.addSuffix && formatDistanceLocale[token].otherWithSuffix) {
+      result = formatDistanceLocale[token].otherWithSuffix.replace('{{count}}', count)
+    } else {
+      result = formatDistanceLocale[token].other.replace('{{count}}', count)
+    }
   }
 
   if (options.addSuffix) {

--- a/src/locale/ja/_lib/formatDistance/test.js
+++ b/src/locale/ja/_lib/formatDistance/test.js
@@ -208,21 +208,21 @@ describe('ja locale > formatDistance', function () {
 
     context('and locale data has `oneWithSuffix`', function () {
       it('adds `ago` to a `oneWithSuffix`', function () {
-        var result = formatDistance('almostXYears', 1, {
+        var result = formatDistance('lessThanXSeconds', 1, {
           addSuffix: true,
           comparison: -1
         })
-        assert(result === '1年近く前')
+        assert(result === '約1秒前')
       })
     })
 
     context('and locale data has `otherWithSuffix`', function () {
       it('adds `ago` to a `otherWithSuffix`', function () {
-        var result = formatDistance('almostXYears', 2, {
+        var result = formatDistance('lessThanXMinutes', 2, {
           addSuffix: true,
           comparison: -1
         })
-        assert(result === '2年近く前')
+        assert(result === '約2分前')
       })
     })
   })


### PR DESCRIPTION
I fixed unnatural japanese translations of `formatDistance`.
`lessThanXXX` with a suffix is translated into Japanese `XXX未満前`, but this expression is not used by Japanese.
