### PR TITLE
In buildLocalizeFn, fallback to defaultWidth if defaultFormattingWidth doesn't exist (fix #1058)

### DIFF
--- a/src/locale/_lib/buildLocalizeFn/index.js
+++ b/src/locale/_lib/buildLocalizeFn/index.js
@@ -1,16 +1,23 @@
-export default function buildLocalizeFn (args) {
-  return function (dirtyIndex, dirtyOptions) {
+export default function buildLocalizeFn(args) {
+  return function(dirtyIndex, dirtyOptions) {
     var options = dirtyOptions || {}
-    var width = options.width ? String(options.width) : args.defaultWidth
+
     var context = options.context ? String(options.context) : 'standalone'
 
     var valuesArray
     if (context === 'formatting' && args.formattingValues) {
-      valuesArray = args.formattingValues[width] || args.formattingValues[args.defaultFormattingWidth]
+      var defaultWidth = args.defaultFormattingWidth || args.defaultWidth
+      var width = options.width ? String(options.width) : defaultWidth
+      valuesArray =
+        args.formattingValues[width] || args.formattingValues[defaultWidth]
     } else {
-      valuesArray = args.values[width] || args.values[args.defaultWidth]
+      var defaultWidth = args.defaultWidth
+      var width = options.width ? String(options.width) : args.defaultWidth
+      valuesArray = args.values[width] || args.values[defaultWidth]
     }
-    var index = args.argumentCallback ? args.argumentCallback(dirtyIndex) : dirtyIndex
+    var index = args.argumentCallback
+      ? args.argumentCallback(dirtyIndex)
+      : dirtyIndex
     return valuesArray[index]
   }
 }


### PR DESCRIPTION
See #1058 for more details