### PR TITLE
Update formatLong for DE locale

### DIFF
--- a/src/locale/de/_lib/formatLong/index.js
+++ b/src/locale/de/_lib/formatLong/index.js
@@ -1,10 +1,11 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 
+// DIN 5008: https://de.wikipedia.org/wiki/Datumsformat#DIN_5008
 var dateFormats = {
-  full: 'EEEE, do MMMM, y',
-  long: 'do MMMM, y',
-  medium: 'd MMM, y',
-  short: 'dd.MM.y'
+  full: 'EEEE, do MMMM y', // Montag, 7. Januar 2018
+  long: 'do MMMM y',       // 7. Januar 2018
+  medium: 'do MMM. y',     // 7. Jan. 2018
+  short: 'dd.MM.y'         // 07.01.2018
 }
 
 var timeFormats = {
@@ -17,8 +18,8 @@ var timeFormats = {
 var dateTimeFormats = {
   full: "{{date}} 'um' {{time}}",
   long: "{{date}} 'um' {{time}}",
-  medium: '{{date}}, {{time}}',
-  short: '{{date}}, {{time}}'
+  medium: '{{date}} {{time}}',
+  short: '{{date}} {{time}}'
 }
 
 var formatLong = {

--- a/src/locale/de/test.js
+++ b/src/locale/de/test.js
@@ -135,17 +135,17 @@ describe('de locale', function () {
 
       it('medium date', function () {
         var result = format(date, 'PP', {locale: locale})
-        assert(result === '5 Apr, 1986')
+        assert(result === '5. Apr. 1986')
       })
 
       it('long date', function () {
         var result = format(date, 'PPP', {locale: locale})
-        assert(result === '5. April, 1986')
+        assert(result === '5. April 1986')
       })
 
       it('full date', function () {
         var result = format(date, 'PPPP', {locale: locale})
-        assert(result === 'Samstag, 5. April, 1986')
+        assert(result === 'Samstag, 5. April 1986')
       })
 
       it('short time', function () {
@@ -160,22 +160,22 @@ describe('de locale', function () {
 
       it('short date + time', function () {
         var result = format(date, 'Pp', {locale: locale})
-        assert(result === '05.04.1986, 10:32')
+        assert(result === '05.04.1986 10:32')
       })
 
       it('medium date + time', function () {
         var result = format(date, 'PPpp', {locale: locale})
-        assert(result === '5 Apr, 1986, 10:32:00')
+        assert(result === '5. Apr. 1986 10:32:00')
       })
 
       it('long date + time', function () {
         var result = format(date, 'PPPp', {locale: locale})
-        assert(result === '5. April, 1986 um 10:32')
+        assert(result === '5. April 1986 um 10:32')
       })
 
       it('full date + time', function () {
         var result = format(date, 'PPPPp', {locale: locale})
-        assert(result === 'Samstag, 5. April, 1986 um 10:32')
+        assert(result === 'Samstag, 5. April 1986 um 10:32')
       })
     })
   })


### PR DESCRIPTION
I updated the de locale to use the format defined in [DIN 5008](https://en.wikipedia.org/wiki/DIN_5008) which is a german standard for writing and layout rules. In the [german date format wikipedia entry](https://de.wikipedia.org/wiki/Datumsformat#DIN_5008) you can see some examples for DIN 5008 formated dates.