### PR TITLE
Use `export default` instead of `export =` in TypeScript definitions (closes #1128)

### DIFF
--- a/examples/typescript/misc.ts
+++ b/examples/typescript/misc.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns'
+import format from 'date-fns/format'
 
 const result = format(new Date(2017, 0, 25, 21, 28, 15), 'dd.MM.yyyy HH:mm:ss')
 console.log(result === '25.01.2017 21:28:15')

--- a/scripts/build/_lib/typings/typeScript.js
+++ b/scripts/build/_lib/typings/typeScript.js
@@ -105,14 +105,14 @@ function getTypeScriptDateFnsFPModuleDefinition(submodule, fns) {
   }
 }
 
-function getTypeScriptFnModuleDefinition(submodule, fnSuffix, isDefault, fn) {
+function getTypeScriptFnModuleDefinition(submodule, fnSuffix, fn) {
   const name = fn.content.name
   const moduleName = `date-fns${submodule}/${name}${fnSuffix}`
 
   const definition = formatBlock`
     declare module '${moduleName}' {
       import {${name}} from 'date-fns${submodule}'
-      export ${isDefault ? 'default' : '='} ${name}
+      export default ${name}
     }
   `
 
@@ -222,7 +222,7 @@ function getTypeScriptInterfaceDefinition(fn) {
 function generateTypescriptFnTyping(fn, aliasDeclarations) {
   const typingFile = formatTypeScriptFile`
     import {${fn.title}} from 'date-fns'
-    export = ${fn.title}
+    export default ${fn.title}
   `
   writeFile(`./src/${fn.title}/index.d.ts`, typingFile)
 }
@@ -230,7 +230,7 @@ function generateTypescriptFnTyping(fn, aliasDeclarations) {
 function generateTypescriptFPFnTyping(fn) {
   const typingFile = formatTypeScriptFile`
     import {${fn.title}} from 'date-fns/fp'
-    export = ${fn.title}
+    export default ${fn.title}
   `
   writeFile(`./src/fp/${fn.title}/index.d.ts`, typingFile)
 }
@@ -238,7 +238,7 @@ function generateTypescriptFPFnTyping(fn) {
 function generateTypescriptLocaleTyping(locale) {
   const typingFile = formatTypeScriptFile`
     import {${locale.name}} from 'date-fns/locale'
-    export = ${locale.name}
+    export default ${locale.name}
   `
   writeFile(`src/locale/${locale.code}/index.d.ts`, typingFile)
 }
@@ -248,18 +248,12 @@ function generateTypeScriptTypings(fns, aliases, locales) {
   const fpFns = fns.filter(fn => fn.isFPFn)
 
   const moduleDefinitions = [getTypeScriptDateFnsModuleDefinition('', nonFPFns)]
+    .concat(nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '', '')))
     .concat(
-      nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '', '', false))
+      nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '', '/index'))
     )
     .concat(
-      nonFPFns.map(
-        getTypeScriptFnModuleDefinition.bind(null, '', '/index', false)
-      )
-    )
-    .concat(
-      nonFPFns.map(
-        getTypeScriptFnModuleDefinition.bind(null, '', '/index.js', false)
-      )
+      nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '', '/index.js'))
     )
     .map(module => module.definition)
 
@@ -285,16 +279,14 @@ function generateTypeScriptTypings(fns, aliases, locales) {
     getTypeScriptDateFnsModuleDefinition('/esm', nonFPFns)
   ]
     .concat(
-      nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '/esm', '', true))
+      nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '/esm', ''))
+    )
+    .concat(
+      nonFPFns.map(getTypeScriptFnModuleDefinition.bind(null, '/esm', '/index'))
     )
     .concat(
       nonFPFns.map(
-        getTypeScriptFnModuleDefinition.bind(null, '/esm', '/index', true)
-      )
-    )
-    .concat(
-      nonFPFns.map(
-        getTypeScriptFnModuleDefinition.bind(null, '/esm', '/index.js', true)
+        getTypeScriptFnModuleDefinition.bind(null, '/esm', '/index.js')
       )
     )
     .map(module => module.definition)

--- a/src/addDays/index.d.ts
+++ b/src/addDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addDays } from 'date-fns'
-export = addDays
+export default addDays

--- a/src/addHours/index.d.ts
+++ b/src/addHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addHours } from 'date-fns'
-export = addHours
+export default addHours

--- a/src/addISOWeekYears/index.d.ts
+++ b/src/addISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addISOWeekYears } from 'date-fns'
-export = addISOWeekYears
+export default addISOWeekYears

--- a/src/addMilliseconds/index.d.ts
+++ b/src/addMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addMilliseconds } from 'date-fns'
-export = addMilliseconds
+export default addMilliseconds

--- a/src/addMinutes/index.d.ts
+++ b/src/addMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addMinutes } from 'date-fns'
-export = addMinutes
+export default addMinutes

--- a/src/addMonths/index.d.ts
+++ b/src/addMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addMonths } from 'date-fns'
-export = addMonths
+export default addMonths

--- a/src/addQuarters/index.d.ts
+++ b/src/addQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addQuarters } from 'date-fns'
-export = addQuarters
+export default addQuarters

--- a/src/addSeconds/index.d.ts
+++ b/src/addSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addSeconds } from 'date-fns'
-export = addSeconds
+export default addSeconds

--- a/src/addWeeks/index.d.ts
+++ b/src/addWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addWeeks } from 'date-fns'
-export = addWeeks
+export default addWeeks

--- a/src/addYears/index.d.ts
+++ b/src/addYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addYears } from 'date-fns'
-export = addYears
+export default addYears

--- a/src/areIntervalsOverlapping/index.d.ts
+++ b/src/areIntervalsOverlapping/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { areIntervalsOverlapping } from 'date-fns'
-export = areIntervalsOverlapping
+export default areIntervalsOverlapping

--- a/src/closestIndexTo/index.d.ts
+++ b/src/closestIndexTo/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { closestIndexTo } from 'date-fns'
-export = closestIndexTo
+export default closestIndexTo

--- a/src/closestTo/index.d.ts
+++ b/src/closestTo/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { closestTo } from 'date-fns'
-export = closestTo
+export default closestTo

--- a/src/compareAsc/index.d.ts
+++ b/src/compareAsc/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { compareAsc } from 'date-fns'
-export = compareAsc
+export default compareAsc

--- a/src/compareDesc/index.d.ts
+++ b/src/compareDesc/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { compareDesc } from 'date-fns'
-export = compareDesc
+export default compareDesc

--- a/src/differenceInCalendarDays/index.d.ts
+++ b/src/differenceInCalendarDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarDays } from 'date-fns'
-export = differenceInCalendarDays
+export default differenceInCalendarDays

--- a/src/differenceInCalendarISOWeekYears/index.d.ts
+++ b/src/differenceInCalendarISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarISOWeekYears } from 'date-fns'
-export = differenceInCalendarISOWeekYears
+export default differenceInCalendarISOWeekYears

--- a/src/differenceInCalendarISOWeeks/index.d.ts
+++ b/src/differenceInCalendarISOWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarISOWeeks } from 'date-fns'
-export = differenceInCalendarISOWeeks
+export default differenceInCalendarISOWeeks

--- a/src/differenceInCalendarMonths/index.d.ts
+++ b/src/differenceInCalendarMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarMonths } from 'date-fns'
-export = differenceInCalendarMonths
+export default differenceInCalendarMonths

--- a/src/differenceInCalendarQuarters/index.d.ts
+++ b/src/differenceInCalendarQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarQuarters } from 'date-fns'
-export = differenceInCalendarQuarters
+export default differenceInCalendarQuarters

--- a/src/differenceInCalendarWeeks/index.d.ts
+++ b/src/differenceInCalendarWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarWeeks } from 'date-fns'
-export = differenceInCalendarWeeks
+export default differenceInCalendarWeeks

--- a/src/differenceInCalendarYears/index.d.ts
+++ b/src/differenceInCalendarYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarYears } from 'date-fns'
-export = differenceInCalendarYears
+export default differenceInCalendarYears

--- a/src/differenceInDays/index.d.ts
+++ b/src/differenceInDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInDays } from 'date-fns'
-export = differenceInDays
+export default differenceInDays

--- a/src/differenceInHours/index.d.ts
+++ b/src/differenceInHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInHours } from 'date-fns'
-export = differenceInHours
+export default differenceInHours

--- a/src/differenceInISOWeekYears/index.d.ts
+++ b/src/differenceInISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInISOWeekYears } from 'date-fns'
-export = differenceInISOWeekYears
+export default differenceInISOWeekYears

--- a/src/differenceInMilliseconds/index.d.ts
+++ b/src/differenceInMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInMilliseconds } from 'date-fns'
-export = differenceInMilliseconds
+export default differenceInMilliseconds

--- a/src/differenceInMinutes/index.d.ts
+++ b/src/differenceInMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInMinutes } from 'date-fns'
-export = differenceInMinutes
+export default differenceInMinutes

--- a/src/differenceInMonths/index.d.ts
+++ b/src/differenceInMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInMonths } from 'date-fns'
-export = differenceInMonths
+export default differenceInMonths

--- a/src/differenceInQuarters/index.d.ts
+++ b/src/differenceInQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInQuarters } from 'date-fns'
-export = differenceInQuarters
+export default differenceInQuarters

--- a/src/differenceInSeconds/index.d.ts
+++ b/src/differenceInSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInSeconds } from 'date-fns'
-export = differenceInSeconds
+export default differenceInSeconds

--- a/src/differenceInWeeks/index.d.ts
+++ b/src/differenceInWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInWeeks } from 'date-fns'
-export = differenceInWeeks
+export default differenceInWeeks

--- a/src/differenceInYears/index.d.ts
+++ b/src/differenceInYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInYears } from 'date-fns'
-export = differenceInYears
+export default differenceInYears

--- a/src/eachDayOfInterval/index.d.ts
+++ b/src/eachDayOfInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachDayOfInterval } from 'date-fns'
-export = eachDayOfInterval
+export default eachDayOfInterval

--- a/src/eachWeekOfInterval/index.d.ts
+++ b/src/eachWeekOfInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekOfInterval } from 'date-fns'
-export = eachWeekOfInterval
+export default eachWeekOfInterval

--- a/src/eachWeekendOfInterval/index.d.ts
+++ b/src/eachWeekendOfInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekendOfInterval } from 'date-fns'
-export = eachWeekendOfInterval
+export default eachWeekendOfInterval

--- a/src/eachWeekendOfMonth/index.d.ts
+++ b/src/eachWeekendOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekendOfMonth } from 'date-fns'
-export = eachWeekendOfMonth
+export default eachWeekendOfMonth

--- a/src/eachWeekendOfYear/index.d.ts
+++ b/src/eachWeekendOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekendOfYear } from 'date-fns'
-export = eachWeekendOfYear
+export default eachWeekendOfYear

--- a/src/endOfDay/index.d.ts
+++ b/src/endOfDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfDay } from 'date-fns'
-export = endOfDay
+export default endOfDay

--- a/src/endOfDecade/index.d.ts
+++ b/src/endOfDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfDecade } from 'date-fns'
-export = endOfDecade
+export default endOfDecade

--- a/src/endOfHour/index.d.ts
+++ b/src/endOfHour/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfHour } from 'date-fns'
-export = endOfHour
+export default endOfHour

--- a/src/endOfISOWeek/index.d.ts
+++ b/src/endOfISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfISOWeek } from 'date-fns'
-export = endOfISOWeek
+export default endOfISOWeek

--- a/src/endOfISOWeekYear/index.d.ts
+++ b/src/endOfISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfISOWeekYear } from 'date-fns'
-export = endOfISOWeekYear
+export default endOfISOWeekYear

--- a/src/endOfMinute/index.d.ts
+++ b/src/endOfMinute/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfMinute } from 'date-fns'
-export = endOfMinute
+export default endOfMinute

--- a/src/endOfMonth/index.d.ts
+++ b/src/endOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfMonth } from 'date-fns'
-export = endOfMonth
+export default endOfMonth

--- a/src/endOfQuarter/index.d.ts
+++ b/src/endOfQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfQuarter } from 'date-fns'
-export = endOfQuarter
+export default endOfQuarter

--- a/src/endOfSecond/index.d.ts
+++ b/src/endOfSecond/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfSecond } from 'date-fns'
-export = endOfSecond
+export default endOfSecond

--- a/src/endOfWeek/index.d.ts
+++ b/src/endOfWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfWeek } from 'date-fns'
-export = endOfWeek
+export default endOfWeek

--- a/src/endOfYear/index.d.ts
+++ b/src/endOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfYear } from 'date-fns'
-export = endOfYear
+export default endOfYear

--- a/src/format/index.d.ts
+++ b/src/format/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { format } from 'date-fns'
-export = format
+export default format

--- a/src/formatDistance/index.d.ts
+++ b/src/formatDistance/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatDistance } from 'date-fns'
-export = formatDistance
+export default formatDistance

--- a/src/formatDistanceStrict/index.d.ts
+++ b/src/formatDistanceStrict/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatDistanceStrict } from 'date-fns'
-export = formatDistanceStrict
+export default formatDistanceStrict

--- a/src/formatRelative/index.d.ts
+++ b/src/formatRelative/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatRelative } from 'date-fns'
-export = formatRelative
+export default formatRelative

--- a/src/fp/addDays/index.d.ts
+++ b/src/fp/addDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addDays } from 'date-fns/fp'
-export = addDays
+export default addDays

--- a/src/fp/addHours/index.d.ts
+++ b/src/fp/addHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addHours } from 'date-fns/fp'
-export = addHours
+export default addHours

--- a/src/fp/addISOWeekYears/index.d.ts
+++ b/src/fp/addISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addISOWeekYears } from 'date-fns/fp'
-export = addISOWeekYears
+export default addISOWeekYears

--- a/src/fp/addMilliseconds/index.d.ts
+++ b/src/fp/addMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addMilliseconds } from 'date-fns/fp'
-export = addMilliseconds
+export default addMilliseconds

--- a/src/fp/addMinutes/index.d.ts
+++ b/src/fp/addMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addMinutes } from 'date-fns/fp'
-export = addMinutes
+export default addMinutes

--- a/src/fp/addMonths/index.d.ts
+++ b/src/fp/addMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addMonths } from 'date-fns/fp'
-export = addMonths
+export default addMonths

--- a/src/fp/addQuarters/index.d.ts
+++ b/src/fp/addQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addQuarters } from 'date-fns/fp'
-export = addQuarters
+export default addQuarters

--- a/src/fp/addSeconds/index.d.ts
+++ b/src/fp/addSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addSeconds } from 'date-fns/fp'
-export = addSeconds
+export default addSeconds

--- a/src/fp/addWeeks/index.d.ts
+++ b/src/fp/addWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addWeeks } from 'date-fns/fp'
-export = addWeeks
+export default addWeeks

--- a/src/fp/addYears/index.d.ts
+++ b/src/fp/addYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { addYears } from 'date-fns/fp'
-export = addYears
+export default addYears

--- a/src/fp/areIntervalsOverlapping/index.d.ts
+++ b/src/fp/areIntervalsOverlapping/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { areIntervalsOverlapping } from 'date-fns/fp'
-export = areIntervalsOverlapping
+export default areIntervalsOverlapping

--- a/src/fp/closestIndexTo/index.d.ts
+++ b/src/fp/closestIndexTo/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { closestIndexTo } from 'date-fns/fp'
-export = closestIndexTo
+export default closestIndexTo

--- a/src/fp/closestTo/index.d.ts
+++ b/src/fp/closestTo/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { closestTo } from 'date-fns/fp'
-export = closestTo
+export default closestTo

--- a/src/fp/compareAsc/index.d.ts
+++ b/src/fp/compareAsc/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { compareAsc } from 'date-fns/fp'
-export = compareAsc
+export default compareAsc

--- a/src/fp/compareDesc/index.d.ts
+++ b/src/fp/compareDesc/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { compareDesc } from 'date-fns/fp'
-export = compareDesc
+export default compareDesc

--- a/src/fp/differenceInCalendarDays/index.d.ts
+++ b/src/fp/differenceInCalendarDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarDays } from 'date-fns/fp'
-export = differenceInCalendarDays
+export default differenceInCalendarDays

--- a/src/fp/differenceInCalendarISOWeekYears/index.d.ts
+++ b/src/fp/differenceInCalendarISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarISOWeekYears } from 'date-fns/fp'
-export = differenceInCalendarISOWeekYears
+export default differenceInCalendarISOWeekYears

--- a/src/fp/differenceInCalendarISOWeeks/index.d.ts
+++ b/src/fp/differenceInCalendarISOWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarISOWeeks } from 'date-fns/fp'
-export = differenceInCalendarISOWeeks
+export default differenceInCalendarISOWeeks

--- a/src/fp/differenceInCalendarMonths/index.d.ts
+++ b/src/fp/differenceInCalendarMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarMonths } from 'date-fns/fp'
-export = differenceInCalendarMonths
+export default differenceInCalendarMonths

--- a/src/fp/differenceInCalendarQuarters/index.d.ts
+++ b/src/fp/differenceInCalendarQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarQuarters } from 'date-fns/fp'
-export = differenceInCalendarQuarters
+export default differenceInCalendarQuarters

--- a/src/fp/differenceInCalendarWeeks/index.d.ts
+++ b/src/fp/differenceInCalendarWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarWeeks } from 'date-fns/fp'
-export = differenceInCalendarWeeks
+export default differenceInCalendarWeeks

--- a/src/fp/differenceInCalendarWeeksWithOptions/index.d.ts
+++ b/src/fp/differenceInCalendarWeeksWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarWeeksWithOptions } from 'date-fns/fp'
-export = differenceInCalendarWeeksWithOptions
+export default differenceInCalendarWeeksWithOptions

--- a/src/fp/differenceInCalendarYears/index.d.ts
+++ b/src/fp/differenceInCalendarYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInCalendarYears } from 'date-fns/fp'
-export = differenceInCalendarYears
+export default differenceInCalendarYears

--- a/src/fp/differenceInDays/index.d.ts
+++ b/src/fp/differenceInDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInDays } from 'date-fns/fp'
-export = differenceInDays
+export default differenceInDays

--- a/src/fp/differenceInHours/index.d.ts
+++ b/src/fp/differenceInHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInHours } from 'date-fns/fp'
-export = differenceInHours
+export default differenceInHours

--- a/src/fp/differenceInISOWeekYears/index.d.ts
+++ b/src/fp/differenceInISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInISOWeekYears } from 'date-fns/fp'
-export = differenceInISOWeekYears
+export default differenceInISOWeekYears

--- a/src/fp/differenceInMilliseconds/index.d.ts
+++ b/src/fp/differenceInMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInMilliseconds } from 'date-fns/fp'
-export = differenceInMilliseconds
+export default differenceInMilliseconds

--- a/src/fp/differenceInMinutes/index.d.ts
+++ b/src/fp/differenceInMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInMinutes } from 'date-fns/fp'
-export = differenceInMinutes
+export default differenceInMinutes

