### PR TITLE
parseJSON - minimal implementation for parsing JSON dates from an API

### DIFF
--- a/src/fp/index.js
+++ b/src/fp/index.js
@@ -196,6 +196,7 @@ export { default as min } from './min/index.js'
 export { default as parse } from './parse/index.js'
 export { default as parseISO } from './parseISO/index.js'
 export { default as parseISOWithOptions } from './parseISOWithOptions/index.js'
+export { default as parseJSON } from './parseJSON/index.js'
 export { default as parseWithOptions } from './parseWithOptions/index.js'
 export {
   default as roundToNearestMinutes

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -238,6 +238,7 @@ declare module.exports: {
   parse: CurriedFn3<Date | number, string, string, Date>,
   parseISO: CurriedFn1<string, Date>,
   parseISOWithOptions: CurriedFn2<Object, string, Date>,
+  parseJSON: CurriedFn1<string | number | Date, Date>,
   parseWithOptions: CurriedFn4<Object, Date | number, string, string, Date>,
   roundToNearestMinutes: CurriedFn1<Date | number, Date>,
   roundToNearestMinutesWithOptions: CurriedFn2<Object, Date | number, Date>,

--- a/src/fp/parseJSON/index.d.ts
+++ b/src/fp/parseJSON/index.d.ts
@@ -1,0 +1,4 @@
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+import { parseJSON } from 'date-fns/fp'
+export default parseJSON

--- a/src/fp/parseJSON/index.js
+++ b/src/fp/parseJSON/index.js
@@ -1,0 +1,8 @@
+// This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
+
+import fn from '../../parseJSON/index.js'
+import convertToFP from '../_lib/convertToFP/index.js'
+
+var parseJSON = convertToFP(fn, 1)
+
+export default parseJSON

--- a/src/fp/parseJSON/index.js.flow
+++ b/src/fp/parseJSON/index.js.flow
@@ -1,0 +1,40 @@
+// @flow
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+export type Interval = {
+  start: Date | number,
+  end: Date | number
+}
+
+export type Locale = {
+  formatDistance: Function,
+  formatRelative: Function,
+  localize: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  formatLong: Object,
+  date: Function,
+  time: Function,
+  dateTime: Function,
+  match: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  }
+}
+
+type CurriedFn1<A, R> = <A>(a: A) => R
+
+declare module.exports: CurriedFn1<string | number | Date, Date>

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,7 @@ export { default as max } from './max/index.js'
 export { default as min } from './min/index.js'
 export { default as parse } from './parse/index.js'
 export { default as parseISO } from './parseISO/index.js'
+export { default as parseJSON } from './parseJSON/index.js'
 export {
   default as roundToNearestMinutes
 } from './roundToNearestMinutes/index.js'

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -508,6 +508,8 @@ declare module.exports: {
     }
   ) => Date,
 
