### PR TITLE
Add @babel/plugin-transform-arrow-functions

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,7 +1,8 @@
 const presets = []
 const plugins = [
   '@babel/plugin-transform-block-scoping',
-  '@babel/plugin-transform-template-literals'
+  '@babel/plugin-transform-template-literals',
+  '@babel/plugin-transform-arrow-functions'
 ]
 
 if (process.env.NODE_ENV === 'test') {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/node": "^7.4.5",
+    "@babel/plugin-transform-arrow-functions": "^7.2.0",
     "@babel/plugin-transform-block-scoping": "^7.4.4",
     "@babel/plugin-transform-modules-commonjs": "^7.4.4",
     "@babel/plugin-transform-template-literals": "^7.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-arrow-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
+  integrity sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-block-scoping@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz#c13279fabf6b916661531841a23c4b7dae29646d"


### PR DESCRIPTION
This fixes yet another problem caused by modern syntax slipped into the
source code.

See https://github.com/date-fns/date-fns/issues/1211#issuecomment-504327216