### PR TITLE
Fix format after migrating V2.

### DIFF
--- a/src/locale/fr-CH/_lib/formatters/index.js
+++ b/src/locale/fr-CH/_lib/formatters/index.js
@@ -5,9 +5,9 @@ var formatters = {}
 // See https://github.com/date-fns/date-fns/issues/437
 var monthsTokens = ['MMM', 'MMMM']
 monthsTokens.forEach(function (monthToken) {
-  formatters['Do ' + monthToken] = function (date, options) {
+  formatters['io ' + monthToken] = function (date, options) {
     var commonFormatters = options.formatters
-    var dayOfMonthToken = date.getUTCDate() === 1 ? 'Do' : 'D'
+    var dayOfMonthToken = date.getUTCDate() === 1 ? 'io' : 'i'
     var dayOfMonthFormatter = commonFormatters[dayOfMonthToken]
     var monthFormatter = commonFormatters[monthToken]
     return dayOfMonthFormatter(date, options) + ' ' + monthFormatter(date, options)

--- a/src/locale/fr/_lib/formatters/index.js
+++ b/src/locale/fr/_lib/formatters/index.js
@@ -5,9 +5,9 @@ var formatters = {}
 // See https://github.com/date-fns/date-fns/issues/437
 var monthsTokens = ['MMM', 'MMMM']
 monthsTokens.forEach(function (monthToken) {
-  formatters['Do ' + monthToken] = function (date, options) {
+  formatters['io ' + monthToken] = function (date, options) {
     var commonFormatters = options.formatters
-    var dayOfMonthToken = date.getUTCDate() === 1 ? 'Do' : 'D'
+    var dayOfMonthToken = date.getUTCDate() === 1 ? 'io' : 'i'
     var dayOfMonthFormatter = commonFormatters[dayOfMonthToken]
     var monthFormatter = commonFormatters[monthToken]
     return dayOfMonthFormatter(date, options) + ' ' + monthFormatter(date, options)


### PR DESCRIPTION
The translation was:

"Samedi 24ième août"

When we expect "Samedi 24 août"

I removed "Do" because I'm not sure if we should apply it in this case, no sense for me with V2.