### PR TITLE
Revert "fix(typings): export interface"

### DIFF
--- a/scripts/build/_lib/typings/typeScript.js
+++ b/scripts/build/_lib/typings/typeScript.js
@@ -373,7 +373,7 @@ function generateTypeScriptTypings(fns, aliases, locales, constants) {
     .map(module => module.definition)
 
   const globalInterfaceDefinition = formatBlock`
-    export interface dateFns {
+    interface dateFns {
       ${addSeparator(
         nonFPFns
           .map(getTypeScriptInterfaceDefinition)


### PR DESCRIPTION
Reverts date-fns/date-fns#1233

The change makes TypeScript fail with an obscure error: https://travis-ci.org/date-fns/date-fns/jobs/559946272#L689

@ricardogobbosouza if you want to see the global interface exported, could you please redo it again, but this time run `./scripts/build/build.sh` to update the typings and then make sure that the smoke tests pass (`./scripts/test/smoke.sh` or `cd examples/typescript && yarn build && yarn test`)