### PR TITLE
Treat invalid time as InvalidDate in parseISO

### DIFF
--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -120,7 +120,7 @@ export default function parseISO(argument, dirtyOptions) {
 
   if (dateStrings.time) {
     time = parseTime(dateStrings.time)
-    if (isNaN(time)) {
+    if (isNaN(time) || time === null) {
       return new Date(NaN)
     }
   }

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -314,6 +314,12 @@ describe('parseISO', () => {
         assert(result instanceof Date)
         assert(isNaN(result))
       })
+
+      it('returns `Invalid Date` for invalid time', () => {
+        const result = parseISO('2014-02-11T21:basketball')
+        assert(result instanceof Date)
+        assert(isNaN(result))
+      })
     })
 
     describe('timezones', () => {


### PR DESCRIPTION
When a date string with an invalid time is provided to `parseISO` it should return `InvalidDate`.