### PR TITLE
Add a default formatStr of 'PP'

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -47,7 +47,9 @@ import { enGB, eo, ru } from 'date-fns/locale'
 
 const locales = {enGB, eo, ru}
 
-export default function (date, formatStr) {
+// by providing a default string of 'PP' or any of its variants for `formatStr`
+// it will format dates in whichever way is appropriate to the locale
+export default function (date, formatStr = 'PP') {
   return format(date, formatStr, {
     locale: locales[window.__localeId__] // or global.__localeId__
   })
@@ -64,6 +66,16 @@ format(friday13, 'EEEE d')
 window.__localeId__ = 'eo'
 format(friday13, 'EEEE d')
 //=> 'vendredo 13'
+
+// If the format string is omitted, it will take the default for the locale.
+window.__localeId__ = 'en'
+format(friday13)
+//=> Jul 13, 2019
+
+window.__localeId__ = 'eo'
+format(friday13)
+//=> 2019-jul-13
+
 ```
 
 ## Adding New Language


### PR DESCRIPTION
Add a default `formatStr` of `'PP'` (or any of its variants) to the example custom formatting function so that it defaults to whichever format the locale has for dates.  Show the example output without `formatStr` set.