### PR TITLE
fix(format): convert null date to empty string

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -348,6 +348,10 @@ export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
     )
   }
 
+  if (!dirtyDate) {
+    return ''
+  }
+
   var formatStr = String(dirtyFormatStr)
   var options = dirtyOptions || {}
 


### PR DESCRIPTION
Currently, the function returns the 1st of January 1970.