### PR TITLE
Upgrade Node.js to v12 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 language: node_js
 node_js:
-  - 10
+  - 12
 
 stages:
   - test


### PR DESCRIPTION
Node.js v12 transitions into LTS, so I think it makes sense to upgrade it.

Also, I want my Hacktoberfest shirt.