### PR TITLE
Throw TypeError if date argument in format functions is invalid

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -1,4 +1,5 @@
 import isValid from '../isValid/index.js'
+import isDate from '../isDate/index.js'
 import defaultLocale from '../locale/en-US/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
 import toDate from '../toDate/index.js'
@@ -313,6 +314,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *   see: https://git.io/fxCyr
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
+ * @throws {TypeError} The first argument should be a number (timestamp ms) or `Date` instance
  * @throws {RangeError} `options.locale` must contain `localize` property
  * @throws {RangeError} `options.locale` must contain `formatLong` property
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
@@ -345,6 +347,12 @@ export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
   if (arguments.length < 2) {
     throw new TypeError(
       '2 arguments required, but only ' + arguments.length + ' present'
+    )
+  }
+
+  if (typeof dirtyDate !== 'number' && !isDate(dirtyDate)) {
+    throw new TypeError(
+      'The first argument should be a number (timestamp ms) or `Date` instance'
     )
   }
 

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -733,7 +733,9 @@ describe('format', function() {
   })
 
   it('throws TypeError exception if the first argument null or undefined', function() {
+    // $ExpectedMistake
     assert.throws(format.bind(null, null, 'yyyy-MM-dd'), TypeError)
+    // $ExpectedMistake
     assert.throws(format.bind(null, undefined, 'yyyy-MM-dd'), TypeError)
   })
 

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -732,6 +732,11 @@ describe('format', function() {
     assert.throws(format.bind(null, 1), TypeError)
   })
 
+  it('throws TypeError exception if the first argument null or undefined', function() {
+    assert.throws(format.bind(null, null, 'yyyy-MM-dd'), TypeError)
+    assert.throws(format.bind(null, undefined, 'yyyy-MM-dd'), TypeError)
+  })
+
   describe('useAdditionalWeekYearTokens and useAdditionalDayOfYearTokens options', () => {
     it('throws an error if D token is used', () => {
       const block = format.bind(null, date, 'yyyy-MM-D')

--- a/src/lightFormat/index.js
+++ b/src/lightFormat/index.js
@@ -1,8 +1,9 @@
+import isDate from '../isDate/index.js'
+import isValid from '../isValid/index.js'
+import subMilliseconds from '../subMilliseconds/index.js'
 import toDate from '../toDate/index.js'
 import formatters from '../_lib/format/lightFormatters/index.js'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
-import isValid from '../isValid/index.js'
-import subMilliseconds from '../subMilliseconds/index.js'
 
 // This RegExp consists of three parts separated by `|`:
 // - (\w)\1* matches any sequences of the same letter
@@ -70,6 +71,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} format string contains an unescaped latin alphabet character
+ * @throws {TypeError} The first argument should be a number (timestamp ms) or `Date` instance
  *
  * @example
  * var result = format(new Date(2014, 1, 11), 'yyyy-MM-dd')
@@ -79,6 +81,12 @@ export default function lightFormat(dirtyDate, dirtyFormatStr) {
   if (arguments.length < 2) {
     throw new TypeError(
       '2 arguments required, but only ' + arguments.length + ' present'
+    )
+  }
+
+  if (typeof dirtyDate !== 'number' && !isDate(dirtyDate)) {
+    throw new TypeError(
+      'The first argument should be a number (timestamp ms) or `Date` instance'
     )
   }
 

--- a/src/lightFormat/test.js
+++ b/src/lightFormat/test.js
@@ -139,4 +139,9 @@ describe('lightFormat', () => {
     assert.throws(lightFormat.bind(null), TypeError)
     assert.throws(lightFormat.bind(null, 1), TypeError)
   })
+
+  it('throws TypeError exception if the first argument null or undefined', function() {
+    assert.throws(lightFormat.bind(null, null, 'yyyy-MM-dd'), TypeError)
+    assert.throws(lightFormat.bind(null, undefined, 'yyyy-MM-dd'), TypeError)
+  })
 })

--- a/src/lightFormat/test.js
+++ b/src/lightFormat/test.js
@@ -141,7 +141,9 @@ describe('lightFormat', () => {
   })
 
   it('throws TypeError exception if the first argument null or undefined', function() {
+    // $ExpectedMistake
     assert.throws(lightFormat.bind(null, null, 'yyyy-MM-dd'), TypeError)
+    // $ExpectedMistake
     assert.throws(lightFormat.bind(null, undefined, 'yyyy-MM-dd'), TypeError)
   })
 })


### PR DESCRIPTION
Now `format` and `lightFormat` would throw `TypeError` if the first argument is not a number or `Date`.

See PR with raised concern regarding the behavior: https://github.com/date-fns/date-fns/pull/1293