### PR TITLE
Fix minor styling issue in typings build scripts

### DIFF
--- a/scripts/build/_lib/typings/flow.js
+++ b/scripts/build/_lib/typings/flow.js
@@ -15,22 +15,22 @@ const getFlowFPTypeAliases = (arity = 4) =>
     'type CurriedFn1<A, R> = <A>(a: A) => R',
 
     formatBlock`
-    type CurriedFn2<A, B, R> = <A>(a: A) => CurriedFn1<B, R>
-      | <A, B>(a: A, b: B) => R
-  `,
+      type CurriedFn2<A, B, R> = <A>(a: A) => CurriedFn1<B, R>
+        | <A, B>(a: A, b: B) => R
+    `,
 
     formatBlock`
-    type CurriedFn3<A, B, C, R> = <A>(a: A) => CurriedFn2<B, C, R>
-      | <A,B>(a: A, b: B) => CurriedFn1<C, R>
-      | <A,B,C>(a: A, b: B, c: C) => R
-  `,
+      type CurriedFn3<A, B, C, R> = <A>(a: A) => CurriedFn2<B, C, R>
+        | <A,B>(a: A, b: B) => CurriedFn1<C, R>
+        | <A,B,C>(a: A, b: B, c: C) => R
+    `,
 
     formatBlock`
-    type CurriedFn4<A, B, C, D, R> = <A>(a: A) => CurriedFn3<B, C, D, R>
-      | <A,B>(a: A, b: B) => CurriedFn2<C, D, R>
-      | <A,B,C>(a: A, b: B, c: C) => CurriedFn1<D, R>
-      | <A,B,C,D>(a: A, b: B, c: C, d: D) => R
-  `
+      type CurriedFn4<A, B, C, D, R> = <A>(a: A) => CurriedFn3<B, C, D, R>
+        | <A,B>(a: A, b: B) => CurriedFn2<C, D, R>
+        | <A,B,C>(a: A, b: B, c: C) => CurriedFn1<D, R>
+        | <A,B,C,D>(a: A, b: B, c: C, d: D) => R
+    `
   ].slice(0, arity)
 
 function getFlowTypeAlias(type) {

--- a/scripts/build/_lib/typings/typeScript.js
+++ b/scripts/build/_lib/typings/typeScript.js
@@ -18,34 +18,34 @@ const {
 const getTypeScriptFPInterfaces = (arity = 4) =>
   [
     formatBlock`
-    interface CurriedFn1<A, R> {
-      (a: A): R
-    }
-  `,
+      interface CurriedFn1<A, R> {
+        (a: A): R
+      }
+    `,
 
     formatBlock`
-    interface CurriedFn2<A, B, R> {
-      (a: A): CurriedFn1<B, R>
-      (a: A, b: B): R
-    }
-  `,
+      interface CurriedFn2<A, B, R> {
+        (a: A): CurriedFn1<B, R>
+        (a: A, b: B): R
+      }
+    `,
 
     formatBlock`
-    interface CurriedFn3<A, B, C, R> {
-      (a: A): CurriedFn2<B, C, R>
-      (a: A, b: B): CurriedFn1<C, R>
-      (a: A, b: B, c: C): R
-    }
-  `,
+      interface CurriedFn3<A, B, C, R> {
+        (a: A): CurriedFn2<B, C, R>
+        (a: A, b: B): CurriedFn1<C, R>
+        (a: A, b: B, c: C): R
+      }
+    `,
 
     formatBlock`
-    interface CurriedFn4<A, B, C, D, R> {
-      (a: A): CurriedFn3<B, C, D, R>
-      (a: A, b: B): CurriedFn2<C, D, R>
-      (a: A, b: B, c: C): CurriedFn1<D, R>
-      (a: A, b: B, c: C, d: D): R
-    }
-  `
+      interface CurriedFn4<A, B, C, D, R> {
+        (a: A): CurriedFn3<B, C, D, R>
+        (a: A, b: B): CurriedFn2<C, D, R>
+        (a: A, b: B, c: C): CurriedFn1<D, R>
+        (a: A, b: B, c: C, d: D): R
+      }
+    `
   ].slice(0, arity)
 
 function getTypeScriptTypeAlias(type) {


### PR DESCRIPTION
Prettier broke indentation a bit and it looked out of place.

This PR does not affect the result of the build at all.