### PR TITLE
addBusinessDays negative amount fix, performance fixes for addBusinessDays and differenceInBusinessDays

### DIFF
--- a/src/addBusinessDays/index.js
+++ b/src/addBusinessDays/index.js
@@ -33,12 +33,17 @@ export default function addBusinessDays(dirtyDate, dirtyAmount) {
   if (isNaN(amount)) return new Date(NaN)
 
   var hours = date.getHours()
-  var numWeekDays = 0
-  while (numWeekDays < amount) {
-    date.setDate(date.getDate() + 1)
-    date.setHours(hours)
-    if (!isWeekend(date)) numWeekDays++
+  var sign = amount < 0 ? -1 : 1
+
+  date.setDate(date.getDate() + toInteger(amount / 5) * 7)
+  amount %= 5 // to get remaining days not part of a full week
+
+  // only loops over remaining days or if day is a weekend, ensures a business day is returned
+  while (amount || isWeekend(date)) {
+    date.setDate(date.getDate() + sign)
+    if (!isWeekend(date)) amount -= sign
   }
 
+  date.setHours(hours)
   return date
 }

--- a/src/addBusinessDays/test.js
+++ b/src/addBusinessDays/test.js
@@ -16,7 +16,9 @@ describe('addBusinessDays', function() {
   })
 
   it('can handle a large number of business days', function() {
-    this.timeout(500 /* 500 ms test timeout */)
+    if (typeof this.timeout === 'function') {
+      this.timeout(500 /* 500 ms test timeout */)
+    }
 
     var result = addBusinessDays(new Date(2014, 0 /* Jan */, 1), 3387885)
     assert.deepEqual(result, new Date(15000, 0 /* Jan */, 1))

--- a/src/addBusinessDays/test.js
+++ b/src/addBusinessDays/test.js
@@ -10,6 +10,18 @@ describe('addBusinessDays', function() {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 15))
   })
 
+  it('handles negative amount', function() {
+    var result = addBusinessDays(new Date(2014, 8 /* Sep */, 15), -10)
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
+  })
+
+  it('can handle a large number of business days', function() {
+    this.timeout(500 /* 500 ms test timeout */)
+
+    var result = addBusinessDays(new Date(2014, 0 /* Jan */, 1), 3387885)
+    assert.deepEqual(result, new Date(15000, 0 /* Jan */, 1))
+  })
+
   it('accepts a timestamp', function() {
     var result = addBusinessDays(new Date(2014, 8 /* Sep */, 1).getTime(), 10)
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 15))

--- a/src/differenceInBusinessDays/index.js
+++ b/src/differenceInBusinessDays/index.js
@@ -46,10 +46,10 @@ export default function differenceInBusinessDays(
 
   if (!isValid(dateLeft) || !isValid(dateRight)) return new Date(NaN)
 
-  var calenderDifference = differenceInCalendarDays(dateLeft, dateRight)
-  var sign = calenderDifference < 0 ? -1 : 1
+  var calendarDifference = differenceInCalendarDays(dateLeft, dateRight)
+  var sign = calendarDifference < 0 ? -1 : 1
 
-  var weeks = toInteger(calenderDifference / 7)
+  var weeks = toInteger(calendarDifference / 7)
 
   var result = weeks * 5
   dateRight = addDays(dateRight, weeks * 7)

--- a/src/differenceInBusinessDays/index.js
+++ b/src/differenceInBusinessDays/index.js
@@ -1,8 +1,10 @@
-import compareAsc from '../compareAsc/index.js'
-import eachDayOfInterval from '../eachDayOfInterval/index.js'
 import isValid from '../isValid/index.js'
 import isWeekend from '../isWeekend/index.js'
 import toDate from '../toDate/index.js'
+import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+import addDays from '../addDays/index.js'
+import isSameDay from '../isSameDay/index.js'
+import toInteger from '../_lib/toInteger/index.js'
 
 /**
  * @name differenceInBusinessDays
@@ -44,19 +46,20 @@ export default function differenceInBusinessDays(
 
   if (!isValid(dateLeft) || !isValid(dateRight)) return new Date(NaN)
 
-  var sign = compareAsc(dateLeft, dateRight)
-  var interval =
-    sign > 0
-      ? { start: dateRight, end: dateLeft }
-      : { start: dateLeft, end: dateRight }
+  var calenderDifference = differenceInCalendarDays(dateLeft, dateRight)
+  var sign = calenderDifference < 0 ? -1 : 1
 
-  var daysOfInterval = eachDayOfInterval(interval)
-  var difference = daysOfInterval.filter(function(day) {
-    return !isWeekend(day)
-  })
-  // Subtract 1 if interval contains ending date that falls on a weekday
-  var result = sign * (difference.length - (isWeekend(dateLeft) ? 0 : 1))
+  var weeks = toInteger(calenderDifference / 7)
 
-  // Prevent negative zero
+  var result = weeks * 5
+  dateRight = addDays(dateRight, weeks * 7)
+
+  // the loop below will run at most 6 times to account for the remaining days that don't makeup a full week
+  while (!isSameDay(dateLeft, dateRight)) {
+    // sign is used to account for both negative and positive differences
+    result += isWeekend(dateRight) ? 0 : sign
+    dateRight = addDays(dateRight, sign)
+  }
+
   return result === 0 ? 0 : result
 }

--- a/src/differenceInBusinessDays/test.js
+++ b/src/differenceInBusinessDays/test.js
@@ -14,8 +14,9 @@ describe('differenceInBusinessDays', function() {
   })
 
   it('can handle long ranges', function() {
-    this.timeout(500 /* 500 ms test timeout */)
-
+    if (typeof this.timeout === 'function') {
+      this.timeout(500 /* 500 ms test timeout */)
+    }
     var result = differenceInBusinessDays(
       new Date(15000, 0 /* Jan */, 1),
       new Date(2014, 0 /* Jan */, 1)

--- a/src/differenceInBusinessDays/test.js
+++ b/src/differenceInBusinessDays/test.js
@@ -13,6 +13,16 @@ describe('differenceInBusinessDays', function() {
     assert(result === 135)
   })
 
+  it('can handle long ranges', function() {
+    this.timeout(500 /* 500 ms test timeout */)
+
+    var result = differenceInBusinessDays(
+      new Date(15000, 0 /* Jan */, 1),
+      new Date(2014, 0 /* Jan */, 1)
+    )
+    assert(result === 3387885)
+  })
+
   it('the same except given first date falls on a weekend', function() {
     var result = differenceInBusinessDays(
       new Date(2019, 6 /* Jul */, 20),


### PR DESCRIPTION
Unlike the addDays function, addBusinessDays does not handle a negative amount and same given date.

```
addBusinessDays(new Date(2014, 8 /* Sep */, 15), -10)
// expected:  Sept 1st 2014
// actual: Sept 15 2014
```

addBusinessDays also loops over the entire given amount linearly e.g. is 1,000,000 is given as the amount than the loop runs 1,000,00 times. This behaviour is fixed using division in the PR.
```
  date.setDate(date.getDate() + toInteger(amount / 5) * 7)
```

differenceInBusinessDays also had the same performance issue where an array of all the dates in a range was being created and filtered through due to the [following line](https://github.com/date-fns/date-fns/blob/master/src/differenceInBusinessDays/index.js#L53:L56)
```
  var daysOfInterval = eachDayOfInterval(interval)
  var difference = daysOfInterval.filter(function(day) {
    return !isWeekend(day)
  })
```
this performance issue is fixed below
```
  var weeks = toInteger(calendarDifference / 7)

  var result = weeks * 5
  dateRight = addDays(dateRight, weeks * 7)
```
remaining days not part of a full week are accounted for afterwards