### PR TITLE
[1310] round timezones offset in milliseconds

### DIFF
--- a/src/_lib/getTimezoneOffsetInMilliseconds/index.js
+++ b/src/_lib/getTimezoneOffsetInMilliseconds/index.js
@@ -11,11 +11,14 @@ var MILLISECONDS_IN_MINUTE = 60000
  *
  * This function returns the timezone offset in milliseconds that takes seconds in account.
  */
-export default function getTimezoneOffsetInMilliseconds (dirtyDate) {
+export default function getTimezoneOffsetInMilliseconds(dirtyDate) {
   var date = new Date(dirtyDate.getTime())
-  var baseTimezoneOffset = date.getTimezoneOffset()
+  var baseTimezoneOffset = Math.ceil(date.getTimezoneOffset())
   date.setSeconds(0, 0)
   var millisecondsPartOfTimezoneOffset = date.getTime() % MILLISECONDS_IN_MINUTE
 
-  return baseTimezoneOffset * MILLISECONDS_IN_MINUTE + millisecondsPartOfTimezoneOffset
+  return (
+    baseTimezoneOffset * MILLISECONDS_IN_MINUTE +
+    millisecondsPartOfTimezoneOffset
+  )
 }


### PR DESCRIPTION
## Description
Chrome and FireFox parse time zone offsets differently

## Reference
[Issue 1310](https://github.com/date-fns/date-fns/issues/1310)

## Checklist:
* [x]  - run lint
* [x] - run tests
* [x] - rebuild FP functions, typings and indices

## How to test
1. Build the package `env PACKAGE_OUTPUT_PATH="$(pwd)/../PATH-TO-YOUR-MODULE/node_modules/date-fns" ./scripts/build/package.sh`
2. Copy it into your project
3. Test with different timezones and dates

## Screenshots
![Screen Shot 2019-10-22 at 01 38 27](https://user-images.githubusercontent.com/41301620/67286549-e1823c00-f4d9-11e9-9a84-8d7fbd365e94.png)
![Screen Shot 2019-10-22 at 14 36 59](https://user-images.githubusercontent.com/41301620/67286550-e1823c00-f4d9-11e9-9605-abc897be9a2d.png)
![Screen Shot 2019-10-22 at 15 37 17](https://user-images.githubusercontent.com/41301620/67286551-e21ad280-f4d9-11e9-8193-3305f3d9f209.png)
![Screen Shot 2019-10-22 at 23 37 39](https://user-images.githubusercontent.com/41301620/67286552-e21ad280-f4d9-11e9-83c1-c4f60d7de3b0.png)
![Screen Shot 2019-10-23 at 00 38 11](https://user-images.githubusercontent.com/41301620/67286553-e21ad280-f4d9-11e9-9ad8-6d9e3ea9ed5e.png)
