### PR TITLE
Add module field to locales packages

### DIFF
--- a/scripts/build/packages.js
+++ b/scripts/build/packages.js
@@ -50,6 +50,7 @@ function writePackage(fullPath) {
 function getInitialPackages() {
   return listFns()
     .concat(listFPFns())
+    .concat(listLocales())
     .concat(extraModules)
     .reduce((acc, module) => {
       acc[module.fullPath] = getModulePackage(module.fullPath)


### PR DESCRIPTION
Currently I have to import esm packages directly.

```js
import en from 'date-fns/esm/locale/en-GB';
import fr from 'date-fns/esm/locale/fr';
import de from 'date-fns/esm/locale/de';
```

with this change merged I will be able to simplify this with

```js
import en from 'date-fns/locale/en-GB';
import fr from 'date-fns/locale/fr';
import de from 'date-fns/locale/de';
```