### PR TITLE
Add @babel/plugin-transform-template-literals (closes #1211)

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,5 +1,8 @@
 const presets = []
-const plugins = ['@babel/plugin-transform-block-scoping']
+const plugins = [
+  '@babel/plugin-transform-block-scoping',
+  '@babel/plugin-transform-template-literals'
+]
 
 if (process.env.NODE_ENV === 'test') {
   presets.push('babel-preset-power-assert')

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/node": "^7.4.5",
     "@babel/plugin-transform-block-scoping": "^7.4.4",
     "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+    "@babel/plugin-transform-template-literals": "^7.4.4",
     "babel-eslint": "^10.0.1",
     "babel-loader": "8.0.6",
     "babel-plugin-add-module-exports": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,13 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  integrity sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-function-name@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
@@ -193,6 +200,14 @@
     "@babel/helper-module-transforms" "^7.4.4"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
+
+"@babel/plugin-transform-template-literals@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
+  integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/polyfill@^7.0.0":
   version "7.4.4"


### PR DESCRIPTION
That fixes the problem with the usage of template literals i.e., in the Polish locale.