### PR TITLE
Fix offset for Eastern Hemisphere in parseISO, fixes #1449, fixes #1119

### DIFF
--- a/scripts/test/dst.sh
+++ b/scripts/test/dst.sh
@@ -10,6 +10,7 @@ export PATH="$(yarn bin):$PATH"
 export NODE_ENV=test
 
 env TZ=America/Sao_Paulo babel-node ./test/dst/parseISO/basic.js
+env TZ=Australia/Sydney babel-node ./test/dst/parseISO/sydney.js
 env TZ=Pacific/Apia babel-node ./test/dst/parseISO/samoa.js
 env TZ=Asia/Damascus babel-node ./test/dst/eachDayOfInterval/basic.js
 env TZ=America/Santiago babel-node ./test/dst/addBusinessDays/basic.js

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -137,10 +137,14 @@ export default function parseISO(argument, dirtyOptions) {
     offset = getTimezoneOffsetInMilliseconds(fullTimeDate)
 
     // Adjust time when it's coming from DST
-    var fullTimeDateNextDay = new Date(fullTime)
-    fullTimeDateNextDay.setDate(fullTimeDate.getDate() + 1)
+    var fullTimeDateDiffDay = new Date(fullTime)
+    if (offset > 0) {
+      fullTimeDateDiffDay.setDate(fullTimeDate.getDate() + 1)
+    } else {
+      fullTimeDateDiffDay.setDate(fullTimeDate.getDate() - 1)
+    }
     var offsetDiff =
-      getTimezoneOffsetInMilliseconds(fullTimeDateNextDay) - offset
+      getTimezoneOffsetInMilliseconds(fullTimeDateDiffDay) - offset
     if (offsetDiff > 0) {
       offset += offsetDiff
     }

--- a/test/dst/parseISO/sydney.js
+++ b/test/dst/parseISO/sydney.js
@@ -1,0 +1,34 @@
+// This is basic DST test for parseISO
+
+import parseISO from '../../../src/parseISO'
+import assert from 'assert'
+
+if (process.env.TZ !== 'Australia/Sydney')
+  throw new Error('The test must be run with TZ=Australia/Sydney')
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+// Test DST start edge
+assert.equal(parseISO('2019-10-06').getDate(), 6) // DST start
+assert.equal(parseISO('2019-10-07').getDate(), 7)
+assert.equal(
+  parseISO('2019-10-06T01:00:00').toString(),
+  'Sun Oct 06 2019 01:00:00 GMT+1000 (Australian Eastern Standard Time)'
+)
+assert.equal(
+  parseISO('2019-10-06T02:00:00').toString(),
+  'Sun Oct 06 2019 03:00:00 GMT+1100 (Australian Eastern Daylight Time)'
+)
+
+// Test DST end edge
+assert.equal(parseISO('2019-04-06').getDate(), 6)
+assert.equal(parseISO('2019-04-07').getDate(), 7) // DST end
+assert.equal(
+  parseISO('2019-04-06T11:00:00').toString(),
+  'Sat Apr 06 2019 11:00:00 GMT+1100 (Australian Eastern Daylight Time)'
+)
+assert.equal(
+  parseISO('2019-04-07T11:00:00').toString(),
+  'Sun Apr 07 2019 11:00:00 GMT+1000 (Australian Eastern Standard Time)'
+)


### PR DESCRIPTION
See #1449, fixes problem for date parsing eg `parseISO('2019-10-06') `