### PR TITLE
Fix incorrect parsing of 24:00 in parseISO (closes #1228)

### DIFF
--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -316,10 +316,6 @@ function validateWeekDate(_year, week, day) {
 }
 
 function validateTime(hours, minutes, seconds) {
-  if (hours === 24) {
-    return minutes === 0 && seconds === 0
-  }
-
   return (
     seconds >= 0 &&
     seconds < 60 &&

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -284,7 +284,7 @@ function dayOfISOWeekYear(isoWeekYear, week, day) {
   var date = new Date(0)
   date.setUTCFullYear(isoWeekYear, 0, 4)
   var fourthOfJanuaryDay = date.getUTCDay() || 7
-  var diff = (week - 1 || 0) * 7 + (day || 0) + 1 - fourthOfJanuaryDay
+  var diff = (week - 1) * 7 + day + 1 - fourthOfJanuaryDay
   date.setUTCDate(date.getUTCDate() + diff)
   return date
 }

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -316,6 +316,10 @@ function validateWeekDate(_year, week, day) {
 }
 
 function validateTime(hours, minutes, seconds) {
+  if (hours === 24) {
+    return minutes === 0 && seconds === 0
+  }
+
   return (
     seconds >= 0 &&
     seconds < 60 &&

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -251,7 +251,7 @@ function parseTime(timeString) {
   }
 
   return (
-    (hours % 24) * MILLISECONDS_IN_HOUR +
+    hours * MILLISECONDS_IN_HOUR +
     minutes * MILLISECONDS_IN_MINUTE +
     seconds * 1000
   )
@@ -299,33 +299,37 @@ function isLeapYearIndex(year) {
 }
 
 function validateDate(year, month, date) {
-  return !(
-    month < 0 ||
-    month > 11 ||
-    date < 1 ||
-    date > (daysInMonths[month] || (isLeapYearIndex(year) ? 29 : 28))
+  return (
+    month >= 0 &&
+    month <= 11 &&
+    date >= 1 &&
+    date <= (daysInMonths[month] || (isLeapYearIndex(year) ? 29 : 28))
   )
 }
 
 function validateDayOfYearDate(year, dayOfYear) {
-  return !(dayOfYear < 1 || dayOfYear > (isLeapYearIndex(year) ? 366 : 365))
+  return dayOfYear >= 1 && dayOfYear <= (isLeapYearIndex(year) ? 366 : 365)
 }
 
 function validateWeekDate(_year, week, day) {
-  return !(week < 0 || week > 52 || day < 0 || day > 6)
+  return week >= 0 && week <= 52 && day >= 0 && day <= 6
 }
 
 function validateTime(hours, minutes, seconds) {
-  return !(
-    seconds < 0 ||
-    seconds >= 60 ||
-    minutes < 0 ||
-    minutes >= 60 ||
-    hours < 0 ||
-    hours >= 25
+  if (hours === 24) {
+    return minutes === 0 && seconds === 0
+  }
+
+  return (
+    seconds >= 0 &&
+    seconds < 60 &&
+    minutes >= 0 &&
+    minutes < 60 &&
+    hours >= 0 &&
+    hours < 25
   )
 }
 
 function validateTimezone(_hours, minutes) {
-  return !(minutes < 0 || minutes > 59)
+  return minutes >= 0 && minutes <= 59
 }

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -213,7 +213,7 @@ function parseDate(dateString, year) {
   var dayOfYear = parseDateUnit(captures[1])
   var month = parseDateUnit(captures[2]) - 1
   var day = parseDateUnit(captures[3])
-  var week = parseDateUnit(captures[4]) - 1
+  var week = parseDateUnit(captures[4])
   var dayOfWeek = parseDateUnit(captures[5]) - 1
 
   if (isWeekDate) {
@@ -284,7 +284,7 @@ function dayOfISOWeekYear(isoWeekYear, week, day) {
   var date = new Date(0)
   date.setUTCFullYear(isoWeekYear, 0, 4)
   var fourthOfJanuaryDay = date.getUTCDay() || 7
-  var diff = (week || 0) * 7 + (day || 0) + 1 - fourthOfJanuaryDay
+  var diff = (week - 1 || 0) * 7 + (day || 0) + 1 - fourthOfJanuaryDay
   date.setUTCDate(date.getUTCDate() + diff)
   return date
 }
@@ -312,7 +312,7 @@ function validateDayOfYearDate(year, dayOfYear) {
 }
 
 function validateWeekDate(_year, week, day) {
-  return week >= 0 && week <= 52 && day >= 0 && day <= 6
+  return week >= 1 && week <= 53 && day >= 0 && day <= 6
 }
 
 function validateTime(hours, minutes, seconds) {

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -90,11 +90,6 @@ describe('parseISO', () => {
         const result = parseISO('2014-02-11T1130')
         assert.deepEqual(result, new Date(2014, 1 /* Feb */, 11, 11, 30))
       })
-
-      it('parses 24:00 as midnight', () => {
-        const result = parseISO('2014-02-11T2400')
-        assert.deepEqual(result, new Date(2014, 1 /* Feb */, 11, 0, 0))
-      })
     })
 
     describe('extended century representation', () => {
@@ -292,9 +287,15 @@ describe('parseISO', () => {
     })
 
     describe('time', () => {
-      it('parses 24:00 as midnight', () => {
+      it('parses 24:00 as midnight of the next day', () => {
         const result = parseISO('2014-02-11T24:00')
-        assert.deepEqual(result, new Date(2014, 1 /* Feb */, 11, 0, 0))
+        assert.deepEqual(result, new Date(2014, 1 /* Feb */, 12, 0, 0))
+      })
+
+      it('returns `Invalid Date` for anything after 24:00', () => {
+        const result = parseISO('2014-02-11T24:01')
+        assert(result instanceof Date)
+        assert(isNaN(result))
       })
 
       it('returns `Invalid Date` for invalid hours', () => {

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -292,12 +292,10 @@ describe('parseISO', () => {
         assert.deepEqual(result, new Date(2014, 1 /* Feb */, 12, 0, 0))
       })
 
-      it('parses 24:mm as correct time of the next day', () => {
-        const result = parseISO('2014-02-11T24:59:59.999')
-        assert.deepEqual(
-          result,
-          new Date(2014, 1 /* Feb */, 12, 0, 59, 59, 999)
-        )
+      it('returns `Invalid Date` for anything after 24:00', () => {
+        const result = parseISO('2014-02-11T24:01')
+        assert(result instanceof Date)
+        assert(isNaN(result))
       })
 
       it('returns `Invalid Date` for invalid hours', () => {

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -292,10 +292,12 @@ describe('parseISO', () => {
         assert.deepEqual(result, new Date(2014, 1 /* Feb */, 12, 0, 0))
       })
 
-      it('returns `Invalid Date` for anything after 24:00', () => {
-        const result = parseISO('2014-02-11T24:01')
-        assert(result instanceof Date)
-        assert(isNaN(result))
+      it('parses 24:mm as correct time of the next day', () => {
+        const result = parseISO('2014-02-11T24:59:59.999')
+        assert.deepEqual(
+          result,
+          new Date(2014, 1 /* Feb */, 12, 0, 59, 59, 999)
+        )
       })
 
       it('returns `Invalid Date` for invalid hours', () => {


### PR DESCRIPTION
According to ISO 8601 '24:00' is supposed to be parsed as 12 AM the _next_ day, but before it was parsed as 12 AM of the _same_ day. See #1228

Also a few code style fixes.





ISO 8601:2004(E)
4.2.3
```
NOTE 1 The end of one calendar day [24:00] coincides with [00:00] at the start of the next calendar day, e.g. [24:00] on 12 April 1985 is the same as [00:00] on 13 April 1985.
```