--- a/src/fp/differenceInMonths/index.d.ts
+++ b/src/fp/differenceInMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInMonths } from 'date-fns/fp'
-export = differenceInMonths
+export default differenceInMonths

--- a/src/fp/differenceInQuarters/index.d.ts
+++ b/src/fp/differenceInQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInQuarters } from 'date-fns/fp'
-export = differenceInQuarters
+export default differenceInQuarters

--- a/src/fp/differenceInSeconds/index.d.ts
+++ b/src/fp/differenceInSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInSeconds } from 'date-fns/fp'
-export = differenceInSeconds
+export default differenceInSeconds

--- a/src/fp/differenceInWeeks/index.d.ts
+++ b/src/fp/differenceInWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInWeeks } from 'date-fns/fp'
-export = differenceInWeeks
+export default differenceInWeeks

--- a/src/fp/differenceInYears/index.d.ts
+++ b/src/fp/differenceInYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { differenceInYears } from 'date-fns/fp'
-export = differenceInYears
+export default differenceInYears

--- a/src/fp/eachDayOfInterval/index.d.ts
+++ b/src/fp/eachDayOfInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachDayOfInterval } from 'date-fns/fp'
-export = eachDayOfInterval
+export default eachDayOfInterval

--- a/src/fp/eachDayOfIntervalWithOptions/index.d.ts
+++ b/src/fp/eachDayOfIntervalWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachDayOfIntervalWithOptions } from 'date-fns/fp'
-export = eachDayOfIntervalWithOptions
+export default eachDayOfIntervalWithOptions

--- a/src/fp/eachWeekOfInterval/index.d.ts
+++ b/src/fp/eachWeekOfInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekOfInterval } from 'date-fns/fp'
-export = eachWeekOfInterval
+export default eachWeekOfInterval

--- a/src/fp/eachWeekOfIntervalWithOptions/index.d.ts
+++ b/src/fp/eachWeekOfIntervalWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekOfIntervalWithOptions } from 'date-fns/fp'
-export = eachWeekOfIntervalWithOptions
+export default eachWeekOfIntervalWithOptions

--- a/src/fp/eachWeekendOfInterval/index.d.ts
+++ b/src/fp/eachWeekendOfInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekendOfInterval } from 'date-fns/fp'
-export = eachWeekendOfInterval
+export default eachWeekendOfInterval

--- a/src/fp/eachWeekendOfMonth/index.d.ts
+++ b/src/fp/eachWeekendOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekendOfMonth } from 'date-fns/fp'
-export = eachWeekendOfMonth
+export default eachWeekendOfMonth

--- a/src/fp/eachWeekendOfYear/index.d.ts
+++ b/src/fp/eachWeekendOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eachWeekendOfYear } from 'date-fns/fp'
-export = eachWeekendOfYear
+export default eachWeekendOfYear

--- a/src/fp/endOfDay/index.d.ts
+++ b/src/fp/endOfDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfDay } from 'date-fns/fp'
-export = endOfDay
+export default endOfDay

--- a/src/fp/endOfDecade/index.d.ts
+++ b/src/fp/endOfDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfDecade } from 'date-fns/fp'
-export = endOfDecade
+export default endOfDecade

--- a/src/fp/endOfDecadeWithOptions/index.d.ts
+++ b/src/fp/endOfDecadeWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfDecadeWithOptions } from 'date-fns/fp'
-export = endOfDecadeWithOptions
+export default endOfDecadeWithOptions

--- a/src/fp/endOfHour/index.d.ts
+++ b/src/fp/endOfHour/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfHour } from 'date-fns/fp'
-export = endOfHour
+export default endOfHour

--- a/src/fp/endOfISOWeek/index.d.ts
+++ b/src/fp/endOfISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfISOWeek } from 'date-fns/fp'
-export = endOfISOWeek
+export default endOfISOWeek

--- a/src/fp/endOfISOWeekYear/index.d.ts
+++ b/src/fp/endOfISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfISOWeekYear } from 'date-fns/fp'
-export = endOfISOWeekYear
+export default endOfISOWeekYear

--- a/src/fp/endOfMinute/index.d.ts
+++ b/src/fp/endOfMinute/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfMinute } from 'date-fns/fp'
-export = endOfMinute
+export default endOfMinute

--- a/src/fp/endOfMonth/index.d.ts
+++ b/src/fp/endOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfMonth } from 'date-fns/fp'
-export = endOfMonth
+export default endOfMonth

--- a/src/fp/endOfQuarter/index.d.ts
+++ b/src/fp/endOfQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfQuarter } from 'date-fns/fp'
-export = endOfQuarter
+export default endOfQuarter

--- a/src/fp/endOfSecond/index.d.ts
+++ b/src/fp/endOfSecond/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfSecond } from 'date-fns/fp'
-export = endOfSecond
+export default endOfSecond

--- a/src/fp/endOfWeek/index.d.ts
+++ b/src/fp/endOfWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfWeek } from 'date-fns/fp'
-export = endOfWeek
+export default endOfWeek

--- a/src/fp/endOfWeekWithOptions/index.d.ts
+++ b/src/fp/endOfWeekWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfWeekWithOptions } from 'date-fns/fp'
-export = endOfWeekWithOptions
+export default endOfWeekWithOptions

--- a/src/fp/endOfYear/index.d.ts
+++ b/src/fp/endOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { endOfYear } from 'date-fns/fp'
-export = endOfYear
+export default endOfYear

--- a/src/fp/format/index.d.ts
+++ b/src/fp/format/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { format } from 'date-fns/fp'
-export = format
+export default format

--- a/src/fp/formatDistance/index.d.ts
+++ b/src/fp/formatDistance/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatDistance } from 'date-fns/fp'
-export = formatDistance
+export default formatDistance

--- a/src/fp/formatDistanceStrict/index.d.ts
+++ b/src/fp/formatDistanceStrict/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatDistanceStrict } from 'date-fns/fp'
-export = formatDistanceStrict
+export default formatDistanceStrict

--- a/src/fp/formatDistanceStrictWithOptions/index.d.ts
+++ b/src/fp/formatDistanceStrictWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatDistanceStrictWithOptions } from 'date-fns/fp'
-export = formatDistanceStrictWithOptions
+export default formatDistanceStrictWithOptions

--- a/src/fp/formatDistanceWithOptions/index.d.ts
+++ b/src/fp/formatDistanceWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatDistanceWithOptions } from 'date-fns/fp'
-export = formatDistanceWithOptions
+export default formatDistanceWithOptions

--- a/src/fp/formatRelative/index.d.ts
+++ b/src/fp/formatRelative/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatRelative } from 'date-fns/fp'
-export = formatRelative
+export default formatRelative

--- a/src/fp/formatRelativeWithOptions/index.d.ts
+++ b/src/fp/formatRelativeWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatRelativeWithOptions } from 'date-fns/fp'
-export = formatRelativeWithOptions
+export default formatRelativeWithOptions

--- a/src/fp/formatWithOptions/index.d.ts
+++ b/src/fp/formatWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { formatWithOptions } from 'date-fns/fp'
-export = formatWithOptions
+export default formatWithOptions

--- a/src/fp/fromUnixTime/index.d.ts
+++ b/src/fp/fromUnixTime/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { fromUnixTime } from 'date-fns/fp'
-export = fromUnixTime
+export default fromUnixTime

--- a/src/fp/getDate/index.d.ts
+++ b/src/fp/getDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDate } from 'date-fns/fp'
-export = getDate
+export default getDate

--- a/src/fp/getDay/index.d.ts
+++ b/src/fp/getDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDay } from 'date-fns/fp'
-export = getDay
+export default getDay

--- a/src/fp/getDayOfYear/index.d.ts
+++ b/src/fp/getDayOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDayOfYear } from 'date-fns/fp'
-export = getDayOfYear
+export default getDayOfYear

--- a/src/fp/getDaysInMonth/index.d.ts
+++ b/src/fp/getDaysInMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDaysInMonth } from 'date-fns/fp'
-export = getDaysInMonth
+export default getDaysInMonth

--- a/src/fp/getDaysInYear/index.d.ts
+++ b/src/fp/getDaysInYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDaysInYear } from 'date-fns/fp'
-export = getDaysInYear
+export default getDaysInYear

--- a/src/fp/getDecade/index.d.ts
+++ b/src/fp/getDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDecade } from 'date-fns/fp'
-export = getDecade
+export default getDecade

--- a/src/fp/getHours/index.d.ts
+++ b/src/fp/getHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getHours } from 'date-fns/fp'
-export = getHours
+export default getHours

--- a/src/fp/getISODay/index.d.ts
+++ b/src/fp/getISODay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISODay } from 'date-fns/fp'
-export = getISODay
+export default getISODay

--- a/src/fp/getISOWeek/index.d.ts
+++ b/src/fp/getISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISOWeek } from 'date-fns/fp'
-export = getISOWeek
+export default getISOWeek

--- a/src/fp/getISOWeekYear/index.d.ts
+++ b/src/fp/getISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISOWeekYear } from 'date-fns/fp'
-export = getISOWeekYear
+export default getISOWeekYear

--- a/src/fp/getISOWeeksInYear/index.d.ts
+++ b/src/fp/getISOWeeksInYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISOWeeksInYear } from 'date-fns/fp'
-export = getISOWeeksInYear
+export default getISOWeeksInYear

--- a/src/fp/getMilliseconds/index.d.ts
+++ b/src/fp/getMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getMilliseconds } from 'date-fns/fp'
-export = getMilliseconds
+export default getMilliseconds

--- a/src/fp/getMinutes/index.d.ts
+++ b/src/fp/getMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getMinutes } from 'date-fns/fp'
-export = getMinutes
+export default getMinutes

--- a/src/fp/getMonth/index.d.ts
+++ b/src/fp/getMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getMonth } from 'date-fns/fp'
-export = getMonth
+export default getMonth

--- a/src/fp/getOverlappingDaysInIntervals/index.d.ts
+++ b/src/fp/getOverlappingDaysInIntervals/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getOverlappingDaysInIntervals } from 'date-fns/fp'
-export = getOverlappingDaysInIntervals
+export default getOverlappingDaysInIntervals

--- a/src/fp/getQuarter/index.d.ts
+++ b/src/fp/getQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getQuarter } from 'date-fns/fp'
-export = getQuarter
+export default getQuarter

--- a/src/fp/getSeconds/index.d.ts
+++ b/src/fp/getSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getSeconds } from 'date-fns/fp'
-export = getSeconds
+export default getSeconds

--- a/src/fp/getTime/index.d.ts
+++ b/src/fp/getTime/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getTime } from 'date-fns/fp'
-export = getTime
+export default getTime

--- a/src/fp/getUnixTime/index.d.ts
+++ b/src/fp/getUnixTime/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getUnixTime } from 'date-fns/fp'
-export = getUnixTime
+export default getUnixTime

--- a/src/fp/getWeek/index.d.ts
+++ b/src/fp/getWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeek } from 'date-fns/fp'
-export = getWeek
+export default getWeek

--- a/src/fp/getWeekOfMonth/index.d.ts
+++ b/src/fp/getWeekOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekOfMonth } from 'date-fns/fp'
-export = getWeekOfMonth
+export default getWeekOfMonth

--- a/src/fp/getWeekOfMonthWithOptions/index.d.ts
+++ b/src/fp/getWeekOfMonthWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekOfMonthWithOptions } from 'date-fns/fp'
-export = getWeekOfMonthWithOptions
+export default getWeekOfMonthWithOptions

--- a/src/fp/getWeekWithOptions/index.d.ts
+++ b/src/fp/getWeekWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekWithOptions } from 'date-fns/fp'
-export = getWeekWithOptions
+export default getWeekWithOptions

--- a/src/fp/getWeekYear/index.d.ts
+++ b/src/fp/getWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekYear } from 'date-fns/fp'
-export = getWeekYear
+export default getWeekYear

--- a/src/fp/getWeekYearWithOptions/index.d.ts
+++ b/src/fp/getWeekYearWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekYearWithOptions } from 'date-fns/fp'
-export = getWeekYearWithOptions
+export default getWeekYearWithOptions

--- a/src/fp/getWeeksInMonth/index.d.ts
+++ b/src/fp/getWeeksInMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeeksInMonth } from 'date-fns/fp'
-export = getWeeksInMonth
+export default getWeeksInMonth

--- a/src/fp/getWeeksInMonthWithOptions/index.d.ts
+++ b/src/fp/getWeeksInMonthWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeeksInMonthWithOptions } from 'date-fns/fp'
-export = getWeeksInMonthWithOptions
+export default getWeeksInMonthWithOptions

--- a/src/fp/getYear/index.d.ts
+++ b/src/fp/getYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getYear } from 'date-fns/fp'
-export = getYear
+export default getYear

--- a/src/fp/isAfter/index.d.ts
+++ b/src/fp/isAfter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isAfter } from 'date-fns/fp'
-export = isAfter
+export default isAfter

--- a/src/fp/isBefore/index.d.ts
+++ b/src/fp/isBefore/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isBefore } from 'date-fns/fp'
-export = isBefore
+export default isBefore

--- a/src/fp/isDate/index.d.ts
+++ b/src/fp/isDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isDate } from 'date-fns/fp'
-export = isDate
+export default isDate

--- a/src/fp/isEqual/index.d.ts
+++ b/src/fp/isEqual/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isEqual } from 'date-fns/fp'
-export = isEqual
+export default isEqual

--- a/src/fp/isFirstDayOfMonth/index.d.ts
+++ b/src/fp/isFirstDayOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isFirstDayOfMonth } from 'date-fns/fp'
-export = isFirstDayOfMonth
+export default isFirstDayOfMonth

--- a/src/fp/isFriday/index.d.ts
+++ b/src/fp/isFriday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isFriday } from 'date-fns/fp'
-export = isFriday
+export default isFriday

--- a/src/fp/isLastDayOfMonth/index.d.ts
+++ b/src/fp/isLastDayOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isLastDayOfMonth } from 'date-fns/fp'
-export = isLastDayOfMonth
+export default isLastDayOfMonth

--- a/src/fp/isLeapYear/index.d.ts
+++ b/src/fp/isLeapYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isLeapYear } from 'date-fns/fp'
-export = isLeapYear
+export default isLeapYear

--- a/src/fp/isMonday/index.d.ts
+++ b/src/fp/isMonday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isMonday } from 'date-fns/fp'
-export = isMonday
+export default isMonday

--- a/src/fp/isSameDay/index.d.ts
+++ b/src/fp/isSameDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameDay } from 'date-fns/fp'
-export = isSameDay
+export default isSameDay

--- a/src/fp/isSameHour/index.d.ts
+++ b/src/fp/isSameHour/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameHour } from 'date-fns/fp'
-export = isSameHour
+export default isSameHour

--- a/src/fp/isSameISOWeek/index.d.ts
+++ b/src/fp/isSameISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameISOWeek } from 'date-fns/fp'
-export = isSameISOWeek
+export default isSameISOWeek

--- a/src/fp/isSameISOWeekYear/index.d.ts
+++ b/src/fp/isSameISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameISOWeekYear } from 'date-fns/fp'
-export = isSameISOWeekYear
+export default isSameISOWeekYear

--- a/src/fp/isSameMinute/index.d.ts
+++ b/src/fp/isSameMinute/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameMinute } from 'date-fns/fp'
-export = isSameMinute
+export default isSameMinute

--- a/src/fp/isSameMonth/index.d.ts
+++ b/src/fp/isSameMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameMonth } from 'date-fns/fp'
-export = isSameMonth
+export default isSameMonth

--- a/src/fp/isSameQuarter/index.d.ts
+++ b/src/fp/isSameQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameQuarter } from 'date-fns/fp'
-export = isSameQuarter
+export default isSameQuarter

--- a/src/fp/isSameSecond/index.d.ts
+++ b/src/fp/isSameSecond/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameSecond } from 'date-fns/fp'
-export = isSameSecond
+export default isSameSecond

--- a/src/fp/isSameWeek/index.d.ts
+++ b/src/fp/isSameWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameWeek } from 'date-fns/fp'
-export = isSameWeek
+export default isSameWeek

--- a/src/fp/isSameWeekWithOptions/index.d.ts
+++ b/src/fp/isSameWeekWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameWeekWithOptions } from 'date-fns/fp'
-export = isSameWeekWithOptions
+export default isSameWeekWithOptions

--- a/src/fp/isSameYear/index.d.ts
+++ b/src/fp/isSameYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameYear } from 'date-fns/fp'
-export = isSameYear
+export default isSameYear

--- a/src/fp/isSaturday/index.d.ts
+++ b/src/fp/isSaturday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSaturday } from 'date-fns/fp'
-export = isSaturday
+export default isSaturday

--- a/src/fp/isSunday/index.d.ts
+++ b/src/fp/isSunday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSunday } from 'date-fns/fp'
-export = isSunday
+export default isSunday

--- a/src/fp/isThursday/index.d.ts
+++ b/src/fp/isThursday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isThursday } from 'date-fns/fp'
-export = isThursday
+export default isThursday

--- a/src/fp/isTuesday/index.d.ts
+++ b/src/fp/isTuesday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isTuesday } from 'date-fns/fp'
-export = isTuesday
+export default isTuesday

--- a/src/fp/isValid/index.d.ts
+++ b/src/fp/isValid/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isValid } from 'date-fns/fp'
-export = isValid
+export default isValid

--- a/src/fp/isWednesday/index.d.ts
+++ b/src/fp/isWednesday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isWednesday } from 'date-fns/fp'
-export = isWednesday
+export default isWednesday

--- a/src/fp/isWeekend/index.d.ts
+++ b/src/fp/isWeekend/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isWeekend } from 'date-fns/fp'
-export = isWeekend
+export default isWeekend

--- a/src/fp/isWithinInterval/index.d.ts
+++ b/src/fp/isWithinInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isWithinInterval } from 'date-fns/fp'
-export = isWithinInterval
+export default isWithinInterval

--- a/src/fp/lastDayOfDecade/index.d.ts
+++ b/src/fp/lastDayOfDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfDecade } from 'date-fns/fp'
-export = lastDayOfDecade
+export default lastDayOfDecade

--- a/src/fp/lastDayOfISOWeek/index.d.ts
+++ b/src/fp/lastDayOfISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfISOWeek } from 'date-fns/fp'
-export = lastDayOfISOWeek
+export default lastDayOfISOWeek

--- a/src/fp/lastDayOfISOWeekYear/index.d.ts
+++ b/src/fp/lastDayOfISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfISOWeekYear } from 'date-fns/fp'
-export = lastDayOfISOWeekYear
+export default lastDayOfISOWeekYear

--- a/src/fp/lastDayOfMonth/index.d.ts
+++ b/src/fp/lastDayOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfMonth } from 'date-fns/fp'
-export = lastDayOfMonth
+export default lastDayOfMonth

--- a/src/fp/lastDayOfQuarter/index.d.ts
+++ b/src/fp/lastDayOfQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfQuarter } from 'date-fns/fp'
-export = lastDayOfQuarter
+export default lastDayOfQuarter

