### PR TITLE
Fix format example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for manipulating **JavaScript dates** in **a browser** & **Node.js**.
 ```js
 import { compareAsc, format } from 'date-fns'
 
-format(new Date(2014, 1, 11), 'yyyy-MM-dd')
+format(new Date(2014, 1, 11), 'YYYY-MM-DD')
 //=> '2014-02-11'
 
 const dates = [


### PR DESCRIPTION
I think the format `yyyy-MM-dd` in the README example is incorrect and should be `YYYY-MM-DD`.