### PR TITLE
Fix pt-BR translation

### DIFF
--- a/src/locale/pt-BR/_lib/localize/index.js
+++ b/src/locale/pt-BR/_lib/localize/index.js
@@ -19,8 +19,8 @@ var monthValues = {
 }
 
 var dayValues = {
-  narrow: ['do', '2º', '3º', '4º', '5º', '6º', 'sá'],
-  short: ['do', '2º', '3º', '4º', '5º', '6º', 'sá'],
+  narrow: ['do', '2ª', '3ª', '4ª', '5ª', '6ª', 'sá'],
+  short: ['do', '2ª', '3ª', '4ª', '5ª', '6ª', 'sá'],
   abbreviated: ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'],
   wide: ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado']
 }

--- a/src/locale/pt-BR/_lib/match/index.js
+++ b/src/locale/pt-BR/_lib/match/index.js
@@ -34,8 +34,8 @@ var parseMonthPatterns = {
 }
 
 var matchDayPatterns = {
-  narrow: /^(dom|[23456]º?|s[aá]b)/i,
-  short: /^(dom|[23456]º?|s[aá]b)/i,
+  narrow: /^(dom|[23456]ª?|s[aá]b)/i,
+  short: /^(dom|[23456]ª?|s[aá]b)/i,
   abbreviated: /^(dom|seg|ter|qua|qui|sex|s[aá]b)/i,
   wide: /^(domingo|(segunda|ter[cç]a|quarta|quinta|sexta)([- ]feira)?|s[aá]bado)/i
 }

--- a/src/locale/pt-BR/test.js
+++ b/src/locale/pt-BR/test.js
@@ -372,12 +372,12 @@ describe('pt-BR locale', function () {
       })
 
       it('narrow', function () {
-        var result = parse('4º', 'EEEEE', baseDate, { locale: locale })
+        var result = parse('4ª', 'EEEEE', baseDate, { locale: locale })
         assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
       })
 
       it('short', function () {
-        var result = parse('5º', 'EEEEEE', baseDate, { locale: locale })
+        var result = parse('5ª', 'EEEEEE', baseDate, { locale: locale })
         assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
       })
     })


### PR DESCRIPTION
Since weekdays' names end with a (as in segunda, terça, quarta, quinta, sexta), it makes more sense to use the character ª instead of º