### PR TITLE
fix: fix TS typings for curried functions

### DIFF
--- a/scripts/build/_lib/typings/typeScript.js
+++ b/scripts/build/_lib/typings/typeScript.js
@@ -19,31 +19,31 @@ const getTypeScriptFPInterfaces = (arity = 4) =>
   [
     formatBlock`
     interface CurriedFn1<A, R> {
-      <A>(a: A): R
+      (a: A): R
     }
   `,
 
     formatBlock`
     interface CurriedFn2<A, B, R> {
-      <A>(a: A): CurriedFn1<B, R>
-      <A, B>(a: A, b: B): R
+      (a: A): CurriedFn1<B, R>
+      (a: A, b: B): R
     }
   `,
 
     formatBlock`
     interface CurriedFn3<A, B, C, R> {
-      <A>(a: A): CurriedFn2<B, C, R>
-      <A,B>(a: A, b: B): CurriedFn1<C, R>
-      <A,B,C>(a: A, b: B, c: C): R
+      (a: A): CurriedFn2<B, C, R>
+      (a: A, b: B): CurriedFn1<C, R>
+      (a: A, b: B, c: C): R
     }
   `,
 
     formatBlock`
     interface CurriedFn4<A, B, C, D, R> {
-      <A>(a: A): CurriedFn3<B, C, D, R>
-      <A,B>(a: A, b: B): CurriedFn2<C, D, R>
-      <A,B,C>(a: A, b: B, c: C): CurriedFn1<D, R>
-      <A,B,C,D>(a: A, b: B, c: C, d: D): R
+      (a: A): CurriedFn3<B, C, D, R>
+      (a: A, b: B): CurriedFn2<C, D, R>
+      (a: A, b: B, c: C): CurriedFn1<D, R>
+      (a: A, b: B, c: C, d: D): R
     }
   `
   ].slice(0, arity)

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -3,25 +3,25 @@
 // FP Interfaces
 
 interface CurriedFn1<A, R> {
-  <A>(a: A): R
+  (a: A): R
 }
 
 interface CurriedFn2<A, B, R> {
-  <A>(a: A): CurriedFn1<B, R>
-  <A, B>(a: A, b: B): R
+  (a: A): CurriedFn1<B, R>
+  (a: A, b: B): R
 }
 
 interface CurriedFn3<A, B, C, R> {
-  <A>(a: A): CurriedFn2<B, C, R>
-  <A, B>(a: A, b: B): CurriedFn1<C, R>
-  <A, B, C>(a: A, b: B, c: C): R
+  (a: A): CurriedFn2<B, C, R>
+  (a: A, b: B): CurriedFn1<C, R>
+  (a: A, b: B, c: C): R
 }
 
 interface CurriedFn4<A, B, C, D, R> {
-  <A>(a: A): CurriedFn3<B, C, D, R>
-  <A, B>(a: A, b: B): CurriedFn2<C, D, R>
-  <A, B, C>(a: A, b: B, c: C): CurriedFn1<D, R>
-  <A, B, C, D>(a: A, b: B, c: C, d: D): R
+  (a: A): CurriedFn3<B, C, D, R>
+  (a: A, b: B): CurriedFn2<C, D, R>
+  (a: A, b: B, c: C): CurriedFn1<D, R>
+  (a: A, b: B, c: C, d: D): R
 }
 
 // Type Aliases


### PR DESCRIPTION
Fixes #1235

Using "generics" with functions overloaded in an interface lead to incorrect
type inference.

e.g.

```javascript
interface CurriedFn2<A, B, R> {
  <A>(a: A): CurriedFn1<B, R>
  <A, B>(a: A, b: B): R
}

const subDays: CurriedFn2<number, number | Date, Date>;

// incorrect but accepted by TS compiler due to type inference
// from <A, B>(a: A, b: B): R, generic A was inferred to Date
// basically allowing any type to pass
const getDays = subDays(new Date(), 7);
```