### PR TITLE
Change unescaped characters handling in `format`, `lightFormat` and `parse` (closes #1056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,12 +361,23 @@ for the list of changes made since `v2.0.0-alpha.1`.
   |                                 | PPPPpppp| Sunday, May 29th, 1453 at ...     |
 
   Characters are now escaped using single quote symbols (`'`) instead of square brackets.
+  `format` now throws RangeError if it encounters an unescaped latin character
+  that isn't a valid formatting token.
 
-  To use `D`,`DD`, `YY`, `YYYY` tokens you should set `awareOfUnicodeTokens`:
+  To use `YY` and `YYYY` tokens that represent week-numbering years,
+  you should set `useAdditionalWeekYearTokens` option:
 
   ```javascript
-  format(Date.now(), 'YY', { awareOfUnicodeTokens: true })
+  format(Date.now(), 'YY', { useAdditionalWeekYearTokens: true })
   //=> '86'
+  ```
+
+  To use `D` and `DD` tokens which represent days of the year,
+  set `useAdditionalDayOfYearTokens` option:
+
+  ```javascript
+  format(Date.now(), 'D', { useAdditionalDayOfYearTokens: true })
+  //=> '364'
   ```
 
 - **BREAKING**: function submodules now use camelCase naming schema:

--- a/docs/unicodeTokens.md
+++ b/docs/unicodeTokens.md
@@ -37,17 +37,18 @@ parse('11.02.87', 'd.MM.yy', new Date()).toString()
 ```
 
 To help with the issue, `format` and `parse` functions won't accept
-`D`, `DD`, `YY` and `YYYY` without `awareOfUnicodeTokens` option:
+these tokens without `useAdditionalDayOfYearTokens` option for `D` and `DD` and
+`useAdditionalWeekYearTokens` options for `YY` and `YYYY`:
 
 ```js
-format(new Date(), 'D', { awareOfUnicodeTokens: true })
+format(new Date(), 'D', { useAdditionalDayOfYearTokens: true })
 //=> '283'
 
-parse('365+1987', 'DD+YYYY', new Date(), { awareOfUnicodeTokens: true }).toString()
+parse('365+1987', 'DD+YYYY', new Date(), {
+  useAdditionalDayOfYearTokens: true,
+  useAdditionalWeekYearTokens: true
+}).toString()
 //=> 'Wed Dec 31 1986 00:00:00 GMT+0200 (EET)'
 ```
-
-The option is supposed to be a temporary solution and might be removed
-in the future minor or major versions.
 
 [Unicode tokens]: https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table

--- a/src/_lib/protectedTokens/index.js
+++ b/src/_lib/protectedTokens/index.js
@@ -1,13 +1,30 @@
-export var protectedTokens = ['D', 'DD', 'YY', 'YYYY']
+var protectedDayOfYearTokens = ['D', 'DD']
+var protectedWeekYearTokens = ['YY', 'YYYY']
 
-export function isProtectedToken(token) {
-  return protectedTokens.indexOf(token) !== -1
+export function isProtectedDayOfYearToken(token) {
+  return protectedDayOfYearTokens.indexOf(token) !== -1
+}
+
+export function isProtectedWeekYearToken(token) {
+  return protectedWeekYearTokens.indexOf(token) !== -1
 }
 
 export function throwProtectedError(token) {
-  throw new RangeError(
-    '`options.awareOfUnicodeTokens` must be set to `true` to use `' +
-      token +
-      '` token; see: https://git.io/fxCyr'
-  )
+  if (token === 'YYYY') {
+    throw new RangeError(
+      'Use `yyyy` instead of `YYYY` for formating years; see: https://git.io/fxCyr'
+    )
+  } else if (token === 'YY') {
+    throw new RangeError(
+      'Use `yy` instead of `YY` for formating years; see: https://git.io/fxCyr'
+    )
+  } else if (token === 'D') {
+    throw new RangeError(
+      'Use `d` instead of `D` for formatting days of the month; see: https://git.io/fxCyr'
+    )
+  } else if (token === 'DD') {
+    throw new RangeError(
+      'Use `dd` instead of `DD` for formatting days of the month; see: https://git.io/fxCyr'
+    )
+  }
 }

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -52,9 +52,7 @@ describe('format', function() {
 
   describe('ordinal numbers', function() {
     it('ordinal day of an ordinal month', function() {
-      var result = format(date, "do 'day of the' Mo 'month' of YYYY", {
-        awareOfUnicodeTokens: true
-      })
+      var result = format(date, "do 'day of the' Mo 'month of' yyyy")
       assert(result === '4th day of the 4th month of 1986')
     })
 
@@ -130,14 +128,14 @@ describe('format', function() {
     describe('local week-numbering year', function() {
       it('works as expected', function() {
         var result = format(date, 'Y Yo YY YYY YYYY YYYYY', {
-          awareOfUnicodeTokens: true
+          useAdditionalWeekYearTokens: true
         })
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
       it('the first week of the next year', function() {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
-          awareOfUnicodeTokens: true
+          useAdditionalWeekYearTokens: true
         })
         assert(result === '2014')
       })
@@ -146,14 +144,14 @@ describe('format', function() {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
           weekStartsOn: 1,
           firstWeekContainsDate: 4,
-          awareOfUnicodeTokens: true
+          useAdditionalWeekYearTokens: true
         })
         assert(result === '2013')
       })
 
       it('the first week of year', function() {
         var result = format(new Date(2016, 0 /* Jan */, 1), 'YYYY', {
-          awareOfUnicodeTokens: true
+          useAdditionalWeekYearTokens: true
         })
         assert(result === '2016')
       })
@@ -306,7 +304,7 @@ describe('format', function() {
     describe('day of year', function() {
       it('works as expected', function() {
         var result = format(date, 'D Do DD DDD DDDDD', {
-          awareOfUnicodeTokens: true
+          useAdditionalDayOfYearTokens: true
         })
         assert(result === '94 94th 94 094 00094')
       })
@@ -315,7 +313,7 @@ describe('format', function() {
         var result = format(
           new Date(1992, 11 /* Dec */, 31, 23, 59, 59, 999),
           'D',
-          { awareOfUnicodeTokens: true }
+          { useAdditionalDayOfYearTokens: true }
         )
         assert(result === '366')
       })
@@ -725,23 +723,29 @@ describe('format', function() {
     assert.throws(block, RangeError)
   })
 
+  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+    assert.throws(format.bind(null, date, 'yyyy-MM-dd-nnnn'), RangeError)
+  })
+
   it('throws TypeError exception if passed less than 2 arguments', function() {
     assert.throws(format.bind(null), TypeError)
     assert.throws(format.bind(null, 1), TypeError)
   })
 
-  describe('awareOfUnicodeTokens option', () => {
+  describe('useAdditionalWeekYearTokens and useAdditionalDayOfYearTokens options', () => {
     it('throws an error if D token is used', () => {
       const block = format.bind(null, date, 'yyyy-MM-D')
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `D` token; see: https://git.io/fxCyr'
+        'Use `d` instead of `D` for formatting days of the month; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows D token if awareOfUnicodeTokens is set to true', () => {
-      const result = format(date, 'yyyy-MM-D', { awareOfUnicodeTokens: true })
+    it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
+      const result = format(date, 'yyyy-MM-D', {
+        useAdditionalDayOfYearTokens: true
+      })
       assert.deepEqual(result, '1986-04-94')
     })
 
@@ -750,12 +754,14 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `DD` token; see: https://git.io/fxCyr'
+        'Use `dd` instead of `DD` for formatting days of the month; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows DD token if awareOfUnicodeTokens is set to true', () => {
-      const result = format(date, 'yyyy-MM-DD', { awareOfUnicodeTokens: true })
+    it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
+      const result = format(date, 'yyyy-MM-DD', {
+        useAdditionalDayOfYearTokens: true
+      })
       assert.deepEqual(result, '1986-04-94')
     })
 
@@ -764,12 +770,14 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+        'Use `yy` instead of `YY` for formating years; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows YY token if awareOfUnicodeTokens is set to true', () => {
-      const result = format(date, 'YY-MM-dd', { awareOfUnicodeTokens: true })
+    it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
+      const result = format(date, 'YY-MM-dd', {
+        useAdditionalWeekYearTokens: true
+      })
       assert.deepEqual(result, '86-04-04')
     })
 
@@ -778,12 +786,14 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+        'Use `yyyy` instead of `YYYY` for formating years; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows YYYY token if awareOfUnicodeTokens is set to true', () => {
-      const result = format(date, 'YYYY-MM-dd', { awareOfUnicodeTokens: true })
+    it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {
+      const result = format(date, 'YYYY-MM-dd', {
+        useAdditionalWeekYearTokens: true
+      })
       assert.deepEqual(result, '1986-04-04')
     })
   })

--- a/src/lightFormat/index.js
+++ b/src/lightFormat/index.js
@@ -17,6 +17,7 @@ var formattingTokensRegExp = /(\w)\1*|''|'(''|[^'])+('|$)|./g
 
 var escapedStringRegExp = /^'(.*?)'?$/
 var doubleQuoteRegExp = /''/g
+var unescapedLatinCharacterRegExp = /[a-zA-Z]/
 
 /**
  * @name lightFormat
@@ -32,7 +33,6 @@ var doubleQuoteRegExp = /''/g
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
- * (see the last example)
  *
  * Format of the string is based on Unicode Technical Standard #35:
  * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
@@ -75,6 +75,7 @@ var doubleQuoteRegExp = /''/g
  * @param {String} format - the string of tokens
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example
  * var result = format(new Date(2014, 1, 11), 'yyyy-MM-dd')
@@ -117,6 +118,14 @@ export default function lightFormat(dirtyDate, dirtyFormatStr) {
       var formatter = formatters[firstCharacter]
       if (formatter) {
         return formatter(utcDate, substring, null, {})
+      }
+
+      if (firstCharacter.match(unescapedLatinCharacterRegExp)) {
+        throw new RangeError(
+          'Format string contains an unescaped latin alphabet character `' +
+            firstCharacter +
+            '`'
+        )
       }
 
       return substring

--- a/src/lightFormat/test.js
+++ b/src/lightFormat/test.js
@@ -126,6 +126,10 @@ describe('lightFormat', () => {
     assert(lightFormat(date, formatString) === '2014-04-04')
   })
 
+  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+    assert.throws(lightFormat.bind(null, date, 'yyyy-MM-dd-nnnn'), RangeError)
+  })
+
   it('throws TypeError exception if passed less than 2 arguments', () => {
     assert.throws(lightFormat.bind(null), TypeError)
     assert.throws(lightFormat.bind(null, 1), TypeError)

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -6,7 +6,8 @@ import subMilliseconds from '../subMilliseconds/index.js'
 import defaultLocale from '../locale/en-US/index.js'
 import parsers from './_lib/parsers/index.js'
 import {
-  isProtectedToken,
+  isProtectedWeekYearToken,
+  isProtectedDayOfYearToken,
   throwProtectedError
 } from '../_lib/protectedTokens/index.js'
 
@@ -29,6 +30,7 @@ var escapedStringRegExp = /^'(.*?)'?$/
 var doubleQuoteRegExp = /''/g
 
 var notWhitespaceRegExp = /\S/
+var unescapedLatinCharacterRegExp = /[a-zA-Z]/
 
 /**
  * @name parse
@@ -109,9 +111,9 @@ var notWhitespaceRegExp = /\S/
  * | Day of month                    |  90 | d       | 1, 2, ..., 31                     |       |
  * |                                 |     | do      | 1st, 2nd, ..., 31st               | 5     |
  * |                                 |     | dd      | 01, 02, ..., 31                   |       |
- * | Day of year                     |  90 | D       | 1, 2, ..., 365, 366               | 6     |
+ * | Day of year                     |  90 | D       | 1, 2, ..., 365, 366               | 7     |
  * |                                 |     | Do      | 1st, 2nd, ..., 365th, 366th       | 5     |
- * |                                 |     | DD      | 01, 02, ..., 365, 366             | 6     |
+ * |                                 |     | DD      | 01, 02, ..., 365, 366             | 7     |
  * |                                 |     | DDD     | 001, 002, ..., 365, 366           |       |
  * |                                 |     | DDDD    | ...                               | 2     |
  * | Day of week (formatting)        |  90 | E..EEE  | Mon, Tue, Wed, ..., Su            |       |
@@ -239,7 +241,11 @@ var notWhitespaceRegExp = /\S/
  *    - `R`: ISO week-numbering year
  *    - `o`: ordinal number modifier
  *
- * 6. These tokens are often confused with others. See: https://git.io/fxCyr
+ * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *
+ * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
  *
  * Values will be assigned to the date in the descending order of its unit's priority.
  * Units of an equal priority overwrite each other in the order of appearance.
@@ -285,16 +291,20 @@ var notWhitespaceRegExp = /\S/
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
- * @param {Boolean} [options.awareOfUnicodeTokens=false] - if true, allows usage of Unicode tokens causes confusion:
- *   - Some of the day of year tokens (`D`, `DD`) that are confused with the day of month tokens (`d`, `dd`).
- *   - Some of the local week-numbering year tokens (`YY`, `YYYY`) that are confused with the calendar year tokens (`yy`, `yyyy`).
- *   See: https://git.io/fxCyr
+ * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
+ *   see: https://git.io/fxCyr
+ * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
+ *   see: https://git.io/fxCyr
  * @returns {Date} the parsed date
  * @throws {TypeError} 3 arguments required
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
  * @throws {RangeError} `options.locale` must contain `match` property
- * @throws {RangeError} `options.awareOfUnicodeTokens` must be set to `true` to use `XX` token; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formating years; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yy` instead of `YY` for formating years; see: https://git.io/fxCyr
+ * @throws {RangeError} use `d` instead of `D` for formating days of the month; see: https://git.io/fxCyr
+ * @throws {RangeError} use `dd` instead of `DD` for formating days of the month; see: https://git.io/fxCyr
+ * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example
  * // Parse 11 February 2014 from middle-endian format:
@@ -392,7 +402,16 @@ export default function parse(
   for (i = 0; i < tokens.length; i++) {
     var token = tokens[i]
 
-    if (!options.awareOfUnicodeTokens && isProtectedToken(token)) {
+    if (
+      !options.useAdditionalWeekYearTokens &&
+      isProtectedWeekYearToken(token)
+    ) {
+      throwProtectedError(token)
+    }
+    if (
+      !options.useAdditionalDayOfYearTokens &&
+      isProtectedDayOfYearToken(token)
+    ) {
       throwProtectedError(token)
     }
 
@@ -420,6 +439,14 @@ export default function parse(
 
       dateString = parseResult.rest
     } else {
+      if (firstCharacter.match(unescapedLatinCharacterRegExp)) {
+        throw new RangeError(
+          'Format string contains an unescaped latin alphabet character `' +
+            firstCharacter +
+            '`'
+        )
+      }
+
       // Replace two single quote characters with one single quote character
       if (token === "''") {
         token = "'"

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -99,13 +99,15 @@ describe('parse', function() {
 
     describe('two-digit numeric year', function() {
       it('works as expected', function() {
-        var result = parse('02', 'YY', baseDate, { awareOfUnicodeTokens: true })
+        var result = parse('02', 'YY', baseDate, {
+          useAdditionalWeekYearTokens: true
+        })
         assert.deepEqual(result, new Date(2001, 11 /* Dec */, 30))
       })
 
       it('gets the 100 year range from `baseDate`', function() {
         var result = parse('02', 'YY', new Date(1860, 6 /* Jul */, 2), {
-          awareOfUnicodeTokens: true
+          useAdditionalWeekYearTokens: true
         })
         assert.deepEqual(result, new Date(1901, 11 /* Dec */, 29))
       })
@@ -118,7 +120,7 @@ describe('parse', function() {
 
     it('four-digit zero-padding', function() {
       var result = parse('2018', 'YYYY', baseDate, {
-        awareOfUnicodeTokens: true
+        useAdditionalWeekYearTokens: true
       })
       assert.deepEqual(result, new Date(2017, 11 /* Dec */, 31))
     })
@@ -387,7 +389,9 @@ describe('parse', function() {
 
   describe('day of year', function() {
     it('numeric', function() {
-      var result = parse('200', 'D', baseDate, { awareOfUnicodeTokens: true })
+      var result = parse('200', 'D', baseDate, {
+        useAdditionalDayOfYearTokens: true
+      })
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
 
@@ -397,7 +401,9 @@ describe('parse', function() {
     })
 
     it('two-digit zero-padding', function() {
-      var result = parse('01', 'DD', baseDate, { awareOfUnicodeTokens: true })
+      var result = parse('01', 'DD', baseDate, {
+        useAdditionalDayOfYearTokens: true
+      })
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
@@ -1167,7 +1173,9 @@ describe('parse', function() {
       })
 
       it('works correctly for two-digit year zero', function() {
-        var result = parse('00', 'YY', baseDate, { awareOfUnicodeTokens: true })
+        var result = parse('00', 'YY', baseDate, {
+          useAdditionalWeekYearTokens: true
+        })
         assert.deepEqual(result, new Date(1999, 11 /* Dec */, 26))
       })
     })
@@ -1233,20 +1241,22 @@ describe('parse', function() {
 
     describe('day of year', function() {
       it('returns `Invalid Date` for invalid day of the year', function() {
-        var result = parse('0', 'D', baseDate, { awareOfUnicodeTokens: true })
+        var result = parse('0', 'D', baseDate, {
+          useAdditionalDayOfYearTokens: true
+        })
         assert(result instanceof Date && isNaN(result))
       })
 
       it('returns `Invalid Date` for 366th day of non-leap year', function() {
         var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1), {
-          awareOfUnicodeTokens: true
+          useAdditionalDayOfYearTokens: true
         })
         assert(result instanceof Date && isNaN(result))
       })
 
       it('parses 366th day of leap year', function() {
         var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1), {
-          awareOfUnicodeTokens: true
+          useAdditionalDayOfYearTokens: true
         })
         assert.deepEqual(result, new Date(2012, 11 /* Dec */, 31))
       })
@@ -1471,21 +1481,28 @@ describe('parse', function() {
       var result = parse('2016-11-05   \n', 'yyyy-MM-dd', baseDate)
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5))
     })
+
+    it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+      assert.throws(
+        parse.bind(null, '2016-11-05-nnnn', 'yyyy-MM-dd-nnnn', baseDate),
+        RangeError
+      )
+    })
   })
 
-  describe('awareOfUnicodeTokens option', () => {
+  describe('useAdditionalWeekYearTokens and useAdditionalDayOfYearTokens options', () => {
     it('throws an error if D token is used', () => {
       const block = parse.bind(null, '2016-11-5', 'yyyy-MM-D', baseDate)
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `D` token; see: https://git.io/fxCyr'
+        'Use `d` instead of `D` for formatting days of the month; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows D token if awareOfUnicodeTokens is set to true', () => {
+    it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = parse('2016-11-5', 'yyyy-MM-D', new Date(1987, 1, 11), {
-        awareOfUnicodeTokens: true
+        useAdditionalDayOfYearTokens: true
       })
       assert.deepEqual(result, new Date(2016, 0, 5))
     })
@@ -1495,13 +1512,13 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `DD` token; see: https://git.io/fxCyr'
+        'Use `dd` instead of `DD` for formatting days of the month; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows DD token if awareOfUnicodeTokens is set to true', () => {
+    it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = parse('2016-11-05', 'yyyy-MM-DD', new Date(1987, 1, 11), {
-        awareOfUnicodeTokens: true
+        useAdditionalDayOfYearTokens: true
       })
       assert.deepEqual(result, new Date(2016, 0, 5))
     })
@@ -1511,13 +1528,13 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+        'Use `yy` instead of `YY` for formating years; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows YY token if awareOfUnicodeTokens is set to true', () => {
+    it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = parse('16-11-05', 'YY-MM-dd', new Date(1987, 1, 11), {
-        awareOfUnicodeTokens: true
+        useAdditionalWeekYearTokens: true
       })
       assert.deepEqual(result, new Date(2015, 10, 5))
     })
@@ -1527,13 +1544,13 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        '`options.awareOfUnicodeTokens` must be set to `true` to use `YY` token; see: https://git.io/fxCyr'
+        'Use `yyyy` instead of `YYYY` for formating years; see: https://git.io/fxCyr'
       )
     })
 
-    it('allows YYYY token if awareOfUnicodeTokens is set to true', () => {
+    it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = parse('2016-11-05', 'YYYY-MM-dd', new Date(1987, 1, 11), {
-        awareOfUnicodeTokens: true
+        useAdditionalWeekYearTokens: true
       })
       assert.deepEqual(result, new Date(2015, 10, 5))
     })


### PR DESCRIPTION
1) Throw RangeError if format string contains an unescaped latin alphabet character;
2) Add new options `useAdditionalWeekYearTokens` and `useAdditionalDayOfYearTokens` for `format` and `parse`. They are permanent API;
3) Remove `awareOfUnicodeTokens` option because it proved to be ineffective.

See #1056 issue for reasoning.