--- a/src/fp/lastDayOfQuarterWithOptions/index.d.ts
+++ b/src/fp/lastDayOfQuarterWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfQuarterWithOptions } from 'date-fns/fp'
-export = lastDayOfQuarterWithOptions
+export default lastDayOfQuarterWithOptions

--- a/src/fp/lastDayOfWeek/index.d.ts
+++ b/src/fp/lastDayOfWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfWeek } from 'date-fns/fp'
-export = lastDayOfWeek
+export default lastDayOfWeek

--- a/src/fp/lastDayOfWeekWithOptions/index.d.ts
+++ b/src/fp/lastDayOfWeekWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfWeekWithOptions } from 'date-fns/fp'
-export = lastDayOfWeekWithOptions
+export default lastDayOfWeekWithOptions

--- a/src/fp/lastDayOfYear/index.d.ts
+++ b/src/fp/lastDayOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfYear } from 'date-fns/fp'
-export = lastDayOfYear
+export default lastDayOfYear

--- a/src/fp/lightFormat/index.d.ts
+++ b/src/fp/lightFormat/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lightFormat } from 'date-fns/fp'
-export = lightFormat
+export default lightFormat

--- a/src/fp/max/index.d.ts
+++ b/src/fp/max/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { max } from 'date-fns/fp'
-export = max
+export default max

--- a/src/fp/min/index.d.ts
+++ b/src/fp/min/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { min } from 'date-fns/fp'
-export = min
+export default min

--- a/src/fp/parse/index.d.ts
+++ b/src/fp/parse/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { parse } from 'date-fns/fp'
-export = parse
+export default parse

--- a/src/fp/parseISO/index.d.ts
+++ b/src/fp/parseISO/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { parseISO } from 'date-fns/fp'
-export = parseISO
+export default parseISO

--- a/src/fp/parseISOWithOptions/index.d.ts
+++ b/src/fp/parseISOWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { parseISOWithOptions } from 'date-fns/fp'
-export = parseISOWithOptions
+export default parseISOWithOptions

--- a/src/fp/parseWithOptions/index.d.ts
+++ b/src/fp/parseWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { parseWithOptions } from 'date-fns/fp'
-export = parseWithOptions
+export default parseWithOptions

--- a/src/fp/roundToNearestMinutes/index.d.ts
+++ b/src/fp/roundToNearestMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { roundToNearestMinutes } from 'date-fns/fp'
-export = roundToNearestMinutes
+export default roundToNearestMinutes

--- a/src/fp/roundToNearestMinutesWithOptions/index.d.ts
+++ b/src/fp/roundToNearestMinutesWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { roundToNearestMinutesWithOptions } from 'date-fns/fp'
-export = roundToNearestMinutesWithOptions
+export default roundToNearestMinutesWithOptions

--- a/src/fp/setDate/index.d.ts
+++ b/src/fp/setDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDate } from 'date-fns/fp'
-export = setDate
+export default setDate

--- a/src/fp/setDay/index.d.ts
+++ b/src/fp/setDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDay } from 'date-fns/fp'
-export = setDay
+export default setDay

--- a/src/fp/setDayOfYear/index.d.ts
+++ b/src/fp/setDayOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDayOfYear } from 'date-fns/fp'
-export = setDayOfYear
+export default setDayOfYear

--- a/src/fp/setDayWithOptions/index.d.ts
+++ b/src/fp/setDayWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDayWithOptions } from 'date-fns/fp'
-export = setDayWithOptions
+export default setDayWithOptions

--- a/src/fp/setHours/index.d.ts
+++ b/src/fp/setHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setHours } from 'date-fns/fp'
-export = setHours
+export default setHours

--- a/src/fp/setISODay/index.d.ts
+++ b/src/fp/setISODay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setISODay } from 'date-fns/fp'
-export = setISODay
+export default setISODay

--- a/src/fp/setISOWeek/index.d.ts
+++ b/src/fp/setISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setISOWeek } from 'date-fns/fp'
-export = setISOWeek
+export default setISOWeek

--- a/src/fp/setISOWeekYear/index.d.ts
+++ b/src/fp/setISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setISOWeekYear } from 'date-fns/fp'
-export = setISOWeekYear
+export default setISOWeekYear

--- a/src/fp/setMilliseconds/index.d.ts
+++ b/src/fp/setMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setMilliseconds } from 'date-fns/fp'
-export = setMilliseconds
+export default setMilliseconds

--- a/src/fp/setMinutes/index.d.ts
+++ b/src/fp/setMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setMinutes } from 'date-fns/fp'
-export = setMinutes
+export default setMinutes

--- a/src/fp/setMonth/index.d.ts
+++ b/src/fp/setMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setMonth } from 'date-fns/fp'
-export = setMonth
+export default setMonth

--- a/src/fp/setQuarter/index.d.ts
+++ b/src/fp/setQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setQuarter } from 'date-fns/fp'
-export = setQuarter
+export default setQuarter

--- a/src/fp/setSeconds/index.d.ts
+++ b/src/fp/setSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setSeconds } from 'date-fns/fp'
-export = setSeconds
+export default setSeconds

--- a/src/fp/setWeek/index.d.ts
+++ b/src/fp/setWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setWeek } from 'date-fns/fp'
-export = setWeek
+export default setWeek

--- a/src/fp/setWeekWithOptions/index.d.ts
+++ b/src/fp/setWeekWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setWeekWithOptions } from 'date-fns/fp'
-export = setWeekWithOptions
+export default setWeekWithOptions

--- a/src/fp/setWeekYear/index.d.ts
+++ b/src/fp/setWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setWeekYear } from 'date-fns/fp'
-export = setWeekYear
+export default setWeekYear

--- a/src/fp/setWeekYearWithOptions/index.d.ts
+++ b/src/fp/setWeekYearWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setWeekYearWithOptions } from 'date-fns/fp'
-export = setWeekYearWithOptions
+export default setWeekYearWithOptions

--- a/src/fp/setYear/index.d.ts
+++ b/src/fp/setYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setYear } from 'date-fns/fp'
-export = setYear
+export default setYear

--- a/src/fp/startOfDay/index.d.ts
+++ b/src/fp/startOfDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfDay } from 'date-fns/fp'
-export = startOfDay
+export default startOfDay

--- a/src/fp/startOfDecade/index.d.ts
+++ b/src/fp/startOfDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfDecade } from 'date-fns/fp'
-export = startOfDecade
+export default startOfDecade

--- a/src/fp/startOfHour/index.d.ts
+++ b/src/fp/startOfHour/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfHour } from 'date-fns/fp'
-export = startOfHour
+export default startOfHour

--- a/src/fp/startOfISOWeek/index.d.ts
+++ b/src/fp/startOfISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfISOWeek } from 'date-fns/fp'
-export = startOfISOWeek
+export default startOfISOWeek

--- a/src/fp/startOfISOWeekYear/index.d.ts
+++ b/src/fp/startOfISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfISOWeekYear } from 'date-fns/fp'
-export = startOfISOWeekYear
+export default startOfISOWeekYear

--- a/src/fp/startOfMinute/index.d.ts
+++ b/src/fp/startOfMinute/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfMinute } from 'date-fns/fp'
-export = startOfMinute
+export default startOfMinute

--- a/src/fp/startOfMonth/index.d.ts
+++ b/src/fp/startOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfMonth } from 'date-fns/fp'
-export = startOfMonth
+export default startOfMonth

--- a/src/fp/startOfQuarter/index.d.ts
+++ b/src/fp/startOfQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfQuarter } from 'date-fns/fp'
-export = startOfQuarter
+export default startOfQuarter

--- a/src/fp/startOfSecond/index.d.ts
+++ b/src/fp/startOfSecond/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfSecond } from 'date-fns/fp'
-export = startOfSecond
+export default startOfSecond

--- a/src/fp/startOfWeek/index.d.ts
+++ b/src/fp/startOfWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfWeek } from 'date-fns/fp'
-export = startOfWeek
+export default startOfWeek

--- a/src/fp/startOfWeekWithOptions/index.d.ts
+++ b/src/fp/startOfWeekWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfWeekWithOptions } from 'date-fns/fp'
-export = startOfWeekWithOptions
+export default startOfWeekWithOptions

--- a/src/fp/startOfWeekYear/index.d.ts
+++ b/src/fp/startOfWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfWeekYear } from 'date-fns/fp'
-export = startOfWeekYear
+export default startOfWeekYear

--- a/src/fp/startOfWeekYearWithOptions/index.d.ts
+++ b/src/fp/startOfWeekYearWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfWeekYearWithOptions } from 'date-fns/fp'
-export = startOfWeekYearWithOptions
+export default startOfWeekYearWithOptions

--- a/src/fp/startOfYear/index.d.ts
+++ b/src/fp/startOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfYear } from 'date-fns/fp'
-export = startOfYear
+export default startOfYear

--- a/src/fp/subDays/index.d.ts
+++ b/src/fp/subDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subDays } from 'date-fns/fp'
-export = subDays
+export default subDays

--- a/src/fp/subHours/index.d.ts
+++ b/src/fp/subHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subHours } from 'date-fns/fp'
-export = subHours
+export default subHours

--- a/src/fp/subISOWeekYears/index.d.ts
+++ b/src/fp/subISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subISOWeekYears } from 'date-fns/fp'
-export = subISOWeekYears
+export default subISOWeekYears

--- a/src/fp/subMilliseconds/index.d.ts
+++ b/src/fp/subMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subMilliseconds } from 'date-fns/fp'
-export = subMilliseconds
+export default subMilliseconds

--- a/src/fp/subMinutes/index.d.ts
+++ b/src/fp/subMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subMinutes } from 'date-fns/fp'
-export = subMinutes
+export default subMinutes

--- a/src/fp/subMonths/index.d.ts
+++ b/src/fp/subMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subMonths } from 'date-fns/fp'
-export = subMonths
+export default subMonths

--- a/src/fp/subQuarters/index.d.ts
+++ b/src/fp/subQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subQuarters } from 'date-fns/fp'
-export = subQuarters
+export default subQuarters

--- a/src/fp/subSeconds/index.d.ts
+++ b/src/fp/subSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subSeconds } from 'date-fns/fp'
-export = subSeconds
+export default subSeconds

--- a/src/fp/subWeeks/index.d.ts
+++ b/src/fp/subWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subWeeks } from 'date-fns/fp'
-export = subWeeks
+export default subWeeks

--- a/src/fp/subYears/index.d.ts
+++ b/src/fp/subYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subYears } from 'date-fns/fp'
-export = subYears
+export default subYears

--- a/src/fp/toDate/index.d.ts
+++ b/src/fp/toDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { toDate } from 'date-fns/fp'
-export = toDate
+export default toDate

--- a/src/fromUnixTime/index.d.ts
+++ b/src/fromUnixTime/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { fromUnixTime } from 'date-fns'
-export = fromUnixTime
+export default fromUnixTime

--- a/src/getDate/index.d.ts
+++ b/src/getDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDate } from 'date-fns'
-export = getDate
+export default getDate

--- a/src/getDay/index.d.ts
+++ b/src/getDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDay } from 'date-fns'
-export = getDay
+export default getDay

--- a/src/getDayOfYear/index.d.ts
+++ b/src/getDayOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDayOfYear } from 'date-fns'
-export = getDayOfYear
+export default getDayOfYear

--- a/src/getDaysInMonth/index.d.ts
+++ b/src/getDaysInMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDaysInMonth } from 'date-fns'
-export = getDaysInMonth
+export default getDaysInMonth

--- a/src/getDaysInYear/index.d.ts
+++ b/src/getDaysInYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDaysInYear } from 'date-fns'
-export = getDaysInYear
+export default getDaysInYear

--- a/src/getDecade/index.d.ts
+++ b/src/getDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getDecade } from 'date-fns'
-export = getDecade
+export default getDecade

--- a/src/getHours/index.d.ts
+++ b/src/getHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getHours } from 'date-fns'
-export = getHours
+export default getHours

--- a/src/getISODay/index.d.ts
+++ b/src/getISODay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISODay } from 'date-fns'
-export = getISODay
+export default getISODay

--- a/src/getISOWeek/index.d.ts
+++ b/src/getISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISOWeek } from 'date-fns'
-export = getISOWeek
+export default getISOWeek

--- a/src/getISOWeekYear/index.d.ts
+++ b/src/getISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISOWeekYear } from 'date-fns'
-export = getISOWeekYear
+export default getISOWeekYear

--- a/src/getISOWeeksInYear/index.d.ts
+++ b/src/getISOWeeksInYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getISOWeeksInYear } from 'date-fns'
-export = getISOWeeksInYear
+export default getISOWeeksInYear

--- a/src/getMilliseconds/index.d.ts
+++ b/src/getMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getMilliseconds } from 'date-fns'
-export = getMilliseconds
+export default getMilliseconds

--- a/src/getMinutes/index.d.ts
+++ b/src/getMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getMinutes } from 'date-fns'
-export = getMinutes
+export default getMinutes

--- a/src/getMonth/index.d.ts
+++ b/src/getMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getMonth } from 'date-fns'
-export = getMonth
+export default getMonth

--- a/src/getOverlappingDaysInIntervals/index.d.ts
+++ b/src/getOverlappingDaysInIntervals/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getOverlappingDaysInIntervals } from 'date-fns'
-export = getOverlappingDaysInIntervals
+export default getOverlappingDaysInIntervals

--- a/src/getQuarter/index.d.ts
+++ b/src/getQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getQuarter } from 'date-fns'
-export = getQuarter
+export default getQuarter

--- a/src/getSeconds/index.d.ts
+++ b/src/getSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getSeconds } from 'date-fns'
-export = getSeconds
+export default getSeconds

--- a/src/getTime/index.d.ts
+++ b/src/getTime/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getTime } from 'date-fns'
-export = getTime
+export default getTime

--- a/src/getUnixTime/index.d.ts
+++ b/src/getUnixTime/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getUnixTime } from 'date-fns'
-export = getUnixTime
+export default getUnixTime

--- a/src/getWeek/index.d.ts
+++ b/src/getWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeek } from 'date-fns'
-export = getWeek
+export default getWeek

--- a/src/getWeekOfMonth/index.d.ts
+++ b/src/getWeekOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekOfMonth } from 'date-fns'
-export = getWeekOfMonth
+export default getWeekOfMonth

--- a/src/getWeekYear/index.d.ts
+++ b/src/getWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeekYear } from 'date-fns'
-export = getWeekYear
+export default getWeekYear

--- a/src/getWeeksInMonth/index.d.ts
+++ b/src/getWeeksInMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getWeeksInMonth } from 'date-fns'
-export = getWeeksInMonth
+export default getWeeksInMonth

--- a/src/getYear/index.d.ts
+++ b/src/getYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { getYear } from 'date-fns'
-export = getYear
+export default getYear

--- a/src/isAfter/index.d.ts
+++ b/src/isAfter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isAfter } from 'date-fns'
-export = isAfter
+export default isAfter

--- a/src/isBefore/index.d.ts
+++ b/src/isBefore/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isBefore } from 'date-fns'
-export = isBefore
+export default isBefore

--- a/src/isDate/index.d.ts
+++ b/src/isDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isDate } from 'date-fns'
-export = isDate
+export default isDate

--- a/src/isEqual/index.d.ts
+++ b/src/isEqual/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isEqual } from 'date-fns'
-export = isEqual
+export default isEqual

--- a/src/isFirstDayOfMonth/index.d.ts
+++ b/src/isFirstDayOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isFirstDayOfMonth } from 'date-fns'
-export = isFirstDayOfMonth
+export default isFirstDayOfMonth

--- a/src/isFriday/index.d.ts
+++ b/src/isFriday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isFriday } from 'date-fns'
-export = isFriday
+export default isFriday

--- a/src/isLastDayOfMonth/index.d.ts
+++ b/src/isLastDayOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isLastDayOfMonth } from 'date-fns'
-export = isLastDayOfMonth
+export default isLastDayOfMonth

--- a/src/isLeapYear/index.d.ts
+++ b/src/isLeapYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isLeapYear } from 'date-fns'
-export = isLeapYear
+export default isLeapYear

--- a/src/isMonday/index.d.ts
+++ b/src/isMonday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isMonday } from 'date-fns'
-export = isMonday
+export default isMonday

--- a/src/isSameDay/index.d.ts
+++ b/src/isSameDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameDay } from 'date-fns'
-export = isSameDay
+export default isSameDay

--- a/src/isSameHour/index.d.ts
+++ b/src/isSameHour/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameHour } from 'date-fns'
-export = isSameHour
+export default isSameHour

--- a/src/isSameISOWeek/index.d.ts
+++ b/src/isSameISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameISOWeek } from 'date-fns'
-export = isSameISOWeek
+export default isSameISOWeek

--- a/src/isSameISOWeekYear/index.d.ts
+++ b/src/isSameISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameISOWeekYear } from 'date-fns'
-export = isSameISOWeekYear
+export default isSameISOWeekYear

--- a/src/isSameMinute/index.d.ts
+++ b/src/isSameMinute/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameMinute } from 'date-fns'
-export = isSameMinute
+export default isSameMinute

--- a/src/isSameMonth/index.d.ts
+++ b/src/isSameMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameMonth } from 'date-fns'
-export = isSameMonth
+export default isSameMonth

--- a/src/isSameQuarter/index.d.ts
+++ b/src/isSameQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameQuarter } from 'date-fns'
-export = isSameQuarter
+export default isSameQuarter

--- a/src/isSameSecond/index.d.ts
+++ b/src/isSameSecond/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameSecond } from 'date-fns'
-export = isSameSecond
+export default isSameSecond

--- a/src/isSameWeek/index.d.ts
+++ b/src/isSameWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameWeek } from 'date-fns'
-export = isSameWeek
+export default isSameWeek

--- a/src/isSameYear/index.d.ts
+++ b/src/isSameYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSameYear } from 'date-fns'
-export = isSameYear
+export default isSameYear

--- a/src/isSaturday/index.d.ts
+++ b/src/isSaturday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSaturday } from 'date-fns'
-export = isSaturday
+export default isSaturday

--- a/src/isSunday/index.d.ts
+++ b/src/isSunday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isSunday } from 'date-fns'
-export = isSunday
+export default isSunday

--- a/src/isThursday/index.d.ts
+++ b/src/isThursday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isThursday } from 'date-fns'
-export = isThursday
+export default isThursday

--- a/src/isTuesday/index.d.ts
+++ b/src/isTuesday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isTuesday } from 'date-fns'
-export = isTuesday
+export default isTuesday

--- a/src/isValid/index.d.ts
+++ b/src/isValid/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isValid } from 'date-fns'
-export = isValid
+export default isValid

--- a/src/isWednesday/index.d.ts
+++ b/src/isWednesday/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isWednesday } from 'date-fns'
-export = isWednesday
+export default isWednesday

--- a/src/isWeekend/index.d.ts
+++ b/src/isWeekend/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isWeekend } from 'date-fns'
-export = isWeekend
+export default isWeekend

--- a/src/isWithinInterval/index.d.ts
+++ b/src/isWithinInterval/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { isWithinInterval } from 'date-fns'
-export = isWithinInterval
+export default isWithinInterval

