### PR TITLE
Fix march in Dutch parsing patterns

### DIFF
--- a/src/locale/nl/_lib/match/index.js
+++ b/src/locale/nl/_lib/match/index.js
@@ -28,8 +28,34 @@ var matchMonthPatterns = {
   wide: /^(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)/i
 }
 var parseMonthPatterns = {
-  narrow: [/^j/i, /^f/i, /^m/i, /^a/i, /^m/i, /^j/i, /^j/i, /^a/i, /^s/i, /^o/i, /^n/i, /^d/i],
-  any: [/^jan/i, /^feb/i, /^mrt/i, /^apr/i, /^mei/i, /^jun/i, /^jul/i, /^aug/i, /^sep/i, /^okt/i, /^nov/i, /^dec/i]
+  narrow: [
+    /^j/i,
+    /^f/i,
+    /^m/i,
+    /^a/i,
+    /^m/i,
+    /^j/i,
+    /^j/i,
+    /^a/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i
+  ],
+  any: [
+    /^jan/i,
+    /^feb/i,
+    /^m(r|a)/i,
+    /^apr/i,
+    /^mei/i,
+    /^jun/i,
+    /^jul/i,
+    /^aug/i,
+    /^sep/i,
+    /^okt/i,
+    /^nov/i,
+    /^dec/i
+  ]
 }
 
 var matchDayPatterns = {
@@ -63,7 +89,7 @@ var match = {
   ordinalNumber: buildMatchPatternFn({
     matchPattern: matchOrdinalNumberPattern,
     parsePattern: parseOrdinalNumberPattern,
-    valueCallback: function (value) {
+    valueCallback: function(value) {
       return parseInt(value, 10)
     }
   }),
@@ -80,7 +106,7 @@ var match = {
     defaultMatchWidth: 'wide',
     parsePatterns: parseQuarterPatterns,
     defaultParseWidth: 'any',
-    valueCallback: function (index) {
+    valueCallback: function(index) {
       return index + 1
     }
   }),


### PR DESCRIPTION
Small change. Most of this PR is just automatic prettifying of the code.
Changed `/^mrt/i` -> `/^m(r|a)/i` to support parsing both wide form (maart) and abbreviated form (mrt) of march in Dutch.

There were no affected examples in the Dutch snapshot, but dates containing "maart" fail parsing without this change. This bug was caught by running a format-parse rountrip unit test similar to the one in #1423