+  parseJSON: (argument: string | number | Date) => Date,
+
   roundToNearestMinutes: (
     date: Date | number,
     options?: {

--- a/src/parseJSON/benchmark.js
+++ b/src/parseJSON/benchmark.js
@@ -1,0 +1,16 @@
+// @flow
+/* eslint-env mocha */
+/* global suite, benchmark */
+
+import parseJSON from '.'
+import moment from 'moment'
+
+suite('toDate', function() {
+  benchmark('date-fns', function() {
+    return parseJSON('2014-10-25T13:46:20+00:00')
+  })
+
+  benchmark('Moment.js', function() {
+    return moment('2014-10-25T13:46:20+00:00')
+  })
+})

--- a/src/parseJSON/index.d.ts
+++ b/src/parseJSON/index.d.ts
@@ -1,0 +1,4 @@
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+import { parseJSON } from 'date-fns'
+export default parseJSON

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -30,7 +30,7 @@ import toDate from '../toDate/index.js'
  * @returns {Date} the parsed date in the local time zone
  * @throws {TypeError} 1 argument required
  */
-export default function index(argument) {
+export default function parseJSON(argument) {
   if (arguments.length < 1) {
     throw new TypeError(
       '1 argument required, but only ' + arguments.length + ' present'

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -1,0 +1,59 @@
+import toDate from '../toDate/index.js'
+
+/**
+ * @name parseJSON
+ * @category Common Helpers
+ * @summary Parse a JSON date string
+ *
+ * @description
+ * Converts a complete ISO date string in UTC time, the typical format for transmitting
+ * a date in JSON, to a JavaScript `Date` instance.
+ *
+ * This is a minimal implementation for converting dates retrieved from a JSON API to
+ * a `Date` instance which can be used with other functions in the `date-fns` library.
+ * The following formats are supported:
+ *
+ *     - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`
+ *     - `2000-03-15T05:20:10Z`: Without milliseconds
+ *     - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
+ *     - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
+ *
+ * For convenience and ease of use these other input types are also supported
+ * via [toDate]{@link https://date-fns.org/docs/toDate}:
+ *
+ *     - A `Date` instance will be cloned
+ *     - A `number` will be treated as a timestamp
+ *
+ * Any other input type or invalid date strings will return an `Invalid Date`.
+ *
+ * @param {String|Number|Date} argument A fully formed ISO1806 date string to convert
+ * @returns {Date} the parsed date in the local time zone
+ * @throws {TypeError} 1 argument required
+ */
+export default function index(argument) {
+  if (arguments.length < 1) {
+    throw new TypeError(
+      '1 argument required, but only ' + arguments.length + ' present'
+    )
+  }
+
+  if (typeof argument === 'string') {
+    var parts = argument.match(
+      /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(?:Z|\+00:?00)/
+    )
+    if (parts) {
+      return new Date(
+        Date.UTC(
+          +parts[1],
+          parts[2] - 1,
+          +parts[3],
+          +parts[4],
+          +parts[5],
+          +parts[6],
+          +(parts[7] || 0)
+        )
+      )
+    }
+  }
+  return toDate(argument)
+}

--- a/src/parseJSON/index.js.flow
+++ b/src/parseJSON/index.js.flow
@@ -1,0 +1,38 @@
+// @flow
+// This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
+
+export type Interval = {
+  start: Date | number,
+  end: Date | number
+}
+
+export type Locale = {
+  formatDistance: Function,
+  formatRelative: Function,
+  localize: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  formatLong: Object,
+  date: Function,
+  time: Function,
+  dateTime: Function,
+  match: {
+    ordinalNumber: Function,
+    era: Function,
+    quarter: Function,
+    month: Function,
+    day: Function,
+    dayPeriod: Function
+  },
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  }
+}
+
+declare module.exports: (argument: string | number | Date) => Date

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -1,3 +1,6 @@
+// @flow
+/* eslint-env mocha */
+
 import assert from 'power-assert'
 import parseJSON from '.'
 

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -1,0 +1,51 @@
+import assert from 'power-assert'
+import parseJSON from '.'
+
+describe('parseJSON', function() {
+  it('parses a fully formed ISO date with Z', () => {
+    const date = '2000-03-15T05:20:10.123Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), date)
+  })
+
+  it('parses a fully formed ISO date with Z without ms', () => {
+    const date = '2000-03-15T05:20:10Z'
+    const expectedDate = '2000-03-15T05:20:10.000Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses a fully formed ISO date with zero offset', () => {
+    const zeroOffset = '2000-03-15T05:20:10+00:00'
+    const expectedDate = '2000-03-15T05:20:10.000Z'
+    const parsedDate = parseJSON(zeroOffset)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses a fully formed ISO date with zero offset without colon', () => {
+    const zeroOffset = '2000-03-15T05:20:10+0000'
+    const expectedDate = '2000-03-15T05:20:10.000Z'
+    const parsedDate = parseJSON(zeroOffset)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('clones a date object', () => {
+    const date = new Date(2000, 2, 15, 5, 20, 10, 20)
+    const parsedDate = parseJSON(date)
+    assert.deepEqual(parsedDate, date)
+    assert.notEqual(parsedDate, date)
+  })
+
+  it('assumes a number is a timestamp', () => {
+    const date = new Date(2000, 2, 15, 5, 20, 10, 20)
+    const timestamp = date.getTime()
+    const parsedDate = parseJSON(timestamp)
+    assert.deepEqual(parsedDate, date)
+  })
+
+  it('returns an invalid date for anything else', () => {
+    assert.equal(parseJSON('').toString(), 'Invalid Date')
+    assert.equal(parseJSON('invalid').toString(), 'Invalid Date')
+    assert.equal(parseJSON('2020-10-10').toString(), 'Invalid Date')
+  })
+})

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -704,6 +704,9 @@ declare module 'date-fns' {
   ): Date
   namespace parseISO {}
 
+  function parseJSON(argument: string | number | Date): Date
+  namespace parseJSON {}
+
   function roundToNearestMinutes(
     date: Date | number,
     options?: {
@@ -1563,6 +1566,11 @@ declare module 'date-fns/parse' {
 declare module 'date-fns/parseISO' {
   import { parseISO } from 'date-fns'
   export default parseISO
+}
+
+declare module 'date-fns/parseJSON' {
+  import { parseJSON } from 'date-fns'
+  export default parseJSON
 }
 
 declare module 'date-fns/roundToNearestMinutes' {
@@ -2455,6 +2463,11 @@ declare module 'date-fns/parseISO/index' {
   export default parseISO
 }
 
+declare module 'date-fns/parseJSON/index' {
+  import { parseJSON } from 'date-fns'
+  export default parseJSON
+}
+
 declare module 'date-fns/roundToNearestMinutes/index' {
   import { roundToNearestMinutes } from 'date-fns'
   export default roundToNearestMinutes
@@ -3345,6 +3358,11 @@ declare module 'date-fns/parseISO/index.js' {
   export default parseISO
 }
 
+declare module 'date-fns/parseJSON/index.js' {
+  import { parseJSON } from 'date-fns'
+  export default parseJSON
+}
+
 declare module 'date-fns/roundToNearestMinutes/index.js' {
   import { roundToNearestMinutes } from 'date-fns'
   export default roundToNearestMinutes
@@ -4032,6 +4050,9 @@ declare module 'date-fns/fp' {
 
   const parseISOWithOptions: CurriedFn2<Object, string, Date>
   namespace parseISOWithOptions {}
+
+  const parseJSON: CurriedFn1<string | number | Date, Date>
+  namespace parseJSON {}
 
   const parseWithOptions: CurriedFn4<
     Object,
@@ -4862,6 +4883,11 @@ declare module 'date-fns/fp/parseISO' {
 declare module 'date-fns/fp/parseISOWithOptions' {
   import { parseISOWithOptions } from 'date-fns/fp'
   export default parseISOWithOptions
+}
+
+declare module 'date-fns/fp/parseJSON' {
+  import { parseJSON } from 'date-fns/fp'
+  export default parseJSON
 }
 
 declare module 'date-fns/fp/parseWithOptions' {
@@ -5774,6 +5800,11 @@ declare module 'date-fns/fp/parseISOWithOptions/index' {
   export default parseISOWithOptions
 }
 
+declare module 'date-fns/fp/parseJSON/index' {
+  import { parseJSON } from 'date-fns/fp'
+  export default parseJSON
+}
+
 declare module 'date-fns/fp/parseWithOptions/index' {
   import { parseWithOptions } from 'date-fns/fp'
   export default parseWithOptions
@@ -6684,6 +6715,11 @@ declare module 'date-fns/fp/parseISOWithOptions/index.js' {
   export default parseISOWithOptions
 }
 
+declare module 'date-fns/fp/parseJSON/index.js' {
+  import { parseJSON } from 'date-fns/fp'
+  export default parseJSON
+}
+
 declare module 'date-fns/fp/parseWithOptions/index.js' {
   import { parseWithOptions } from 'date-fns/fp'
   export default parseWithOptions
@@ -7553,6 +7589,9 @@ declare module 'date-fns/esm' {
   ): Date
   namespace parseISO {}
 
+  function parseJSON(argument: string | number | Date): Date
+  namespace parseJSON {}
+
   function roundToNearestMinutes(
     date: Date | number,
     options?: {
@@ -8412,6 +8451,11 @@ declare module 'date-fns/esm/parse' {
 declare module 'date-fns/esm/parseISO' {
   import { parseISO } from 'date-fns/esm'
   export default parseISO
+}
+
+declare module 'date-fns/esm/parseJSON' {
+  import { parseJSON } from 'date-fns/esm'
+  export default parseJSON
 }
 
 declare module 'date-fns/esm/roundToNearestMinutes' {
@@ -9304,6 +9348,11 @@ declare module 'date-fns/esm/parseISO/index' {
   export default parseISO
 }
 
+declare module 'date-fns/esm/parseJSON/index' {
+  import { parseJSON } from 'date-fns/esm'
+  export default parseJSON
+}
+
 declare module 'date-fns/esm/roundToNearestMinutes/index' {
   import { roundToNearestMinutes } from 'date-fns/esm'
   export default roundToNearestMinutes
@@ -10194,6 +10243,11 @@ declare module 'date-fns/esm/parseISO/index.js' {
   export default parseISO
 }
 
+declare module 'date-fns/esm/parseJSON/index.js' {
+  import { parseJSON } from 'date-fns/esm'
+  export default parseJSON
+}
+
 declare module 'date-fns/esm/roundToNearestMinutes/index.js' {
   import { roundToNearestMinutes } from 'date-fns/esm'
   export default roundToNearestMinutes
@@ -10881,6 +10935,9 @@ declare module 'date-fns/esm/fp' {
 
   const parseISOWithOptions: CurriedFn2<Object, string, Date>
   namespace parseISOWithOptions {}
+
+  const parseJSON: CurriedFn1<string | number | Date, Date>
+  namespace parseJSON {}
 
   const parseWithOptions: CurriedFn4<
     Object,
@@ -11711,6 +11768,11 @@ declare module 'date-fns/esm/fp/parseISO' {
 declare module 'date-fns/esm/fp/parseISOWithOptions' {
   import { parseISOWithOptions } from 'date-fns/esm/fp'
   export default parseISOWithOptions
+}
+
+declare module 'date-fns/esm/fp/parseJSON' {
+  import { parseJSON } from 'date-fns/esm/fp'
+  export default parseJSON
 }
 
 declare module 'date-fns/esm/fp/parseWithOptions' {
@@ -12623,6 +12685,11 @@ declare module 'date-fns/esm/fp/parseISOWithOptions/index' {
   export default parseISOWithOptions
 }
 
+declare module 'date-fns/esm/fp/parseJSON/index' {
+  import { parseJSON } from 'date-fns/esm/fp'
+  export default parseJSON
+}
+
 declare module 'date-fns/esm/fp/parseWithOptions/index' {
   import { parseWithOptions } from 'date-fns/esm/fp'
   export default parseWithOptions
@@ -13531,6 +13598,11 @@ declare module 'date-fns/esm/fp/parseISO/index.js' {
 declare module 'date-fns/esm/fp/parseISOWithOptions/index.js' {
   import { parseISOWithOptions } from 'date-fns/esm/fp'
   export default parseISOWithOptions
+}
+
+declare module 'date-fns/esm/fp/parseJSON/index.js' {
+  import { parseJSON } from 'date-fns/esm/fp'
+  export default parseJSON
 }
 
 declare module 'date-fns/esm/fp/parseWithOptions/index.js' {
@@ -16599,6 +16671,8 @@ interface dateFns {
       additionalDigits?: 0 | 1 | 2
     }
   ): Date
+
+  parseJSON(argument: string | number | Date): Date
 
   roundToNearestMinutes(
     date: Date | number,


### PR DESCRIPTION
The ISO date parsing previously done in `toDate` was moved into `parseISO` to keep the minimal build size low when string date manipulation is not required (#1016). The problem is that any application that retrieves a date from an API will parse some form of serialized date string before passing it to other functions. The following is typical example:

```js
const output = format(addDays(parseISO(dateFromAPI), 1), 'yyyy-MM-dd')
```

As soon as `parseISO` is used in this way the benefit of removing `toDate` has been negated. The `parseISO` and `parse` functions are still around 7000 and 8000 bytes respectively. The proposed `parseUTC` function is only ~520 bytes in size and sufficient to parse the standard JSON serialized date string formats of most server-side languages. 

Aside from complete ISO dates and the input types accepted by `toDate` the function returns an `Invalid Date`. The intention of this function will not be to parse user input, for this `parse` would still be needed, but it permits convenient parsing of date strings from an API with a known ISO format.

This is a proposed compromise/solution for the issue I raised [here](https://github.com/date-fns/date-fns/issues/1016#issuecomment-498315179), and something I have used in a couple of projects recently to good effect. 

I am still undecided about the best name for this function. My initial thought was `parseJSONDate`, but then I realized only UTC dates are supported and calling it `parseUTC` might be more generic and describe the function more specifically.

I would like to propose this function for inclusion in the core `date-fns` library, however, if it is deemed not a good fit I can also add it to `date-fns-tz`.