--- a/src/lastDayOfDecade/index.d.ts
+++ b/src/lastDayOfDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfDecade } from 'date-fns'
-export = lastDayOfDecade
+export default lastDayOfDecade

--- a/src/lastDayOfISOWeek/index.d.ts
+++ b/src/lastDayOfISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfISOWeek } from 'date-fns'
-export = lastDayOfISOWeek
+export default lastDayOfISOWeek

--- a/src/lastDayOfISOWeekYear/index.d.ts
+++ b/src/lastDayOfISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfISOWeekYear } from 'date-fns'
-export = lastDayOfISOWeekYear
+export default lastDayOfISOWeekYear

--- a/src/lastDayOfMonth/index.d.ts
+++ b/src/lastDayOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfMonth } from 'date-fns'
-export = lastDayOfMonth
+export default lastDayOfMonth

--- a/src/lastDayOfQuarter/index.d.ts
+++ b/src/lastDayOfQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfQuarter } from 'date-fns'
-export = lastDayOfQuarter
+export default lastDayOfQuarter

--- a/src/lastDayOfWeek/index.d.ts
+++ b/src/lastDayOfWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfWeek } from 'date-fns'
-export = lastDayOfWeek
+export default lastDayOfWeek

--- a/src/lastDayOfYear/index.d.ts
+++ b/src/lastDayOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lastDayOfYear } from 'date-fns'
-export = lastDayOfYear
+export default lastDayOfYear

--- a/src/lightFormat/index.d.ts
+++ b/src/lightFormat/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lightFormat } from 'date-fns'
-export = lightFormat
+export default lightFormat

--- a/src/locale/af/index.d.ts
+++ b/src/locale/af/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { af } from 'date-fns/locale'
-export = af
+export default af

--- a/src/locale/ar-DZ/index.d.ts
+++ b/src/locale/ar-DZ/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { arDZ } from 'date-fns/locale'
-export = arDZ
+export default arDZ

--- a/src/locale/ar-SA/index.d.ts
+++ b/src/locale/ar-SA/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { arSA } from 'date-fns/locale'
-export = arSA
+export default arSA

--- a/src/locale/ar/index.d.ts
+++ b/src/locale/ar/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ar } from 'date-fns/locale'
-export = ar
+export default ar

--- a/src/locale/be/index.d.ts
+++ b/src/locale/be/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { be } from 'date-fns/locale'
-export = be
+export default be

--- a/src/locale/bg/index.d.ts
+++ b/src/locale/bg/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { bg } from 'date-fns/locale'
-export = bg
+export default bg

--- a/src/locale/bn/index.d.ts
+++ b/src/locale/bn/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { bn } from 'date-fns/locale'
-export = bn
+export default bn

--- a/src/locale/ca/index.d.ts
+++ b/src/locale/ca/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ca } from 'date-fns/locale'
-export = ca
+export default ca

--- a/src/locale/cs/index.d.ts
+++ b/src/locale/cs/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { cs } from 'date-fns/locale'
-export = cs
+export default cs

--- a/src/locale/da/index.d.ts
+++ b/src/locale/da/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { da } from 'date-fns/locale'
-export = da
+export default da

--- a/src/locale/de/index.d.ts
+++ b/src/locale/de/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { de } from 'date-fns/locale'
-export = de
+export default de

--- a/src/locale/el/index.d.ts
+++ b/src/locale/el/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { el } from 'date-fns/locale'
-export = el
+export default el

--- a/src/locale/en-CA/index.d.ts
+++ b/src/locale/en-CA/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { enCA } from 'date-fns/locale'
-export = enCA
+export default enCA

--- a/src/locale/en-GB/index.d.ts
+++ b/src/locale/en-GB/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { enGB } from 'date-fns/locale'
-export = enGB
+export default enGB

--- a/src/locale/en-US/index.d.ts
+++ b/src/locale/en-US/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { enUS } from 'date-fns/locale'
-export = enUS
+export default enUS

--- a/src/locale/eo/index.d.ts
+++ b/src/locale/eo/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { eo } from 'date-fns/locale'
-export = eo
+export default eo

--- a/src/locale/es/index.d.ts
+++ b/src/locale/es/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { es } from 'date-fns/locale'
-export = es
+export default es

--- a/src/locale/et/index.d.ts
+++ b/src/locale/et/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { et } from 'date-fns/locale'
-export = et
+export default et

--- a/src/locale/fi/index.d.ts
+++ b/src/locale/fi/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { fi } from 'date-fns/locale'
-export = fi
+export default fi

--- a/src/locale/fil/index.d.ts
+++ b/src/locale/fil/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { fil } from 'date-fns/locale'
-export = fil
+export default fil

--- a/src/locale/fr-CH/index.d.ts
+++ b/src/locale/fr-CH/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { frCH } from 'date-fns/locale'
-export = frCH
+export default frCH

--- a/src/locale/fr/index.d.ts
+++ b/src/locale/fr/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { fr } from 'date-fns/locale'
-export = fr
+export default fr

--- a/src/locale/gl/index.d.ts
+++ b/src/locale/gl/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { gl } from 'date-fns/locale'
-export = gl
+export default gl

--- a/src/locale/he/index.d.ts
+++ b/src/locale/he/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { he } from 'date-fns/locale'
-export = he
+export default he

--- a/src/locale/hr/index.d.ts
+++ b/src/locale/hr/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { hr } from 'date-fns/locale'
-export = hr
+export default hr

--- a/src/locale/hu/index.d.ts
+++ b/src/locale/hu/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { hu } from 'date-fns/locale'
-export = hu
+export default hu

--- a/src/locale/id/index.d.ts
+++ b/src/locale/id/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { id } from 'date-fns/locale'
-export = id
+export default id

--- a/src/locale/is/index.d.ts
+++ b/src/locale/is/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { is } from 'date-fns/locale'
-export = is
+export default is

--- a/src/locale/it/index.d.ts
+++ b/src/locale/it/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { it } from 'date-fns/locale'
-export = it
+export default it

--- a/src/locale/ja/index.d.ts
+++ b/src/locale/ja/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ja } from 'date-fns/locale'
-export = ja
+export default ja

--- a/src/locale/ka/index.d.ts
+++ b/src/locale/ka/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ka } from 'date-fns/locale'
-export = ka
+export default ka

--- a/src/locale/ko/index.d.ts
+++ b/src/locale/ko/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ko } from 'date-fns/locale'
-export = ko
+export default ko

--- a/src/locale/lt/index.d.ts
+++ b/src/locale/lt/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lt } from 'date-fns/locale'
-export = lt
+export default lt

--- a/src/locale/lv/index.d.ts
+++ b/src/locale/lv/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { lv } from 'date-fns/locale'
-export = lv
+export default lv

--- a/src/locale/mk/index.d.ts
+++ b/src/locale/mk/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { mk } from 'date-fns/locale'
-export = mk
+export default mk

--- a/src/locale/ms/index.d.ts
+++ b/src/locale/ms/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ms } from 'date-fns/locale'
-export = ms
+export default ms

--- a/src/locale/nb/index.d.ts
+++ b/src/locale/nb/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { nb } from 'date-fns/locale'
-export = nb
+export default nb

--- a/src/locale/nl-BE/index.d.ts
+++ b/src/locale/nl-BE/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { nlBE } from 'date-fns/locale'
-export = nlBE
+export default nlBE

--- a/src/locale/nl/index.d.ts
+++ b/src/locale/nl/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { nl } from 'date-fns/locale'
-export = nl
+export default nl

--- a/src/locale/nn/index.d.ts
+++ b/src/locale/nn/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { nn } from 'date-fns/locale'
-export = nn
+export default nn

--- a/src/locale/pl/index.d.ts
+++ b/src/locale/pl/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { pl } from 'date-fns/locale'
-export = pl
+export default pl

--- a/src/locale/pt-BR/index.d.ts
+++ b/src/locale/pt-BR/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ptBR } from 'date-fns/locale'
-export = ptBR
+export default ptBR

--- a/src/locale/pt/index.d.ts
+++ b/src/locale/pt/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { pt } from 'date-fns/locale'
-export = pt
+export default pt

--- a/src/locale/ro/index.d.ts
+++ b/src/locale/ro/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ro } from 'date-fns/locale'
-export = ro
+export default ro

--- a/src/locale/ru/index.d.ts
+++ b/src/locale/ru/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { ru } from 'date-fns/locale'
-export = ru
+export default ru

--- a/src/locale/sk/index.d.ts
+++ b/src/locale/sk/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { sk } from 'date-fns/locale'
-export = sk
+export default sk

--- a/src/locale/sl/index.d.ts
+++ b/src/locale/sl/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { sl } from 'date-fns/locale'
-export = sl
+export default sl

--- a/src/locale/sr/index.d.ts
+++ b/src/locale/sr/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { sr } from 'date-fns/locale'
-export = sr
+export default sr

--- a/src/locale/sv/index.d.ts
+++ b/src/locale/sv/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { sv } from 'date-fns/locale'
-export = sv
+export default sv

--- a/src/locale/th/index.d.ts
+++ b/src/locale/th/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { th } from 'date-fns/locale'
-export = th
+export default th

--- a/src/locale/tr/index.d.ts
+++ b/src/locale/tr/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { tr } from 'date-fns/locale'
-export = tr
+export default tr

--- a/src/locale/uk/index.d.ts
+++ b/src/locale/uk/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { uk } from 'date-fns/locale'
-export = uk
+export default uk

--- a/src/locale/vi/index.d.ts
+++ b/src/locale/vi/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { vi } from 'date-fns/locale'
-export = vi
+export default vi

--- a/src/locale/zh-CN/index.d.ts
+++ b/src/locale/zh-CN/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { zhCN } from 'date-fns/locale'
-export = zhCN
+export default zhCN

--- a/src/locale/zh-TW/index.d.ts
+++ b/src/locale/zh-TW/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { zhTW } from 'date-fns/locale'
-export = zhTW
+export default zhTW

--- a/src/max/index.d.ts
+++ b/src/max/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { max } from 'date-fns'
-export = max
+export default max

--- a/src/min/index.d.ts
+++ b/src/min/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { min } from 'date-fns'
-export = min
+export default min

--- a/src/parse/index.d.ts
+++ b/src/parse/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { parse } from 'date-fns'
-export = parse
+export default parse

--- a/src/parseISO/index.d.ts
+++ b/src/parseISO/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { parseISO } from 'date-fns'
-export = parseISO
+export default parseISO

--- a/src/roundToNearestMinutes/index.d.ts
+++ b/src/roundToNearestMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { roundToNearestMinutes } from 'date-fns'
-export = roundToNearestMinutes
+export default roundToNearestMinutes

--- a/src/setDate/index.d.ts
+++ b/src/setDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDate } from 'date-fns'
-export = setDate
+export default setDate

--- a/src/setDay/index.d.ts
+++ b/src/setDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDay } from 'date-fns'
-export = setDay
+export default setDay

--- a/src/setDayOfYear/index.d.ts
+++ b/src/setDayOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setDayOfYear } from 'date-fns'
-export = setDayOfYear
+export default setDayOfYear

--- a/src/setHours/index.d.ts
+++ b/src/setHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setHours } from 'date-fns'
-export = setHours
+export default setHours

--- a/src/setISODay/index.d.ts
+++ b/src/setISODay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setISODay } from 'date-fns'
-export = setISODay
+export default setISODay

--- a/src/setISOWeek/index.d.ts
+++ b/src/setISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setISOWeek } from 'date-fns'
-export = setISOWeek
+export default setISOWeek

--- a/src/setISOWeekYear/index.d.ts
+++ b/src/setISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setISOWeekYear } from 'date-fns'
-export = setISOWeekYear
+export default setISOWeekYear

--- a/src/setMilliseconds/index.d.ts
+++ b/src/setMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setMilliseconds } from 'date-fns'
-export = setMilliseconds
+export default setMilliseconds

--- a/src/setMinutes/index.d.ts
+++ b/src/setMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setMinutes } from 'date-fns'
-export = setMinutes
+export default setMinutes

--- a/src/setMonth/index.d.ts
+++ b/src/setMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setMonth } from 'date-fns'
-export = setMonth
+export default setMonth

--- a/src/setQuarter/index.d.ts
+++ b/src/setQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setQuarter } from 'date-fns'
-export = setQuarter
+export default setQuarter

--- a/src/setSeconds/index.d.ts
+++ b/src/setSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setSeconds } from 'date-fns'
-export = setSeconds
+export default setSeconds

--- a/src/setWeek/index.d.ts
+++ b/src/setWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setWeek } from 'date-fns'
-export = setWeek
+export default setWeek

--- a/src/setWeekYear/index.d.ts
+++ b/src/setWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setWeekYear } from 'date-fns'
-export = setWeekYear
+export default setWeekYear

--- a/src/setYear/index.d.ts
+++ b/src/setYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { setYear } from 'date-fns'
-export = setYear
+export default setYear

--- a/src/startOfDay/index.d.ts
+++ b/src/startOfDay/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfDay } from 'date-fns'
-export = startOfDay
+export default startOfDay

--- a/src/startOfDecade/index.d.ts
+++ b/src/startOfDecade/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfDecade } from 'date-fns'
-export = startOfDecade
+export default startOfDecade

--- a/src/startOfHour/index.d.ts
+++ b/src/startOfHour/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfHour } from 'date-fns'
-export = startOfHour
+export default startOfHour

--- a/src/startOfISOWeek/index.d.ts
+++ b/src/startOfISOWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfISOWeek } from 'date-fns'
-export = startOfISOWeek
+export default startOfISOWeek

--- a/src/startOfISOWeekYear/index.d.ts
+++ b/src/startOfISOWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfISOWeekYear } from 'date-fns'
-export = startOfISOWeekYear
+export default startOfISOWeekYear

--- a/src/startOfMinute/index.d.ts
+++ b/src/startOfMinute/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfMinute } from 'date-fns'
-export = startOfMinute
+export default startOfMinute

--- a/src/startOfMonth/index.d.ts
+++ b/src/startOfMonth/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfMonth } from 'date-fns'
-export = startOfMonth
+export default startOfMonth

--- a/src/startOfQuarter/index.d.ts
+++ b/src/startOfQuarter/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfQuarter } from 'date-fns'
-export = startOfQuarter
+export default startOfQuarter

--- a/src/startOfSecond/index.d.ts
+++ b/src/startOfSecond/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfSecond } from 'date-fns'
-export = startOfSecond
+export default startOfSecond

--- a/src/startOfWeek/index.d.ts
+++ b/src/startOfWeek/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfWeek } from 'date-fns'
-export = startOfWeek
+export default startOfWeek

--- a/src/startOfWeekYear/index.d.ts
+++ b/src/startOfWeekYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfWeekYear } from 'date-fns'
-export = startOfWeekYear
+export default startOfWeekYear

--- a/src/startOfYear/index.d.ts
+++ b/src/startOfYear/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { startOfYear } from 'date-fns'
-export = startOfYear
+export default startOfYear

--- a/src/subDays/index.d.ts
+++ b/src/subDays/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subDays } from 'date-fns'
-export = subDays
+export default subDays

--- a/src/subHours/index.d.ts
+++ b/src/subHours/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subHours } from 'date-fns'
-export = subHours
+export default subHours

--- a/src/subISOWeekYears/index.d.ts
+++ b/src/subISOWeekYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subISOWeekYears } from 'date-fns'
-export = subISOWeekYears
+export default subISOWeekYears

--- a/src/subMilliseconds/index.d.ts
+++ b/src/subMilliseconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subMilliseconds } from 'date-fns'
-export = subMilliseconds
+export default subMilliseconds

--- a/src/subMinutes/index.d.ts
+++ b/src/subMinutes/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subMinutes } from 'date-fns'
-export = subMinutes
+export default subMinutes

--- a/src/subMonths/index.d.ts
+++ b/src/subMonths/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subMonths } from 'date-fns'
-export = subMonths
+export default subMonths

--- a/src/subQuarters/index.d.ts
+++ b/src/subQuarters/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subQuarters } from 'date-fns'
-export = subQuarters
+export default subQuarters

--- a/src/subSeconds/index.d.ts
+++ b/src/subSeconds/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subSeconds } from 'date-fns'
-export = subSeconds
+export default subSeconds

--- a/src/subWeeks/index.d.ts
+++ b/src/subWeeks/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subWeeks } from 'date-fns'
-export = subWeeks
+export default subWeeks

--- a/src/subYears/index.d.ts
+++ b/src/subYears/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { subYears } from 'date-fns'
-export = subYears
+export default subYears

