### PR TITLE
Fix `isDate` to return false for Invalid Dates

### DIFF
--- a/src/isDate/index.js
+++ b/src/isDate/index.js
@@ -42,8 +42,8 @@ export default function isDate(value) {
   }
 
   return (
-    value instanceof Date ||
+    (value instanceof Date ||
     (typeof value === 'object' &&
-      Object.prototype.toString.call(value) === '[object Date]')
+      Object.prototype.toString.call(value) === '[object Date]')) && !isNaN(value.getTime())
   )
 }


### PR DESCRIPTION
Currently if I use

```javascript
isDate (new Date ('aaaaaaa'))
``` 
or

```javascript
isDate(new Date('22/22/2222'))
```
it will return `true`, because when `new Date(someArgument)` returns `Invalid Date` it still a `instance of` `Date`. So I check if the argument passed to `isDate` contains an valid miliseconds value.