### PR TITLE
Allow `parseJSON` to accept strings without a trailing 'Z' symbold and with up to 6 digits in the milliseconds field (#1496)

### DIFF
--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -17,6 +17,8 @@ import toDate from '../toDate/index.js'
  *     - `2000-03-15T05:20:10Z`: Without milliseconds
  *     - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
  *     - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
+ *     - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
+ *     - `2000-03-15T05:20:10.134566`: Up to 6 digits in milliseconds field. Only first 3 are taken into account since JS does now allow fractional milliseconds
  *
  * For convenience and ease of use these other input types are also supported
  * via [toDate]{@link https://date-fns.org/docs/toDate}:
@@ -39,7 +41,7 @@ export default function parseJSON(argument) {
 
   if (typeof argument === 'string') {
     var parts = argument.match(
-      /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(?:Z|\+00:?00)/
+      /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,6}))?(?:Z|\+00:?00)?/
     )
     if (parts) {
       return new Date(
@@ -50,7 +52,7 @@ export default function parseJSON(argument) {
           +parts[4],
           +parts[5],
           +parts[6],
-          +(parts[7] || 0)
+          +((parts[7] || '0') + '00').substring(0, 3)
         )
       )
     }

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -32,6 +32,34 @@ describe('parseJSON', function() {
     assert.equal(parsedDate.toISOString(), expectedDate)
   })
 
+  it('parses a fully formed ISO date without Z', () => {
+    const date = '2000-03-15T05:20:10.123'
+    const expectedDate = '2000-03-15T05:20:10.123Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses a fully formed ISO date without Z and with 6-digit millisecond part', () => {
+    const date = '2000-03-15T05:20:10.123456'
+    const expectedDate = '2000-03-15T05:20:10.123Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses a fully formed ISO with 1-digit millisecond part', () => {
+    const date = '2000-03-15T05:20:10.1Z'
+    const expectedDate = '2000-03-15T05:20:10.100Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses a fully formed ISO with 2-digit millisecond part', () => {
+    const date = '2000-03-15T05:20:10.12Z'
+    const expectedDate = '2000-03-15T05:20:10.120Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
   it('clones a date object', () => {
     const date = new Date(2000, 2, 15, 5, 20, 10, 20)
     const parsedDate = parseJSON(date)


### PR DESCRIPTION
Here's one thing to think about though.. JS Date does not allow to have fractional milliseconds. So, the way i've implemented it is that extra digits are simply truncated. E.g.:

2019-12-31T23:59:59.999999Z becomes 2019-12-31T23:59:59.999Z

The question arises: do we need implemented a proper rounding here instead of truncation? E.g., with proper rounding:

2019-12-31T23:59:59.999999Z becomes 2020-01-01T00:00:00Z

In my opinion, this is not really needed and we should keep truncating it for the sake of simplicity. But I'd like to hear different opinions.