--- a/src/toDate/index.d.ts
+++ b/src/toDate/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 import { toDate } from 'date-fns'
-export = toDate
+export default toDate

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1102,2327 +1102,2327 @@ declare module 'date-fns' {
 
 declare module 'date-fns/addDays' {
   import { addDays } from 'date-fns'
-  export = addDays
+  export default addDays
 }
 
 declare module 'date-fns/addHours' {
   import { addHours } from 'date-fns'
-  export = addHours
+  export default addHours
 }
 
 declare module 'date-fns/addISOWeekYears' {
   import { addISOWeekYears } from 'date-fns'
-  export = addISOWeekYears
+  export default addISOWeekYears
 }
 
 declare module 'date-fns/addMilliseconds' {
   import { addMilliseconds } from 'date-fns'
-  export = addMilliseconds
+  export default addMilliseconds
 }
 
 declare module 'date-fns/addMinutes' {
   import { addMinutes } from 'date-fns'
-  export = addMinutes
+  export default addMinutes
 }
 
 declare module 'date-fns/addMonths' {
   import { addMonths } from 'date-fns'
-  export = addMonths
+  export default addMonths
 }
 
 declare module 'date-fns/addQuarters' {
   import { addQuarters } from 'date-fns'
-  export = addQuarters
+  export default addQuarters
 }
 
 declare module 'date-fns/addSeconds' {
   import { addSeconds } from 'date-fns'
-  export = addSeconds
+  export default addSeconds
 }
 
 declare module 'date-fns/addWeeks' {
   import { addWeeks } from 'date-fns'
-  export = addWeeks
+  export default addWeeks
 }
 
 declare module 'date-fns/addYears' {
   import { addYears } from 'date-fns'
-  export = addYears
+  export default addYears
 }
 
 declare module 'date-fns/areIntervalsOverlapping' {
   import { areIntervalsOverlapping } from 'date-fns'
-  export = areIntervalsOverlapping
+  export default areIntervalsOverlapping
 }
 
 declare module 'date-fns/closestIndexTo' {
   import { closestIndexTo } from 'date-fns'
-  export = closestIndexTo
+  export default closestIndexTo
 }
 
 declare module 'date-fns/closestTo' {
   import { closestTo } from 'date-fns'
-  export = closestTo
+  export default closestTo
 }
 
 declare module 'date-fns/compareAsc' {
   import { compareAsc } from 'date-fns'
-  export = compareAsc
+  export default compareAsc
 }
 
 declare module 'date-fns/compareDesc' {
   import { compareDesc } from 'date-fns'
-  export = compareDesc
+  export default compareDesc
 }
 
 declare module 'date-fns/differenceInCalendarDays' {
   import { differenceInCalendarDays } from 'date-fns'
-  export = differenceInCalendarDays
+  export default differenceInCalendarDays
 }
 
 declare module 'date-fns/differenceInCalendarISOWeeks' {
   import { differenceInCalendarISOWeeks } from 'date-fns'
-  export = differenceInCalendarISOWeeks
+  export default differenceInCalendarISOWeeks
 }
 
 declare module 'date-fns/differenceInCalendarISOWeekYears' {
   import { differenceInCalendarISOWeekYears } from 'date-fns'
-  export = differenceInCalendarISOWeekYears
+  export default differenceInCalendarISOWeekYears
 }
 
 declare module 'date-fns/differenceInCalendarMonths' {
   import { differenceInCalendarMonths } from 'date-fns'
-  export = differenceInCalendarMonths
+  export default differenceInCalendarMonths
 }
 
 declare module 'date-fns/differenceInCalendarQuarters' {
   import { differenceInCalendarQuarters } from 'date-fns'
-  export = differenceInCalendarQuarters
+  export default differenceInCalendarQuarters
 }
 
 declare module 'date-fns/differenceInCalendarWeeks' {
   import { differenceInCalendarWeeks } from 'date-fns'
-  export = differenceInCalendarWeeks
+  export default differenceInCalendarWeeks
 }
 
 declare module 'date-fns/differenceInCalendarYears' {
   import { differenceInCalendarYears } from 'date-fns'
-  export = differenceInCalendarYears
+  export default differenceInCalendarYears
 }
 
 declare module 'date-fns/differenceInDays' {
   import { differenceInDays } from 'date-fns'
-  export = differenceInDays
+  export default differenceInDays
 }
 
 declare module 'date-fns/differenceInHours' {
   import { differenceInHours } from 'date-fns'
-  export = differenceInHours
+  export default differenceInHours
 }
 
 declare module 'date-fns/differenceInISOWeekYears' {
   import { differenceInISOWeekYears } from 'date-fns'
-  export = differenceInISOWeekYears
+  export default differenceInISOWeekYears
 }
 
 declare module 'date-fns/differenceInMilliseconds' {
   import { differenceInMilliseconds } from 'date-fns'
-  export = differenceInMilliseconds
+  export default differenceInMilliseconds
 }
 
 declare module 'date-fns/differenceInMinutes' {
   import { differenceInMinutes } from 'date-fns'
-  export = differenceInMinutes
+  export default differenceInMinutes
 }
 
 declare module 'date-fns/differenceInMonths' {
   import { differenceInMonths } from 'date-fns'
-  export = differenceInMonths
+  export default differenceInMonths
 }
 
 declare module 'date-fns/differenceInQuarters' {
   import { differenceInQuarters } from 'date-fns'
-  export = differenceInQuarters
+  export default differenceInQuarters
 }
 
 declare module 'date-fns/differenceInSeconds' {
   import { differenceInSeconds } from 'date-fns'
-  export = differenceInSeconds
+  export default differenceInSeconds
 }
 
 declare module 'date-fns/differenceInWeeks' {
   import { differenceInWeeks } from 'date-fns'
-  export = differenceInWeeks
+  export default differenceInWeeks
 }
 
 declare module 'date-fns/differenceInYears' {
   import { differenceInYears } from 'date-fns'
-  export = differenceInYears
+  export default differenceInYears
 }
 
 declare module 'date-fns/eachDayOfInterval' {
   import { eachDayOfInterval } from 'date-fns'
-  export = eachDayOfInterval
+  export default eachDayOfInterval
 }
 
 declare module 'date-fns/eachWeekendOfInterval' {
   import { eachWeekendOfInterval } from 'date-fns'
-  export = eachWeekendOfInterval
+  export default eachWeekendOfInterval
 }
 
 declare module 'date-fns/eachWeekendOfMonth' {
   import { eachWeekendOfMonth } from 'date-fns'
-  export = eachWeekendOfMonth
+  export default eachWeekendOfMonth
 }
 
 declare module 'date-fns/eachWeekendOfYear' {
   import { eachWeekendOfYear } from 'date-fns'
-  export = eachWeekendOfYear
+  export default eachWeekendOfYear
 }
 
 declare module 'date-fns/eachWeekOfInterval' {
   import { eachWeekOfInterval } from 'date-fns'
-  export = eachWeekOfInterval
+  export default eachWeekOfInterval
 }
 
 declare module 'date-fns/endOfDay' {
   import { endOfDay } from 'date-fns'
-  export = endOfDay
+  export default endOfDay
 }
 
 declare module 'date-fns/endOfDecade' {
   import { endOfDecade } from 'date-fns'
-  export = endOfDecade
+  export default endOfDecade
 }
 
 declare module 'date-fns/endOfHour' {
   import { endOfHour } from 'date-fns'
-  export = endOfHour
+  export default endOfHour
 }
 
 declare module 'date-fns/endOfISOWeek' {
   import { endOfISOWeek } from 'date-fns'
-  export = endOfISOWeek
+  export default endOfISOWeek
 }
 
 declare module 'date-fns/endOfISOWeekYear' {
   import { endOfISOWeekYear } from 'date-fns'
-  export = endOfISOWeekYear
+  export default endOfISOWeekYear
 }
 
 declare module 'date-fns/endOfMinute' {
   import { endOfMinute } from 'date-fns'
-  export = endOfMinute
+  export default endOfMinute
 }
 
 declare module 'date-fns/endOfMonth' {
   import { endOfMonth } from 'date-fns'
-  export = endOfMonth
+  export default endOfMonth
 }
 
 declare module 'date-fns/endOfQuarter' {
   import { endOfQuarter } from 'date-fns'
-  export = endOfQuarter
+  export default endOfQuarter
 }
 
 declare module 'date-fns/endOfSecond' {
   import { endOfSecond } from 'date-fns'
-  export = endOfSecond
+  export default endOfSecond
 }
 
 declare module 'date-fns/endOfWeek' {
   import { endOfWeek } from 'date-fns'
-  export = endOfWeek
+  export default endOfWeek
 }
 
 declare module 'date-fns/endOfYear' {
   import { endOfYear } from 'date-fns'
-  export = endOfYear
+  export default endOfYear
 }
 
 declare module 'date-fns/format' {
   import { format } from 'date-fns'
-  export = format
+  export default format
 }
 
 declare module 'date-fns/formatDistance' {
   import { formatDistance } from 'date-fns'
-  export = formatDistance
+  export default formatDistance
 }
 
 declare module 'date-fns/formatDistanceStrict' {
   import { formatDistanceStrict } from 'date-fns'
-  export = formatDistanceStrict
+  export default formatDistanceStrict
 }
 
 declare module 'date-fns/formatRelative' {
   import { formatRelative } from 'date-fns'
-  export = formatRelative
+  export default formatRelative
 }
 
 declare module 'date-fns/fromUnixTime' {
   import { fromUnixTime } from 'date-fns'
-  export = fromUnixTime
+  export default fromUnixTime
 }
 
 declare module 'date-fns/getDate' {
   import { getDate } from 'date-fns'
-  export = getDate
+  export default getDate
 }
 
 declare module 'date-fns/getDay' {
   import { getDay } from 'date-fns'
-  export = getDay
+  export default getDay
 }
 
 declare module 'date-fns/getDayOfYear' {
   import { getDayOfYear } from 'date-fns'
-  export = getDayOfYear
+  export default getDayOfYear
 }
 
 declare module 'date-fns/getDaysInMonth' {
   import { getDaysInMonth } from 'date-fns'
-  export = getDaysInMonth
+  export default getDaysInMonth
 }
 
 declare module 'date-fns/getDaysInYear' {
   import { getDaysInYear } from 'date-fns'
-  export = getDaysInYear
+  export default getDaysInYear
 }
 
 declare module 'date-fns/getDecade' {
   import { getDecade } from 'date-fns'
-  export = getDecade
+  export default getDecade
 }
 
 declare module 'date-fns/getHours' {
   import { getHours } from 'date-fns'
-  export = getHours
+  export default getHours
 }
 
 declare module 'date-fns/getISODay' {
   import { getISODay } from 'date-fns'
-  export = getISODay
+  export default getISODay
 }
 
 declare module 'date-fns/getISOWeek' {
   import { getISOWeek } from 'date-fns'
-  export = getISOWeek
+  export default getISOWeek
 }
 
 declare module 'date-fns/getISOWeeksInYear' {
   import { getISOWeeksInYear } from 'date-fns'
-  export = getISOWeeksInYear
+  export default getISOWeeksInYear
 }
 
 declare module 'date-fns/getISOWeekYear' {
   import { getISOWeekYear } from 'date-fns'
-  export = getISOWeekYear
+  export default getISOWeekYear
 }
 
 declare module 'date-fns/getMilliseconds' {
   import { getMilliseconds } from 'date-fns'
-  export = getMilliseconds
+  export default getMilliseconds
 }
 
 declare module 'date-fns/getMinutes' {
   import { getMinutes } from 'date-fns'
-  export = getMinutes
+  export default getMinutes
 }
 
 declare module 'date-fns/getMonth' {
   import { getMonth } from 'date-fns'
-  export = getMonth
+  export default getMonth
 }
 
 declare module 'date-fns/getOverlappingDaysInIntervals' {
   import { getOverlappingDaysInIntervals } from 'date-fns'
-  export = getOverlappingDaysInIntervals
+  export default getOverlappingDaysInIntervals
 }
 
 declare module 'date-fns/getQuarter' {
   import { getQuarter } from 'date-fns'
-  export = getQuarter
+  export default getQuarter
 }
 
 declare module 'date-fns/getSeconds' {
   import { getSeconds } from 'date-fns'
-  export = getSeconds
+  export default getSeconds
 }
 
 declare module 'date-fns/getTime' {
   import { getTime } from 'date-fns'
-  export = getTime
+  export default getTime
 }
 
 declare module 'date-fns/getUnixTime' {
   import { getUnixTime } from 'date-fns'
-  export = getUnixTime
+  export default getUnixTime
 }
 
 declare module 'date-fns/getWeek' {
   import { getWeek } from 'date-fns'
-  export = getWeek
+  export default getWeek
 }
 
 declare module 'date-fns/getWeekOfMonth' {
   import { getWeekOfMonth } from 'date-fns'
-  export = getWeekOfMonth
+  export default getWeekOfMonth
 }
 
 declare module 'date-fns/getWeeksInMonth' {
   import { getWeeksInMonth } from 'date-fns'
-  export = getWeeksInMonth
+  export default getWeeksInMonth
 }
 
 declare module 'date-fns/getWeekYear' {
   import { getWeekYear } from 'date-fns'
-  export = getWeekYear
+  export default getWeekYear
 }
 
 declare module 'date-fns/getYear' {
   import { getYear } from 'date-fns'
-  export = getYear
+  export default getYear
 }
 
 declare module 'date-fns/isAfter' {
   import { isAfter } from 'date-fns'
-  export = isAfter
+  export default isAfter
 }
 
 declare module 'date-fns/isBefore' {
   import { isBefore } from 'date-fns'
-  export = isBefore
+  export default isBefore
 }
 
 declare module 'date-fns/isDate' {
   import { isDate } from 'date-fns'
-  export = isDate
+  export default isDate
 }
 
 declare module 'date-fns/isEqual' {
   import { isEqual } from 'date-fns'
-  export = isEqual
+  export default isEqual
 }
 
 declare module 'date-fns/isFirstDayOfMonth' {
   import { isFirstDayOfMonth } from 'date-fns'
-  export = isFirstDayOfMonth
+  export default isFirstDayOfMonth
 }
 
 declare module 'date-fns/isFriday' {
   import { isFriday } from 'date-fns'
-  export = isFriday
+  export default isFriday
 }
 
 declare module 'date-fns/isLastDayOfMonth' {
   import { isLastDayOfMonth } from 'date-fns'
-  export = isLastDayOfMonth
+  export default isLastDayOfMonth
 }
 
 declare module 'date-fns/isLeapYear' {
   import { isLeapYear } from 'date-fns'
-  export = isLeapYear
+  export default isLeapYear
 }
 
 declare module 'date-fns/isMonday' {
   import { isMonday } from 'date-fns'
-  export = isMonday
+  export default isMonday
 }
 
 declare module 'date-fns/isSameDay' {
   import { isSameDay } from 'date-fns'
-  export = isSameDay
+  export default isSameDay
 }
 
 declare module 'date-fns/isSameHour' {
   import { isSameHour } from 'date-fns'
-  export = isSameHour
+  export default isSameHour
 }
 
 declare module 'date-fns/isSameISOWeek' {
   import { isSameISOWeek } from 'date-fns'
-  export = isSameISOWeek
+  export default isSameISOWeek
 }
 
 declare module 'date-fns/isSameISOWeekYear' {
   import { isSameISOWeekYear } from 'date-fns'
-  export = isSameISOWeekYear
+  export default isSameISOWeekYear
 }
 
 declare module 'date-fns/isSameMinute' {
   import { isSameMinute } from 'date-fns'
-  export = isSameMinute
+  export default isSameMinute
 }
 
 declare module 'date-fns/isSameMonth' {
   import { isSameMonth } from 'date-fns'
-  export = isSameMonth
+  export default isSameMonth
 }
 
 declare module 'date-fns/isSameQuarter' {
   import { isSameQuarter } from 'date-fns'
-  export = isSameQuarter
+  export default isSameQuarter
 }
 
 declare module 'date-fns/isSameSecond' {
   import { isSameSecond } from 'date-fns'
-  export = isSameSecond
+  export default isSameSecond
 }
 
 declare module 'date-fns/isSameWeek' {
   import { isSameWeek } from 'date-fns'
-  export = isSameWeek
+  export default isSameWeek
 }
 
 declare module 'date-fns/isSameYear' {
   import { isSameYear } from 'date-fns'
-  export = isSameYear
+  export default isSameYear
 }
 
 declare module 'date-fns/isSaturday' {
   import { isSaturday } from 'date-fns'
-  export = isSaturday
+  export default isSaturday
 }
 
 declare module 'date-fns/isSunday' {
   import { isSunday } from 'date-fns'
-  export = isSunday
+  export default isSunday
 }
 
 declare module 'date-fns/isThursday' {
   import { isThursday } from 'date-fns'
-  export = isThursday
+  export default isThursday
 }
 
 declare module 'date-fns/isTuesday' {
   import { isTuesday } from 'date-fns'
-  export = isTuesday
+  export default isTuesday
 }
 
 declare module 'date-fns/isValid' {
   import { isValid } from 'date-fns'
-  export = isValid
+  export default isValid
 }
 
 declare module 'date-fns/isWednesday' {
   import { isWednesday } from 'date-fns'
-  export = isWednesday
+  export default isWednesday
 }
 
 declare module 'date-fns/isWeekend' {
   import { isWeekend } from 'date-fns'
-  export = isWeekend
+  export default isWeekend
 }
 
 declare module 'date-fns/isWithinInterval' {
   import { isWithinInterval } from 'date-fns'
-  export = isWithinInterval
+  export default isWithinInterval
 }
 
 declare module 'date-fns/lastDayOfDecade' {
   import { lastDayOfDecade } from 'date-fns'
-  export = lastDayOfDecade
+  export default lastDayOfDecade
 }
 
 declare module 'date-fns/lastDayOfISOWeek' {
   import { lastDayOfISOWeek } from 'date-fns'
-  export = lastDayOfISOWeek
+  export default lastDayOfISOWeek
 }
 
 declare module 'date-fns/lastDayOfISOWeekYear' {
   import { lastDayOfISOWeekYear } from 'date-fns'
-  export = lastDayOfISOWeekYear
+  export default lastDayOfISOWeekYear
 }
 
 declare module 'date-fns/lastDayOfMonth' {
   import { lastDayOfMonth } from 'date-fns'
-  export = lastDayOfMonth
+  export default lastDayOfMonth
 }
 
 declare module 'date-fns/lastDayOfQuarter' {
   import { lastDayOfQuarter } from 'date-fns'
-  export = lastDayOfQuarter
+  export default lastDayOfQuarter
 }
 
 declare module 'date-fns/lastDayOfWeek' {
   import { lastDayOfWeek } from 'date-fns'
-  export = lastDayOfWeek
+  export default lastDayOfWeek
 }
 
 declare module 'date-fns/lastDayOfYear' {
   import { lastDayOfYear } from 'date-fns'
-  export = lastDayOfYear
+  export default lastDayOfYear
 }
 
 declare module 'date-fns/lightFormat' {
   import { lightFormat } from 'date-fns'
-  export = lightFormat
+  export default lightFormat
 }
 
 declare module 'date-fns/max' {
   import { max } from 'date-fns'
-  export = max
+  export default max
 }
 
 declare module 'date-fns/min' {
   import { min } from 'date-fns'
-  export = min
+  export default min
 }
 
 declare module 'date-fns/parse' {
   import { parse } from 'date-fns'
-  export = parse
+  export default parse
 }
 
 declare module 'date-fns/parseISO' {
   import { parseISO } from 'date-fns'
-  export = parseISO
+  export default parseISO
 }
 
 declare module 'date-fns/roundToNearestMinutes' {
   import { roundToNearestMinutes } from 'date-fns'
-  export = roundToNearestMinutes
+  export default roundToNearestMinutes
 }
 
 declare module 'date-fns/setDate' {
   import { setDate } from 'date-fns'
-  export = setDate
+  export default setDate
 }
 
 declare module 'date-fns/setDay' {
   import { setDay } from 'date-fns'
-  export = setDay
+  export default setDay
 }
 
 declare module 'date-fns/setDayOfYear' {
   import { setDayOfYear } from 'date-fns'
-  export = setDayOfYear
+  export default setDayOfYear
 }
 
 declare module 'date-fns/setHours' {
   import { setHours } from 'date-fns'
-  export = setHours
+  export default setHours
 }
 
 declare module 'date-fns/setISODay' {
   import { setISODay } from 'date-fns'
-  export = setISODay
+  export default setISODay
 }
 
 declare module 'date-fns/setISOWeek' {
   import { setISOWeek } from 'date-fns'
-  export = setISOWeek
+  export default setISOWeek
 }
 
 declare module 'date-fns/setISOWeekYear' {
   import { setISOWeekYear } from 'date-fns'
-  export = setISOWeekYear
+  export default setISOWeekYear
 }
 
 declare module 'date-fns/setMilliseconds' {
   import { setMilliseconds } from 'date-fns'
-  export = setMilliseconds
+  export default setMilliseconds
 }
 
 declare module 'date-fns/setMinutes' {
   import { setMinutes } from 'date-fns'
-  export = setMinutes
+  export default setMinutes
 }
 
 declare module 'date-fns/setMonth' {
   import { setMonth } from 'date-fns'
-  export = setMonth
+  export default setMonth
 }
 
 declare module 'date-fns/setQuarter' {
   import { setQuarter } from 'date-fns'
-  export = setQuarter
+  export default setQuarter
 }
 
 declare module 'date-fns/setSeconds' {
   import { setSeconds } from 'date-fns'
-  export = setSeconds
+  export default setSeconds
 }
 
 declare module 'date-fns/setWeek' {
   import { setWeek } from 'date-fns'
-  export = setWeek
+  export default setWeek
 }
 
 declare module 'date-fns/setWeekYear' {
   import { setWeekYear } from 'date-fns'
-  export = setWeekYear
+  export default setWeekYear
 }
 
 declare module 'date-fns/setYear' {
   import { setYear } from 'date-fns'
-  export = setYear
+  export default setYear
 }
 
 declare module 'date-fns/startOfDay' {
   import { startOfDay } from 'date-fns'
-  export = startOfDay
+  export default startOfDay
 }
 
 declare module 'date-fns/startOfDecade' {
   import { startOfDecade } from 'date-fns'
-  export = startOfDecade
+  export default startOfDecade
 }
 
 declare module 'date-fns/startOfHour' {
   import { startOfHour } from 'date-fns'
-  export = startOfHour
+  export default startOfHour
 }
 
 declare module 'date-fns/startOfISOWeek' {
   import { startOfISOWeek } from 'date-fns'
-  export = startOfISOWeek
+  export default startOfISOWeek
 }
 
 declare module 'date-fns/startOfISOWeekYear' {
   import { startOfISOWeekYear } from 'date-fns'
-  export = startOfISOWeekYear
+  export default startOfISOWeekYear
 }
 
 declare module 'date-fns/startOfMinute' {
   import { startOfMinute } from 'date-fns'
-  export = startOfMinute
+  export default startOfMinute
 }
 
 declare module 'date-fns/startOfMonth' {
   import { startOfMonth } from 'date-fns'
-  export = startOfMonth
+  export default startOfMonth
 }
 
 declare module 'date-fns/startOfQuarter' {
   import { startOfQuarter } from 'date-fns'
-  export = startOfQuarter
+  export default startOfQuarter
 }
 
 declare module 'date-fns/startOfSecond' {
   import { startOfSecond } from 'date-fns'
-  export = startOfSecond
+  export default startOfSecond
 }
 
 declare module 'date-fns/startOfWeek' {
   import { startOfWeek } from 'date-fns'
-  export = startOfWeek
+  export default startOfWeek
 }
 
 declare module 'date-fns/startOfWeekYear' {
   import { startOfWeekYear } from 'date-fns'
-  export = startOfWeekYear
+  export default startOfWeekYear
 }
 
 declare module 'date-fns/startOfYear' {
   import { startOfYear } from 'date-fns'
-  export = startOfYear
+  export default startOfYear
 }
 
 declare module 'date-fns/subDays' {
   import { subDays } from 'date-fns'
-  export = subDays
+  export default subDays
 }
 
 declare module 'date-fns/subHours' {
   import { subHours } from 'date-fns'
-  export = subHours
+  export default subHours
 }
 
 declare module 'date-fns/subISOWeekYears' {
   import { subISOWeekYears } from 'date-fns'
-  export = subISOWeekYears
+  export default subISOWeekYears
 }
 
 declare module 'date-fns/subMilliseconds' {
   import { subMilliseconds } from 'date-fns'
-  export = subMilliseconds
+  export default subMilliseconds
 }
 
 declare module 'date-fns/subMinutes' {
   import { subMinutes } from 'date-fns'
-  export = subMinutes
+  export default subMinutes
 }
 
 declare module 'date-fns/subMonths' {
   import { subMonths } from 'date-fns'
-  export = subMonths
+  export default subMonths
 }
 
 declare module 'date-fns/subQuarters' {
   import { subQuarters } from 'date-fns'
-  export = subQuarters
+  export default subQuarters
 }
 
 declare module 'date-fns/subSeconds' {
   import { subSeconds } from 'date-fns'
-  export = subSeconds
+  export default subSeconds
 }
 
 declare module 'date-fns/subWeeks' {
   import { subWeeks } from 'date-fns'
-  export = subWeeks
+  export default subWeeks
 }
 
 declare module 'date-fns/subYears' {
   import { subYears } from 'date-fns'
-  export = subYears
+  export default subYears
 }
 
 declare module 'date-fns/toDate' {
   import { toDate } from 'date-fns'
-  export = toDate
+  export default toDate
 }
 
 declare module 'date-fns/addDays/index' {
   import { addDays } from 'date-fns'
-  export = addDays
+  export default addDays
 }
 
 declare module 'date-fns/addHours/index' {
   import { addHours } from 'date-fns'
-  export = addHours
+  export default addHours
 }
 
 declare module 'date-fns/addISOWeekYears/index' {
   import { addISOWeekYears } from 'date-fns'
-  export = addISOWeekYears
+  export default addISOWeekYears
 }
 
 declare module 'date-fns/addMilliseconds/index' {
   import { addMilliseconds } from 'date-fns'
-  export = addMilliseconds
+  export default addMilliseconds
 }
 
 declare module 'date-fns/addMinutes/index' {
   import { addMinutes } from 'date-fns'
-  export = addMinutes
+  export default addMinutes
 }
 
 declare module 'date-fns/addMonths/index' {
   import { addMonths } from 'date-fns'
-  export = addMonths
+  export default addMonths
 }
 
 declare module 'date-fns/addQuarters/index' {
   import { addQuarters } from 'date-fns'
-  export = addQuarters
+  export default addQuarters
 }
 
 declare module 'date-fns/addSeconds/index' {
   import { addSeconds } from 'date-fns'
-  export = addSeconds
+  export default addSeconds
 }
 
 declare module 'date-fns/addWeeks/index' {
   import { addWeeks } from 'date-fns'
-  export = addWeeks
+  export default addWeeks
 }
 
 declare module 'date-fns/addYears/index' {
   import { addYears } from 'date-fns'
-  export = addYears
+  export default addYears
 }
 
 declare module 'date-fns/areIntervalsOverlapping/index' {
   import { areIntervalsOverlapping } from 'date-fns'
-  export = areIntervalsOverlapping
+  export default areIntervalsOverlapping
 }
 
 declare module 'date-fns/closestIndexTo/index' {
   import { closestIndexTo } from 'date-fns'
-  export = closestIndexTo
+  export default closestIndexTo
 }
 
 declare module 'date-fns/closestTo/index' {
   import { closestTo } from 'date-fns'
-  export = closestTo
+  export default closestTo
 }
 
 declare module 'date-fns/compareAsc/index' {
   import { compareAsc } from 'date-fns'
-  export = compareAsc
+  export default compareAsc
 }
 
 declare module 'date-fns/compareDesc/index' {
   import { compareDesc } from 'date-fns'
-  export = compareDesc
+  export default compareDesc
 }
 
 declare module 'date-fns/differenceInCalendarDays/index' {
   import { differenceInCalendarDays } from 'date-fns'
-  export = differenceInCalendarDays
+  export default differenceInCalendarDays
 }
 
 declare module 'date-fns/differenceInCalendarISOWeeks/index' {
   import { differenceInCalendarISOWeeks } from 'date-fns'
-  export = differenceInCalendarISOWeeks
+  export default differenceInCalendarISOWeeks
 }
 
 declare module 'date-fns/differenceInCalendarISOWeekYears/index' {
   import { differenceInCalendarISOWeekYears } from 'date-fns'
-  export = differenceInCalendarISOWeekYears
+  export default differenceInCalendarISOWeekYears
 }
 
 declare module 'date-fns/differenceInCalendarMonths/index' {
   import { differenceInCalendarMonths } from 'date-fns'
-  export = differenceInCalendarMonths
+  export default differenceInCalendarMonths
 }
 
 declare module 'date-fns/differenceInCalendarQuarters/index' {
   import { differenceInCalendarQuarters } from 'date-fns'
-  export = differenceInCalendarQuarters
+  export default differenceInCalendarQuarters
 }
 
 declare module 'date-fns/differenceInCalendarWeeks/index' {
   import { differenceInCalendarWeeks } from 'date-fns'
-  export = differenceInCalendarWeeks
+  export default differenceInCalendarWeeks
 }
 
 declare module 'date-fns/differenceInCalendarYears/index' {
   import { differenceInCalendarYears } from 'date-fns'
-  export = differenceInCalendarYears
+  export default differenceInCalendarYears
 }
 
 declare module 'date-fns/differenceInDays/index' {
   import { differenceInDays } from 'date-fns'
-  export = differenceInDays
+  export default differenceInDays
 }
 
 declare module 'date-fns/differenceInHours/index' {
   import { differenceInHours } from 'date-fns'
-  export = differenceInHours
+  export default differenceInHours
 }
 
 declare module 'date-fns/differenceInISOWeekYears/index' {
   import { differenceInISOWeekYears } from 'date-fns'
-  export = differenceInISOWeekYears
+  export default differenceInISOWeekYears
 }
 
 declare module 'date-fns/differenceInMilliseconds/index' {
   import { differenceInMilliseconds } from 'date-fns'
-  export = differenceInMilliseconds
+  export default differenceInMilliseconds
 }
 
 declare module 'date-fns/differenceInMinutes/index' {
   import { differenceInMinutes } from 'date-fns'
-  export = differenceInMinutes
+  export default differenceInMinutes
 }
 
 declare module 'date-fns/differenceInMonths/index' {
   import { differenceInMonths } from 'date-fns'
-  export = differenceInMonths
+  export default differenceInMonths
 }
 
 declare module 'date-fns/differenceInQuarters/index' {
   import { differenceInQuarters } from 'date-fns'
-  export = differenceInQuarters
+  export default differenceInQuarters
 }
 
 declare module 'date-fns/differenceInSeconds/index' {
   import { differenceInSeconds } from 'date-fns'
-  export = differenceInSeconds
+  export default differenceInSeconds
 }
 
 declare module 'date-fns/differenceInWeeks/index' {
   import { differenceInWeeks } from 'date-fns'
-  export = differenceInWeeks
+  export default differenceInWeeks
 }
 
 declare module 'date-fns/differenceInYears/index' {
   import { differenceInYears } from 'date-fns'
-  export = differenceInYears
+  export default differenceInYears
 }
 
 declare module 'date-fns/eachDayOfInterval/index' {
   import { eachDayOfInterval } from 'date-fns'
-  export = eachDayOfInterval
+  export default eachDayOfInterval
 }
 
 declare module 'date-fns/eachWeekendOfInterval/index' {
   import { eachWeekendOfInterval } from 'date-fns'
-  export = eachWeekendOfInterval
+  export default eachWeekendOfInterval
 }
 
 declare module 'date-fns/eachWeekendOfMonth/index' {
   import { eachWeekendOfMonth } from 'date-fns'
-  export = eachWeekendOfMonth
+  export default eachWeekendOfMonth
 }
 
 declare module 'date-fns/eachWeekendOfYear/index' {
   import { eachWeekendOfYear } from 'date-fns'
-  export = eachWeekendOfYear
+  export default eachWeekendOfYear
 }
 
 declare module 'date-fns/eachWeekOfInterval/index' {
   import { eachWeekOfInterval } from 'date-fns'
-  export = eachWeekOfInterval
+  export default eachWeekOfInterval
 }
 
 declare module 'date-fns/endOfDay/index' {
   import { endOfDay } from 'date-fns'
-  export = endOfDay
+  export default endOfDay
 }
 
 declare module 'date-fns/endOfDecade/index' {
   import { endOfDecade } from 'date-fns'
-  export = endOfDecade
+  export default endOfDecade
 }
 
 declare module 'date-fns/endOfHour/index' {
   import { endOfHour } from 'date-fns'
-  export = endOfHour
+  export default endOfHour
 }
 
 declare module 'date-fns/endOfISOWeek/index' {
   import { endOfISOWeek } from 'date-fns'
-  export = endOfISOWeek
+  export default endOfISOWeek
 }
 
 declare module 'date-fns/endOfISOWeekYear/index' {
   import { endOfISOWeekYear } from 'date-fns'
-  export = endOfISOWeekYear
+  export default endOfISOWeekYear
 }
 
 declare module 'date-fns/endOfMinute/index' {
   import { endOfMinute } from 'date-fns'
-  export = endOfMinute
+  export default endOfMinute
 }
 
 declare module 'date-fns/endOfMonth/index' {
   import { endOfMonth } from 'date-fns'
-  export = endOfMonth
+  export default endOfMonth
 }
 
 declare module 'date-fns/endOfQuarter/index' {
   import { endOfQuarter } from 'date-fns'
-  export = endOfQuarter
+  export default endOfQuarter
 }
 
 declare module 'date-fns/endOfSecond/index' {
   import { endOfSecond } from 'date-fns'
-  export = endOfSecond
+  export default endOfSecond
 }
 
 declare module 'date-fns/endOfWeek/index' {
   import { endOfWeek } from 'date-fns'
-  export = endOfWeek
+  export default endOfWeek
 }
 
 declare module 'date-fns/endOfYear/index' {
   import { endOfYear } from 'date-fns'
-  export = endOfYear
+  export default endOfYear
 }
 
 declare module 'date-fns/format/index' {
   import { format } from 'date-fns'
-  export = format
+  export default format
 }
 
 declare module 'date-fns/formatDistance/index' {
   import { formatDistance } from 'date-fns'
-  export = formatDistance
+  export default formatDistance
 }
 
 declare module 'date-fns/formatDistanceStrict/index' {
   import { formatDistanceStrict } from 'date-fns'
-  export = formatDistanceStrict
+  export default formatDistanceStrict
 }
 
 declare module 'date-fns/formatRelative/index' {
   import { formatRelative } from 'date-fns'
-  export = formatRelative
+  export default formatRelative
 }
 
 declare module 'date-fns/fromUnixTime/index' {
   import { fromUnixTime } from 'date-fns'
-  export = fromUnixTime
+  export default fromUnixTime
 }
 
 declare module 'date-fns/getDate/index' {
   import { getDate } from 'date-fns'
-  export = getDate
+  export default getDate
 }
 
 declare module 'date-fns/getDay/index' {
   import { getDay } from 'date-fns'
-  export = getDay
+  export default getDay
 }
 
 declare module 'date-fns/getDayOfYear/index' {
   import { getDayOfYear } from 'date-fns'
-  export = getDayOfYear
+  export default getDayOfYear
 }
 
 declare module 'date-fns/getDaysInMonth/index' {
   import { getDaysInMonth } from 'date-fns'
-  export = getDaysInMonth
+  export default getDaysInMonth
 }
 
 declare module 'date-fns/getDaysInYear/index' {
   import { getDaysInYear } from 'date-fns'
-  export = getDaysInYear
+  export default getDaysInYear
 }
 
 declare module 'date-fns/getDecade/index' {
   import { getDecade } from 'date-fns'
-  export = getDecade
+  export default getDecade
 }
 
 declare module 'date-fns/getHours/index' {
   import { getHours } from 'date-fns'
-  export = getHours
+  export default getHours
 }
 
 declare module 'date-fns/getISODay/index' {
   import { getISODay } from 'date-fns'
-  export = getISODay
+  export default getISODay
 }
 
 declare module 'date-fns/getISOWeek/index' {
   import { getISOWeek } from 'date-fns'
-  export = getISOWeek
+  export default getISOWeek
 }
 
 declare module 'date-fns/getISOWeeksInYear/index' {
   import { getISOWeeksInYear } from 'date-fns'
-  export = getISOWeeksInYear
+  export default getISOWeeksInYear
 }
 
 declare module 'date-fns/getISOWeekYear/index' {
   import { getISOWeekYear } from 'date-fns'
-  export = getISOWeekYear
+  export default getISOWeekYear
 }
 
 declare module 'date-fns/getMilliseconds/index' {
   import { getMilliseconds } from 'date-fns'
-  export = getMilliseconds
+  export default getMilliseconds
 }
 
 declare module 'date-fns/getMinutes/index' {
   import { getMinutes } from 'date-fns'
-  export = getMinutes
+  export default getMinutes
 }
 
 declare module 'date-fns/getMonth/index' {
   import { getMonth } from 'date-fns'
-  export = getMonth
+  export default getMonth
 }
 
 declare module 'date-fns/getOverlappingDaysInIntervals/index' {
   import { getOverlappingDaysInIntervals } from 'date-fns'
-  export = getOverlappingDaysInIntervals
+  export default getOverlappingDaysInIntervals
 }
 
 declare module 'date-fns/getQuarter/index' {
   import { getQuarter } from 'date-fns'
-  export = getQuarter
+  export default getQuarter
 }
 
 declare module 'date-fns/getSeconds/index' {
   import { getSeconds } from 'date-fns'
-  export = getSeconds
+  export default getSeconds
 }
 
 declare module 'date-fns/getTime/index' {
   import { getTime } from 'date-fns'
-  export = getTime
+  export default getTime
 }
 
 declare module 'date-fns/getUnixTime/index' {
   import { getUnixTime } from 'date-fns'
-  export = getUnixTime
+  export default getUnixTime
 }
 
 declare module 'date-fns/getWeek/index' {
   import { getWeek } from 'date-fns'
-  export = getWeek
+  export default getWeek
 }
 
 declare module 'date-fns/getWeekOfMonth/index' {
   import { getWeekOfMonth } from 'date-fns'
-  export = getWeekOfMonth
+  export default getWeekOfMonth
 }
 
 declare module 'date-fns/getWeeksInMonth/index' {
   import { getWeeksInMonth } from 'date-fns'
-  export = getWeeksInMonth
+  export default getWeeksInMonth
 }
 
 declare module 'date-fns/getWeekYear/index' {
   import { getWeekYear } from 'date-fns'
-  export = getWeekYear
+  export default getWeekYear
 }
 
 declare module 'date-fns/getYear/index' {
   import { getYear } from 'date-fns'
-  export = getYear
+  export default getYear
 }
 
 declare module 'date-fns/isAfter/index' {
   import { isAfter } from 'date-fns'
-  export = isAfter
+  export default isAfter
 }
 
 declare module 'date-fns/isBefore/index' {
   import { isBefore } from 'date-fns'
-  export = isBefore
+  export default isBefore
 }
 
 declare module 'date-fns/isDate/index' {
   import { isDate } from 'date-fns'
-  export = isDate
+  export default isDate
 }
 
 declare module 'date-fns/isEqual/index' {
   import { isEqual } from 'date-fns'
-  export = isEqual
+  export default isEqual
 }
 
 declare module 'date-fns/isFirstDayOfMonth/index' {
   import { isFirstDayOfMonth } from 'date-fns'
-  export = isFirstDayOfMonth
+  export default isFirstDayOfMonth
 }
 
 declare module 'date-fns/isFriday/index' {
   import { isFriday } from 'date-fns'
-  export = isFriday
+  export default isFriday
 }
 
 declare module 'date-fns/isLastDayOfMonth/index' {
   import { isLastDayOfMonth } from 'date-fns'
-  export = isLastDayOfMonth
+  export default isLastDayOfMonth
 }
 
 declare module 'date-fns/isLeapYear/index' {
   import { isLeapYear } from 'date-fns'
-  export = isLeapYear
+  export default isLeapYear
 }
 
 declare module 'date-fns/isMonday/index' {
   import { isMonday } from 'date-fns'
-  export = isMonday
+  export default isMonday
 }
 
 declare module 'date-fns/isSameDay/index' {
   import { isSameDay } from 'date-fns'
-  export = isSameDay
+  export default isSameDay
 }
 
 declare module 'date-fns/isSameHour/index' {
   import { isSameHour } from 'date-fns'
-  export = isSameHour
+  export default isSameHour
 }
 
 declare module 'date-fns/isSameISOWeek/index' {
   import { isSameISOWeek } from 'date-fns'
-  export = isSameISOWeek
+  export default isSameISOWeek
 }
 
 declare module 'date-fns/isSameISOWeekYear/index' {
   import { isSameISOWeekYear } from 'date-fns'
-  export = isSameISOWeekYear
+  export default isSameISOWeekYear
 }
 
 declare module 'date-fns/isSameMinute/index' {
   import { isSameMinute } from 'date-fns'
-  export = isSameMinute
+  export default isSameMinute
 }
 
 declare module 'date-fns/isSameMonth/index' {
   import { isSameMonth } from 'date-fns'
-  export = isSameMonth
+  export default isSameMonth
 }
 
 declare module 'date-fns/isSameQuarter/index' {
   import { isSameQuarter } from 'date-fns'
-  export = isSameQuarter
+  export default isSameQuarter
 }
 
 declare module 'date-fns/isSameSecond/index' {
   import { isSameSecond } from 'date-fns'
-  export = isSameSecond
+  export default isSameSecond
 }
 
 declare module 'date-fns/isSameWeek/index' {
   import { isSameWeek } from 'date-fns'
-  export = isSameWeek
+  export default isSameWeek
 }
 
 declare module 'date-fns/isSameYear/index' {
   import { isSameYear } from 'date-fns'
-  export = isSameYear
+  export default isSameYear
 }
 
 declare module 'date-fns/isSaturday/index' {
   import { isSaturday } from 'date-fns'
-  export = isSaturday
+  export default isSaturday
 }
 
 declare module 'date-fns/isSunday/index' {
   import { isSunday } from 'date-fns'
-  export = isSunday
+  export default isSunday
 }
 
 declare module 'date-fns/isThursday/index' {
   import { isThursday } from 'date-fns'
-  export = isThursday
+  export default isThursday
 }
 
 declare module 'date-fns/isTuesday/index' {
   import { isTuesday } from 'date-fns'
-  export = isTuesday
+  export default isTuesday
 }
 
 declare module 'date-fns/isValid/index' {
   import { isValid } from 'date-fns'
-  export = isValid
+  export default isValid
 }
 
 declare module 'date-fns/isWednesday/index' {
   import { isWednesday } from 'date-fns'
-  export = isWednesday
+  export default isWednesday
 }
 
 declare module 'date-fns/isWeekend/index' {
   import { isWeekend } from 'date-fns'
-  export = isWeekend
+  export default isWeekend
 }
 
 declare module 'date-fns/isWithinInterval/index' {
   import { isWithinInterval } from 'date-fns'
-  export = isWithinInterval
+  export default isWithinInterval
 }
 
 declare module 'date-fns/lastDayOfDecade/index' {
   import { lastDayOfDecade } from 'date-fns'
-  export = lastDayOfDecade
+  export default lastDayOfDecade
 }
 
 declare module 'date-fns/lastDayOfISOWeek/index' {
   import { lastDayOfISOWeek } from 'date-fns'
-  export = lastDayOfISOWeek
+  export default lastDayOfISOWeek
 }
 
 declare module 'date-fns/lastDayOfISOWeekYear/index' {
   import { lastDayOfISOWeekYear } from 'date-fns'
-  export = lastDayOfISOWeekYear
+  export default lastDayOfISOWeekYear
 }
 
 declare module 'date-fns/lastDayOfMonth/index' {
   import { lastDayOfMonth } from 'date-fns'
-  export = lastDayOfMonth
+  export default lastDayOfMonth
 }
 
 declare module 'date-fns/lastDayOfQuarter/index' {
   import { lastDayOfQuarter } from 'date-fns'
-  export = lastDayOfQuarter
+  export default lastDayOfQuarter
 }
 
 declare module 'date-fns/lastDayOfWeek/index' {
   import { lastDayOfWeek } from 'date-fns'
-  export = lastDayOfWeek
+  export default lastDayOfWeek
 }
 
 declare module 'date-fns/lastDayOfYear/index' {
   import { lastDayOfYear } from 'date-fns'
-  export = lastDayOfYear
+  export default lastDayOfYear
 }
 
 declare module 'date-fns/lightFormat/index' {
   import { lightFormat } from 'date-fns'
-  export = lightFormat
+  export default lightFormat
 }
 
 declare module 'date-fns/max/index' {
   import { max } from 'date-fns'
-  export = max
+  export default max
 }
 
 declare module 'date-fns/min/index' {
   import { min } from 'date-fns'
-  export = min
+  export default min
 }
 
 declare module 'date-fns/parse/index' {
   import { parse } from 'date-fns'
-  export = parse
+  export default parse
 }
 
 declare module 'date-fns/parseISO/index' {
   import { parseISO } from 'date-fns'
-  export = parseISO
+  export default parseISO
 }
 
 declare module 'date-fns/roundToNearestMinutes/index' {
   import { roundToNearestMinutes } from 'date-fns'
-  export = roundToNearestMinutes
+  export default roundToNearestMinutes
 }
 
 declare module 'date-fns/setDate/index' {
   import { setDate } from 'date-fns'
-  export = setDate
+  export default setDate
 }
 
 declare module 'date-fns/setDay/index' {
   import { setDay } from 'date-fns'
-  export = setDay
+  export default setDay
 }
 
 declare module 'date-fns/setDayOfYear/index' {
   import { setDayOfYear } from 'date-fns'
-  export = setDayOfYear
+  export default setDayOfYear
 }
 
 declare module 'date-fns/setHours/index' {
   import { setHours } from 'date-fns'
-  export = setHours
+  export default setHours
 }
 
 declare module 'date-fns/setISODay/index' {
   import { setISODay } from 'date-fns'
-  export = setISODay
+  export default setISODay
 }
 
 declare module 'date-fns/setISOWeek/index' {
   import { setISOWeek } from 'date-fns'
-  export = setISOWeek
+  export default setISOWeek
 }
 
 declare module 'date-fns/setISOWeekYear/index' {
   import { setISOWeekYear } from 'date-fns'
-  export = setISOWeekYear
+  export default setISOWeekYear
 }
 
 declare module 'date-fns/setMilliseconds/index' {
   import { setMilliseconds } from 'date-fns'
-  export = setMilliseconds
+  export default setMilliseconds
 }
 
 declare module 'date-fns/setMinutes/index' {
   import { setMinutes } from 'date-fns'
-  export = setMinutes
+  export default setMinutes
 }
 
 declare module 'date-fns/setMonth/index' {
   import { setMonth } from 'date-fns'
-  export = setMonth
+  export default setMonth
 }
 
 declare module 'date-fns/setQuarter/index' {
   import { setQuarter } from 'date-fns'
-  export = setQuarter
+  export default setQuarter
 }
 
 declare module 'date-fns/setSeconds/index' {
   import { setSeconds } from 'date-fns'
-  export = setSeconds
+  export default setSeconds
 }
 
 declare module 'date-fns/setWeek/index' {
   import { setWeek } from 'date-fns'
-  export = setWeek
+  export default setWeek
 }
 
 declare module 'date-fns/setWeekYear/index' {
   import { setWeekYear } from 'date-fns'
-  export = setWeekYear
+  export default setWeekYear
 }
 
 declare module 'date-fns/setYear/index' {
   import { setYear } from 'date-fns'
-  export = setYear
+  export default setYear
 }
 
 declare module 'date-fns/startOfDay/index' {
   import { startOfDay } from 'date-fns'
-  export = startOfDay
+  export default startOfDay
 }
 
 declare module 'date-fns/startOfDecade/index' {
   import { startOfDecade } from 'date-fns'
-  export = startOfDecade
+  export default startOfDecade
 }
 
 declare module 'date-fns/startOfHour/index' {
   import { startOfHour } from 'date-fns'
-  export = startOfHour
+  export default startOfHour
 }
 
 declare module 'date-fns/startOfISOWeek/index' {
   import { startOfISOWeek } from 'date-fns'
-  export = startOfISOWeek
+  export default startOfISOWeek
 }
 
 declare module 'date-fns/startOfISOWeekYear/index' {
   import { startOfISOWeekYear } from 'date-fns'
-  export = startOfISOWeekYear
+  export default startOfISOWeekYear
 }
 
 declare module 'date-fns/startOfMinute/index' {
   import { startOfMinute } from 'date-fns'
-  export = startOfMinute
+  export default startOfMinute
 }
 
 declare module 'date-fns/startOfMonth/index' {
   import { startOfMonth } from 'date-fns'
-  export = startOfMonth
+  export default startOfMonth
 }
 
 declare module 'date-fns/startOfQuarter/index' {
   import { startOfQuarter } from 'date-fns'
-  export = startOfQuarter
+  export default startOfQuarter
 }
 
 declare module 'date-fns/startOfSecond/index' {
   import { startOfSecond } from 'date-fns'
-  export = startOfSecond
+  export default startOfSecond
 }
 
 declare module 'date-fns/startOfWeek/index' {
   import { startOfWeek } from 'date-fns'
-  export = startOfWeek
+  export default startOfWeek
 }
 
 declare module 'date-fns/startOfWeekYear/index' {
   import { startOfWeekYear } from 'date-fns'
-  export = startOfWeekYear
+  export default startOfWeekYear
 }
 
 declare module 'date-fns/startOfYear/index' {
   import { startOfYear } from 'date-fns'
-  export = startOfYear
+  export default startOfYear
 }
 
 declare module 'date-fns/subDays/index' {
   import { subDays } from 'date-fns'
-  export = subDays
+  export default subDays
 }
 
 declare module 'date-fns/subHours/index' {
   import { subHours } from 'date-fns'
-  export = subHours
+  export default subHours
 }
 
 declare module 'date-fns/subISOWeekYears/index' {
   import { subISOWeekYears } from 'date-fns'
-  export = subISOWeekYears
+  export default subISOWeekYears
 }
 
 declare module 'date-fns/subMilliseconds/index' {
   import { subMilliseconds } from 'date-fns'
-  export = subMilliseconds
+  export default subMilliseconds
 }
 
 declare module 'date-fns/subMinutes/index' {
   import { subMinutes } from 'date-fns'
-  export = subMinutes
+  export default subMinutes
 }
 
 declare module 'date-fns/subMonths/index' {
   import { subMonths } from 'date-fns'
-  export = subMonths
+  export default subMonths
 }
 
 declare module 'date-fns/subQuarters/index' {
   import { subQuarters } from 'date-fns'
-  export = subQuarters
+  export default subQuarters
 }
 
 declare module 'date-fns/subSeconds/index' {
   import { subSeconds } from 'date-fns'
-  export = subSeconds
+  export default subSeconds
 }
 
 declare module 'date-fns/subWeeks/index' {
   import { subWeeks } from 'date-fns'
-  export = subWeeks
+  export default subWeeks
 }
 
 declare module 'date-fns/subYears/index' {
   import { subYears } from 'date-fns'
-  export = subYears
+  export default subYears
 }
 
 declare module 'date-fns/toDate/index' {
   import { toDate } from 'date-fns'
-  export = toDate
+  export default toDate
 }
 
 declare module 'date-fns/addDays/index.js' {
   import { addDays } from 'date-fns'
-  export = addDays
+  export default addDays
 }
 
 declare module 'date-fns/addHours/index.js' {
   import { addHours } from 'date-fns'
-  export = addHours
+  export default addHours
 }
 
 declare module 'date-fns/addISOWeekYears/index.js' {
   import { addISOWeekYears } from 'date-fns'
-  export = addISOWeekYears
+  export default addISOWeekYears
 }
 
 declare module 'date-fns/addMilliseconds/index.js' {
   import { addMilliseconds } from 'date-fns'
-  export = addMilliseconds
+  export default addMilliseconds
 }
 
 declare module 'date-fns/addMinutes/index.js' {
   import { addMinutes } from 'date-fns'
-  export = addMinutes
+  export default addMinutes
 }
 
 declare module 'date-fns/addMonths/index.js' {
   import { addMonths } from 'date-fns'
-  export = addMonths
+  export default addMonths
 }
 
 declare module 'date-fns/addQuarters/index.js' {
   import { addQuarters } from 'date-fns'
-  export = addQuarters
+  export default addQuarters
 }
 
 declare module 'date-fns/addSeconds/index.js' {
   import { addSeconds } from 'date-fns'
-  export = addSeconds
+  export default addSeconds
 }
 
 declare module 'date-fns/addWeeks/index.js' {
   import { addWeeks } from 'date-fns'
-  export = addWeeks
+  export default addWeeks
 }
 
 declare module 'date-fns/addYears/index.js' {
   import { addYears } from 'date-fns'
-  export = addYears
+  export default addYears
 }
 
 declare module 'date-fns/areIntervalsOverlapping/index.js' {
   import { areIntervalsOverlapping } from 'date-fns'
-  export = areIntervalsOverlapping
+  export default areIntervalsOverlapping
 }
 
 declare module 'date-fns/closestIndexTo/index.js' {
   import { closestIndexTo } from 'date-fns'
-  export = closestIndexTo
+  export default closestIndexTo
 }
 
 declare module 'date-fns/closestTo/index.js' {
   import { closestTo } from 'date-fns'
-  export = closestTo
+  export default closestTo
 }
 
 declare module 'date-fns/compareAsc/index.js' {
   import { compareAsc } from 'date-fns'
-  export = compareAsc
+  export default compareAsc
 }
 
 declare module 'date-fns/compareDesc/index.js' {
   import { compareDesc } from 'date-fns'
-  export = compareDesc
+  export default compareDesc
 }
 
 declare module 'date-fns/differenceInCalendarDays/index.js' {
   import { differenceInCalendarDays } from 'date-fns'
-  export = differenceInCalendarDays
+  export default differenceInCalendarDays
 }
 
 declare module 'date-fns/differenceInCalendarISOWeeks/index.js' {
   import { differenceInCalendarISOWeeks } from 'date-fns'
-  export = differenceInCalendarISOWeeks
+  export default differenceInCalendarISOWeeks
 }
 
 declare module 'date-fns/differenceInCalendarISOWeekYears/index.js' {
   import { differenceInCalendarISOWeekYears } from 'date-fns'
-  export = differenceInCalendarISOWeekYears
+  export default differenceInCalendarISOWeekYears
 }
 
 declare module 'date-fns/differenceInCalendarMonths/index.js' {
   import { differenceInCalendarMonths } from 'date-fns'
-  export = differenceInCalendarMonths
+  export default differenceInCalendarMonths
 }
 
 declare module 'date-fns/differenceInCalendarQuarters/index.js' {
   import { differenceInCalendarQuarters } from 'date-fns'
-  export = differenceInCalendarQuarters
+  export default differenceInCalendarQuarters
 }
 
 declare module 'date-fns/differenceInCalendarWeeks/index.js' {
   import { differenceInCalendarWeeks } from 'date-fns'
-  export = differenceInCalendarWeeks
+  export default differenceInCalendarWeeks
 }
 
 declare module 'date-fns/differenceInCalendarYears/index.js' {
   import { differenceInCalendarYears } from 'date-fns'
-  export = differenceInCalendarYears
+  export default differenceInCalendarYears
 }
 
 declare module 'date-fns/differenceInDays/index.js' {
   import { differenceInDays } from 'date-fns'
-  export = differenceInDays
+  export default differenceInDays
 }
 
 declare module 'date-fns/differenceInHours/index.js' {
   import { differenceInHours } from 'date-fns'
-  export = differenceInHours
+  export default differenceInHours
 }
 
 declare module 'date-fns/differenceInISOWeekYears/index.js' {
   import { differenceInISOWeekYears } from 'date-fns'
-  export = differenceInISOWeekYears
+  export default differenceInISOWeekYears
 }
 
 declare module 'date-fns/differenceInMilliseconds/index.js' {
   import { differenceInMilliseconds } from 'date-fns'
-  export = differenceInMilliseconds
+  export default differenceInMilliseconds
 }
 
 declare module 'date-fns/differenceInMinutes/index.js' {
   import { differenceInMinutes } from 'date-fns'
-  export = differenceInMinutes
+  export default differenceInMinutes
 }
 
 declare module 'date-fns/differenceInMonths/index.js' {
   import { differenceInMonths } from 'date-fns'
-  export = differenceInMonths
+  export default differenceInMonths
 }
 
 declare module 'date-fns/differenceInQuarters/index.js' {
   import { differenceInQuarters } from 'date-fns'
-  export = differenceInQuarters
+  export default differenceInQuarters
 }
 
 declare module 'date-fns/differenceInSeconds/index.js' {
   import { differenceInSeconds } from 'date-fns'
-  export = differenceInSeconds
+  export default differenceInSeconds
 }
 
 declare module 'date-fns/differenceInWeeks/index.js' {
   import { differenceInWeeks } from 'date-fns'
-  export = differenceInWeeks
+  export default differenceInWeeks
 }
 
 declare module 'date-fns/differenceInYears/index.js' {
   import { differenceInYears } from 'date-fns'
-  export = differenceInYears
+  export default differenceInYears
 }
 
 declare module 'date-fns/eachDayOfInterval/index.js' {
   import { eachDayOfInterval } from 'date-fns'
-  export = eachDayOfInterval
+  export default eachDayOfInterval
 }
 
 declare module 'date-fns/eachWeekendOfInterval/index.js' {
   import { eachWeekendOfInterval } from 'date-fns'
-  export = eachWeekendOfInterval
+  export default eachWeekendOfInterval
 }
 
 declare module 'date-fns/eachWeekendOfMonth/index.js' {
   import { eachWeekendOfMonth } from 'date-fns'
-  export = eachWeekendOfMonth
+  export default eachWeekendOfMonth
 }
 
 declare module 'date-fns/eachWeekendOfYear/index.js' {
   import { eachWeekendOfYear } from 'date-fns'
-  export = eachWeekendOfYear
+  export default eachWeekendOfYear
 }
 
 declare module 'date-fns/eachWeekOfInterval/index.js' {
   import { eachWeekOfInterval } from 'date-fns'
-  export = eachWeekOfInterval
+  export default eachWeekOfInterval
 }
 
 declare module 'date-fns/endOfDay/index.js' {
   import { endOfDay } from 'date-fns'
-  export = endOfDay
+  export default endOfDay
 }
 
 declare module 'date-fns/endOfDecade/index.js' {
   import { endOfDecade } from 'date-fns'
-  export = endOfDecade
+  export default endOfDecade
 }
 
 declare module 'date-fns/endOfHour/index.js' {
   import { endOfHour } from 'date-fns'
-  export = endOfHour
+  export default endOfHour
 }
 
 declare module 'date-fns/endOfISOWeek/index.js' {
   import { endOfISOWeek } from 'date-fns'
-  export = endOfISOWeek
+  export default endOfISOWeek
 }
 
 declare module 'date-fns/endOfISOWeekYear/index.js' {
   import { endOfISOWeekYear } from 'date-fns'
-  export = endOfISOWeekYear
+  export default endOfISOWeekYear
 }
 
 declare module 'date-fns/endOfMinute/index.js' {
   import { endOfMinute } from 'date-fns'
-  export = endOfMinute
+  export default endOfMinute
 }
 
 declare module 'date-fns/endOfMonth/index.js' {
   import { endOfMonth } from 'date-fns'
-  export = endOfMonth
+  export default endOfMonth
 }
 
 declare module 'date-fns/endOfQuarter/index.js' {
   import { endOfQuarter } from 'date-fns'
-  export = endOfQuarter
+  export default endOfQuarter
 }
 
 declare module 'date-fns/endOfSecond/index.js' {
   import { endOfSecond } from 'date-fns'
-  export = endOfSecond
+  export default endOfSecond
 }
 
 declare module 'date-fns/endOfWeek/index.js' {
   import { endOfWeek } from 'date-fns'
-  export = endOfWeek
+  export default endOfWeek
 }
 
 declare module 'date-fns/endOfYear/index.js' {
   import { endOfYear } from 'date-fns'
-  export = endOfYear
+  export default endOfYear
 }
 
 declare module 'date-fns/format/index.js' {
   import { format } from 'date-fns'
-  export = format
+  export default format
 }
 
 declare module 'date-fns/formatDistance/index.js' {
   import { formatDistance } from 'date-fns'
-  export = formatDistance
+  export default formatDistance
 }
 
 declare module 'date-fns/formatDistanceStrict/index.js' {
   import { formatDistanceStrict } from 'date-fns'
-  export = formatDistanceStrict
+  export default formatDistanceStrict
 }
 
 declare module 'date-fns/formatRelative/index.js' {
   import { formatRelative } from 'date-fns'
-  export = formatRelative
+  export default formatRelative
 }
 
 declare module 'date-fns/fromUnixTime/index.js' {
   import { fromUnixTime } from 'date-fns'
-  export = fromUnixTime
+  export default fromUnixTime
 }
 
 declare module 'date-fns/getDate/index.js' {
   import { getDate } from 'date-fns'
-  export = getDate
+  export default getDate
 }
 
 declare module 'date-fns/getDay/index.js' {
   import { getDay } from 'date-fns'
-  export = getDay
+  export default getDay
 }
 
 declare module 'date-fns/getDayOfYear/index.js' {
   import { getDayOfYear } from 'date-fns'
-  export = getDayOfYear
+  export default getDayOfYear
 }
 
 declare module 'date-fns/getDaysInMonth/index.js' {
   import { getDaysInMonth } from 'date-fns'
-  export = getDaysInMonth
+  export default getDaysInMonth
 }
 
 declare module 'date-fns/getDaysInYear/index.js' {
   import { getDaysInYear } from 'date-fns'
-  export = getDaysInYear
+  export default getDaysInYear
 }
 
 declare module 'date-fns/getDecade/index.js' {
   import { getDecade } from 'date-fns'
-  export = getDecade
+  export default getDecade
 }
 
 declare module 'date-fns/getHours/index.js' {
   import { getHours } from 'date-fns'
-  export = getHours
+  export default getHours
 }
 
 declare module 'date-fns/getISODay/index.js' {
   import { getISODay } from 'date-fns'
-  export = getISODay
+  export default getISODay
 }
 
 declare module 'date-fns/getISOWeek/index.js' {
   import { getISOWeek } from 'date-fns'
-  export = getISOWeek
+  export default getISOWeek
 }
 
 declare module 'date-fns/getISOWeeksInYear/index.js' {
   import { getISOWeeksInYear } from 'date-fns'
-  export = getISOWeeksInYear
+  export default getISOWeeksInYear
 }
 
 declare module 'date-fns/getISOWeekYear/index.js' {
   import { getISOWeekYear } from 'date-fns'
-  export = getISOWeekYear
+  export default getISOWeekYear
 }
 
 declare module 'date-fns/getMilliseconds/index.js' {
   import { getMilliseconds } from 'date-fns'
-  export = getMilliseconds
+  export default getMilliseconds
 }
 
 declare module 'date-fns/getMinutes/index.js' {
   import { getMinutes } from 'date-fns'
-  export = getMinutes
+  export default getMinutes
 }
 
 declare module 'date-fns/getMonth/index.js' {
   import { getMonth } from 'date-fns'
-  export = getMonth
+  export default getMonth
 }
 
 declare module 'date-fns/getOverlappingDaysInIntervals/index.js' {
   import { getOverlappingDaysInIntervals } from 'date-fns'
-  export = getOverlappingDaysInIntervals
+  export default getOverlappingDaysInIntervals
 }
 
 declare module 'date-fns/getQuarter/index.js' {
   import { getQuarter } from 'date-fns'
-  export = getQuarter
+  export default getQuarter
 }
 
 declare module 'date-fns/getSeconds/index.js' {
   import { getSeconds } from 'date-fns'
-  export = getSeconds
+  export default getSeconds
 }
 
 declare module 'date-fns/getTime/index.js' {
   import { getTime } from 'date-fns'
-  export = getTime
+  export default getTime
 }
 
 declare module 'date-fns/getUnixTime/index.js' {
   import { getUnixTime } from 'date-fns'
-  export = getUnixTime
+  export default getUnixTime
 }
 
 declare module 'date-fns/getWeek/index.js' {
   import { getWeek } from 'date-fns'
-  export = getWeek
+  export default getWeek
 }
 
 declare module 'date-fns/getWeekOfMonth/index.js' {
   import { getWeekOfMonth } from 'date-fns'
-  export = getWeekOfMonth
+  export default getWeekOfMonth
 }
 
 declare module 'date-fns/getWeeksInMonth/index.js' {
   import { getWeeksInMonth } from 'date-fns'
-  export = getWeeksInMonth
+  export default getWeeksInMonth
 }
 
 declare module 'date-fns/getWeekYear/index.js' {
   import { getWeekYear } from 'date-fns'
-  export = getWeekYear
+  export default getWeekYear
 }
 
 declare module 'date-fns/getYear/index.js' {
   import { getYear } from 'date-fns'
-  export = getYear
+  export default getYear
 }
 
 declare module 'date-fns/isAfter/index.js' {
   import { isAfter } from 'date-fns'
-  export = isAfter
+  export default isAfter
 }
 
 declare module 'date-fns/isBefore/index.js' {
   import { isBefore } from 'date-fns'
-  export = isBefore
+  export default isBefore
 }
 
 declare module 'date-fns/isDate/index.js' {
   import { isDate } from 'date-fns'
-  export = isDate
+  export default isDate
 }
 
 declare module 'date-fns/isEqual/index.js' {
   import { isEqual } from 'date-fns'
-  export = isEqual
+  export default isEqual
 }
 
 declare module 'date-fns/isFirstDayOfMonth/index.js' {
   import { isFirstDayOfMonth } from 'date-fns'
-  export = isFirstDayOfMonth
+  export default isFirstDayOfMonth
 }
 
 declare module 'date-fns/isFriday/index.js' {
   import { isFriday } from 'date-fns'
-  export = isFriday
+  export default isFriday
 }
 
 declare module 'date-fns/isLastDayOfMonth/index.js' {
   import { isLastDayOfMonth } from 'date-fns'
-  export = isLastDayOfMonth
+  export default isLastDayOfMonth
 }
 
 declare module 'date-fns/isLeapYear/index.js' {
   import { isLeapYear } from 'date-fns'
-  export = isLeapYear
+  export default isLeapYear
 }
 
 declare module 'date-fns/isMonday/index.js' {
   import { isMonday } from 'date-fns'
-  export = isMonday
+  export default isMonday
 }
 
 declare module 'date-fns/isSameDay/index.js' {
   import { isSameDay } from 'date-fns'
-  export = isSameDay
+  export default isSameDay
 }
 
 declare module 'date-fns/isSameHour/index.js' {
   import { isSameHour } from 'date-fns'
-  export = isSameHour
+  export default isSameHour
 }
 
 declare module 'date-fns/isSameISOWeek/index.js' {
   import { isSameISOWeek } from 'date-fns'
-  export = isSameISOWeek
+  export default isSameISOWeek
 }
 
 declare module 'date-fns/isSameISOWeekYear/index.js' {
   import { isSameISOWeekYear } from 'date-fns'
-  export = isSameISOWeekYear
+  export default isSameISOWeekYear
 }
 
 declare module 'date-fns/isSameMinute/index.js' {
   import { isSameMinute } from 'date-fns'
-  export = isSameMinute
+  export default isSameMinute
 }
 
 declare module 'date-fns/isSameMonth/index.js' {
   import { isSameMonth } from 'date-fns'
-  export = isSameMonth
+  export default isSameMonth
 }
 
 declare module 'date-fns/isSameQuarter/index.js' {
   import { isSameQuarter } from 'date-fns'
-  export = isSameQuarter
+  export default isSameQuarter
 }
 
 declare module 'date-fns/isSameSecond/index.js' {
   import { isSameSecond } from 'date-fns'
-  export = isSameSecond
+  export default isSameSecond
 }
 
 declare module 'date-fns/isSameWeek/index.js' {
   import { isSameWeek } from 'date-fns'
-  export = isSameWeek
+  export default isSameWeek
 }
 
 declare module 'date-fns/isSameYear/index.js' {
   import { isSameYear } from 'date-fns'
-  export = isSameYear
+  export default isSameYear
 }
 
 declare module 'date-fns/isSaturday/index.js' {
   import { isSaturday } from 'date-fns'
-  export = isSaturday
+  export default isSaturday
 }
 
 declare module 'date-fns/isSunday/index.js' {
   import { isSunday } from 'date-fns'
-  export = isSunday
+  export default isSunday
 }
 
 declare module 'date-fns/isThursday/index.js' {
   import { isThursday } from 'date-fns'
-  export = isThursday
+  export default isThursday
 }
 
 declare module 'date-fns/isTuesday/index.js' {
   import { isTuesday } from 'date-fns'
-  export = isTuesday
+  export default isTuesday
 }
 
 declare module 'date-fns/isValid/index.js' {
   import { isValid } from 'date-fns'
-  export = isValid
+  export default isValid
 }
 
 declare module 'date-fns/isWednesday/index.js' {
   import { isWednesday } from 'date-fns'
-  export = isWednesday
+  export default isWednesday
 }
 
 declare module 'date-fns/isWeekend/index.js' {
   import { isWeekend } from 'date-fns'
-  export = isWeekend
+  export default isWeekend
 }
 
 declare module 'date-fns/isWithinInterval/index.js' {
   import { isWithinInterval } from 'date-fns'
-  export = isWithinInterval
+  export default isWithinInterval
 }
 
 declare module 'date-fns/lastDayOfDecade/index.js' {
   import { lastDayOfDecade } from 'date-fns'
-  export = lastDayOfDecade
+  export default lastDayOfDecade
 }
 
 declare module 'date-fns/lastDayOfISOWeek/index.js' {
   import { lastDayOfISOWeek } from 'date-fns'
-  export = lastDayOfISOWeek
+  export default lastDayOfISOWeek
 }
 
 declare module 'date-fns/lastDayOfISOWeekYear/index.js' {
   import { lastDayOfISOWeekYear } from 'date-fns'
-  export = lastDayOfISOWeekYear
+  export default lastDayOfISOWeekYear
 }
 
 declare module 'date-fns/lastDayOfMonth/index.js' {
   import { lastDayOfMonth } from 'date-fns'
-  export = lastDayOfMonth
+  export default lastDayOfMonth
 }
 
 declare module 'date-fns/lastDayOfQuarter/index.js' {
   import { lastDayOfQuarter } from 'date-fns'
-  export = lastDayOfQuarter
+  export default lastDayOfQuarter
 }
 
 declare module 'date-fns/lastDayOfWeek/index.js' {
   import { lastDayOfWeek } from 'date-fns'
-  export = lastDayOfWeek
+  export default lastDayOfWeek
 }
 
 declare module 'date-fns/lastDayOfYear/index.js' {
   import { lastDayOfYear } from 'date-fns'
-  export = lastDayOfYear
+  export default lastDayOfYear
 }
 
 declare module 'date-fns/lightFormat/index.js' {
   import { lightFormat } from 'date-fns'
-  export = lightFormat
+  export default lightFormat
 }
 
 declare module 'date-fns/max/index.js' {
   import { max } from 'date-fns'
-  export = max
+  export default max
 }
 
 declare module 'date-fns/min/index.js' {
   import { min } from 'date-fns'
-  export = min
+  export default min
 }
 
 declare module 'date-fns/parse/index.js' {
   import { parse } from 'date-fns'
-  export = parse
+  export default parse
 }
 
 declare module 'date-fns/parseISO/index.js' {
   import { parseISO } from 'date-fns'
-  export = parseISO
+  export default parseISO
 }
 
 declare module 'date-fns/roundToNearestMinutes/index.js' {
   import { roundToNearestMinutes } from 'date-fns'
-  export = roundToNearestMinutes
+  export default roundToNearestMinutes
 }
 
 declare module 'date-fns/setDate/index.js' {
   import { setDate } from 'date-fns'
-  export = setDate
+  export default setDate
 }
 
 declare module 'date-fns/setDay/index.js' {
   import { setDay } from 'date-fns'
-  export = setDay
+  export default setDay
 }
 
 declare module 'date-fns/setDayOfYear/index.js' {
   import { setDayOfYear } from 'date-fns'
-  export = setDayOfYear
+  export default setDayOfYear
 }
 
 declare module 'date-fns/setHours/index.js' {
   import { setHours } from 'date-fns'
-  export = setHours
+  export default setHours
 }
 
 declare module 'date-fns/setISODay/index.js' {
   import { setISODay } from 'date-fns'
-  export = setISODay
+  export default setISODay
 }
 
 declare module 'date-fns/setISOWeek/index.js' {
   import { setISOWeek } from 'date-fns'
-  export = setISOWeek
+  export default setISOWeek
 }
 
 declare module 'date-fns/setISOWeekYear/index.js' {
   import { setISOWeekYear } from 'date-fns'
-  export = setISOWeekYear
+  export default setISOWeekYear
 }
 
 declare module 'date-fns/setMilliseconds/index.js' {
   import { setMilliseconds } from 'date-fns'
-  export = setMilliseconds
+  export default setMilliseconds
 }
 
 declare module 'date-fns/setMinutes/index.js' {
   import { setMinutes } from 'date-fns'
-  export = setMinutes
+  export default setMinutes
 }
 
 declare module 'date-fns/setMonth/index.js' {
   import { setMonth } from 'date-fns'
-  export = setMonth
+  export default setMonth
 }
 
 declare module 'date-fns/setQuarter/index.js' {
   import { setQuarter } from 'date-fns'
-  export = setQuarter
+  export default setQuarter
 }
 
 declare module 'date-fns/setSeconds/index.js' {
   import { setSeconds } from 'date-fns'
-  export = setSeconds
+  export default setSeconds
 }
 
 declare module 'date-fns/setWeek/index.js' {
   import { setWeek } from 'date-fns'
-  export = setWeek
+  export default setWeek
 }
 
 declare module 'date-fns/setWeekYear/index.js' {
   import { setWeekYear } from 'date-fns'
-  export = setWeekYear
+  export default setWeekYear
 }
 
 declare module 'date-fns/setYear/index.js' {
   import { setYear } from 'date-fns'
-  export = setYear
+  export default setYear
 }
 
 declare module 'date-fns/startOfDay/index.js' {
   import { startOfDay } from 'date-fns'
-  export = startOfDay
+  export default startOfDay
 }
 
 declare module 'date-fns/startOfDecade/index.js' {
   import { startOfDecade } from 'date-fns'
-  export = startOfDecade
+  export default startOfDecade
 }
 
 declare module 'date-fns/startOfHour/index.js' {
   import { startOfHour } from 'date-fns'
-  export = startOfHour
+  export default startOfHour
 }
 
 declare module 'date-fns/startOfISOWeek/index.js' {
   import { startOfISOWeek } from 'date-fns'
-  export = startOfISOWeek
+  export default startOfISOWeek
 }
 
 declare module 'date-fns/startOfISOWeekYear/index.js' {
   import { startOfISOWeekYear } from 'date-fns'
-  export = startOfISOWeekYear
+  export default startOfISOWeekYear
 }
 
 declare module 'date-fns/startOfMinute/index.js' {
   import { startOfMinute } from 'date-fns'
-  export = startOfMinute
+  export default startOfMinute
 }
 
 declare module 'date-fns/startOfMonth/index.js' {
   import { startOfMonth } from 'date-fns'
-  export = startOfMonth
+  export default startOfMonth
 }
 
 declare module 'date-fns/startOfQuarter/index.js' {
   import { startOfQuarter } from 'date-fns'
-  export = startOfQuarter
+  export default startOfQuarter
 }
 
 declare module 'date-fns/startOfSecond/index.js' {
   import { startOfSecond } from 'date-fns'
-  export = startOfSecond
+  export default startOfSecond
 }
 
 declare module 'date-fns/startOfWeek/index.js' {
   import { startOfWeek } from 'date-fns'
-  export = startOfWeek
+  export default startOfWeek
 }
 
 declare module 'date-fns/startOfWeekYear/index.js' {
   import { startOfWeekYear } from 'date-fns'
-  export = startOfWeekYear
+  export default startOfWeekYear
 }
 
 declare module 'date-fns/startOfYear/index.js' {
   import { startOfYear } from 'date-fns'
-  export = startOfYear
+  export default startOfYear
 }
 
 declare module 'date-fns/subDays/index.js' {
   import { subDays } from 'date-fns'
-  export = subDays
+  export default subDays
 }
 
 declare module 'date-fns/subHours/index.js' {
   import { subHours } from 'date-fns'
-  export = subHours
+  export default subHours
 }
 
 declare module 'date-fns/subISOWeekYears/index.js' {
   import { subISOWeekYears } from 'date-fns'
-  export = subISOWeekYears
+  export default subISOWeekYears
 }
 
 declare module 'date-fns/subMilliseconds/index.js' {
   import { subMilliseconds } from 'date-fns'
-  export = subMilliseconds
+  export default subMilliseconds
 }
 
 declare module 'date-fns/subMinutes/index.js' {
   import { subMinutes } from 'date-fns'
-  export = subMinutes
+  export default subMinutes
 }
 
 declare module 'date-fns/subMonths/index.js' {
   import { subMonths } from 'date-fns'
-  export = subMonths
+  export default subMonths
 }
 
 declare module 'date-fns/subQuarters/index.js' {
   import { subQuarters } from 'date-fns'
-  export = subQuarters
+  export default subQuarters
 }
 
 declare module 'date-fns/subSeconds/index.js' {
   import { subSeconds } from 'date-fns'
-  export = subSeconds
+  export default subSeconds
 }
 
 declare module 'date-fns/subWeeks/index.js' {
   import { subWeeks } from 'date-fns'
-  export = subWeeks
+  export default subWeeks
 }
 
 declare module 'date-fns/subYears/index.js' {
   import { subYears } from 'date-fns'
-  export = subYears
+  export default subYears
 }
 
 declare module 'date-fns/toDate/index.js' {
   import { toDate } from 'date-fns'
-  export = toDate
+  export default toDate
 }
 
 // FP Functions


### PR DESCRIPTION
See #1128