### PR TITLE
Don't skip start date in eachWeekendOfInterval

### DIFF
--- a/src/eachWeekendOfInterval/index.js
+++ b/src/eachWeekendOfInterval/index.js
@@ -39,8 +39,8 @@ export default function eachWeekendOfInterval(interval) {
   var dateInterval = eachDayOfInterval(interval)
   var weekends = []
   var index = 0
-  while (index++ < dateInterval.length) {
-    var date = dateInterval[index]
+  while (index < dateInterval.length) {
+    var date = dateInterval[index++]
     if (isWeekend(date)) {
       weekends.push(date)
       if (isSunday(date)) index = index + 5

--- a/src/eachWeekendOfInterval/test.js
+++ b/src/eachWeekendOfInterval/test.js
@@ -18,6 +18,19 @@ describe('eachWeekendOfInterval', function() {
     ])
   })
 
+  it('returns all weekends within the interval when starting on a weekend', function() {
+    var result = eachWeekendOfInterval({
+      start: new Date(2018, 8 /* Sept */, 22),
+      end: new Date(2018, 8 /* Sept */, 30)
+    })
+    assert.deepEqual(result, [
+      new Date(2018, 8 /* Sept */, 22),
+      new Date(2018, 8 /* Sept */, 23),
+      new Date(2018, 8 /* Sept */, 29),
+      new Date(2018, 8 /* Sept */, 30)
+    ])
+  })
+
   it('throws `RangeError` invalid interval start date is used', function() {
     // $ExpectedMistake
     var block = eachWeekendOfInterval.bind(null, {


### PR DESCRIPTION
It seems `eachWeekendOfInterval` was skipping the first date in the supplied interval. This PR fixes the issue and adds a test to check the case where the `start` date of the interval falls on a weekend.