### PR TITLE
Updated isValid() example, refs #1461

### DIFF
--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -29,7 +29,7 @@ import toDate from '../toDate/index.js'
  *   | `new Date('')`            | `false`       | `false`       |
  *   | `new Date(1488370835081)` | `true`        | `true`        |
  *   | `new Date(NaN)`           | `false`       | `false`       |
- *   | `'2016-01-01'`            | `TypeError`   | `false`        |
+ *   | `'2016-01-01'`            | `TypeError`   | `false`       |
  *   | `''`                      | `TypeError`   | `false`       |
  *   | `1488370835081`           | `TypeError`   | `true`        |
  *   | `NaN`                     | `TypeError`   | `false`       |

--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -29,7 +29,7 @@ import toDate from '../toDate/index.js'
  *   | `new Date('')`            | `false`       | `false`       |
  *   | `new Date(1488370835081)` | `true`        | `true`        |
  *   | `new Date(NaN)`           | `false`       | `false`       |
- *   | `'2016-01-01'`            | `TypeError`   | `true`        |
+ *   | `'2016-01-01'`            | `TypeError`   | `false`        |
  *   | `''`                      | `TypeError`   | `false`       |
  *   | `1488370835081`           | `TypeError`   | `true`        |
  *   | `NaN`                     | `TypeError`   | `false`       |


### PR DESCRIPTION
Passing date as a string to isValid method will always result in false result on v2.x.