### PR TITLE
In generated types, give objects more verbose types

### DIFF
--- a/scripts/build/_lib/typings/common.js
+++ b/scripts/build/_lib/typings/common.js
@@ -73,13 +73,15 @@ function getType(types, { props = [], forceArray = false } = {}) {
 }
 
 function getFPFnType(params, returns) {
-  const fpParams = params.map(param => param.type.names)
+  const fpParamTypes = params.map(param =>
+    getType(param.type.names, { props: param.props })
+  )
 
-  const arity = fpParams.length
+  const arity = fpParamTypes.length
 
-  fpParams.push(returns)
+  fpParamTypes.push(getType(returns))
 
-  return `CurriedFn${arity}<${fpParams.map(getType).join(', ')}>`
+  return `CurriedFn${arity}<${fpParamTypes.join(', ')}>`
 }
 
 module.exports = {

--- a/src/fp/differenceInCalendarWeeksWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarWeeksWithOptions/index.js.flow
@@ -50,4 +50,12 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, Date | number, Date | number, number>
+declare module.exports: CurriedFn3<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  Date | number,
+  number
+>

--- a/src/fp/eachDayOfIntervalWithOptions/index.js.flow
+++ b/src/fp/eachDayOfIntervalWithOptions/index.js.flow
@@ -41,4 +41,10 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Interval, Date[]>
+declare module.exports: CurriedFn2<
+  {
+    step?: number
+  },
+  Interval,
+  Date[]
+>

--- a/src/fp/eachWeekOfIntervalWithOptions/index.js.flow
+++ b/src/fp/eachWeekOfIntervalWithOptions/index.js.flow
@@ -41,4 +41,11 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Interval, Date[]>
+declare module.exports: CurriedFn2<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Interval,
+  Date[]
+>

--- a/src/fp/endOfDecadeWithOptions/index.js.flow
+++ b/src/fp/endOfDecadeWithOptions/index.js.flow
@@ -41,4 +41,10 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    additionalDigits?: 0 | 1 | 2
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/endOfWeekWithOptions/index.js.flow
+++ b/src/fp/endOfWeekWithOptions/index.js.flow
@@ -41,4 +41,11 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/formatDistanceStrictWithOptions/index.js.flow
+++ b/src/fp/formatDistanceStrictWithOptions/index.js.flow
@@ -50,4 +50,14 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, Date | number, Date | number, string>
+declare module.exports: CurriedFn3<
+  {
+    locale?: Locale,
+    roundingMethod?: 'floor' | 'ceil' | 'round',
+    unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
+    addSuffix?: boolean
+  },
+  Date | number,
+  Date | number,
+  string
+>

--- a/src/fp/formatDistanceWithOptions/index.js.flow
+++ b/src/fp/formatDistanceWithOptions/index.js.flow
@@ -50,4 +50,13 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, Date | number, Date | number, string>
+declare module.exports: CurriedFn3<
+  {
+    locale?: Locale,
+    addSuffix?: boolean,
+    includeSeconds?: boolean
+  },
+  Date | number,
+  Date | number,
+  string
+>

--- a/src/fp/formatRelativeWithOptions/index.js.flow
+++ b/src/fp/formatRelativeWithOptions/index.js.flow
@@ -50,4 +50,12 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, Date | number, Date | number, string>
+declare module.exports: CurriedFn3<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  Date | number,
+  string
+>

--- a/src/fp/formatWithOptions/index.js.flow
+++ b/src/fp/formatWithOptions/index.js.flow
@@ -50,4 +50,15 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, string, Date | number, string>
+declare module.exports: CurriedFn3<
+  {
+    useAdditionalDayOfYearTokens?: boolean,
+    useAdditionalWeekYearTokens?: boolean,
+    firstWeekContainsDate?: number,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  string,
+  Date | number,
+  string
+>

--- a/src/fp/getWeekOfMonthWithOptions/index.js.flow
+++ b/src/fp/getWeekOfMonthWithOptions/index.js.flow
@@ -41,4 +41,11 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, number>
+declare module.exports: CurriedFn2<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  number
+>

--- a/src/fp/getWeekWithOptions/index.js.flow
+++ b/src/fp/getWeekWithOptions/index.js.flow
@@ -41,4 +41,12 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, number>
+declare module.exports: CurriedFn2<
+  {
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  number
+>

--- a/src/fp/getWeekYearWithOptions/index.js.flow
+++ b/src/fp/getWeekYearWithOptions/index.js.flow
@@ -41,4 +41,12 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, number>
+declare module.exports: CurriedFn2<
+  {
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  number
+>

--- a/src/fp/getWeeksInMonthWithOptions/index.js.flow
+++ b/src/fp/getWeeksInMonthWithOptions/index.js.flow
@@ -41,4 +41,11 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, number>
+declare module.exports: CurriedFn2<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  number
+>

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -102,7 +102,10 @@ declare module.exports: {
   >,
   differenceInCalendarWeeks: CurriedFn2<Date | number, Date | number, number>,
   differenceInCalendarWeeksWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     number
@@ -119,15 +122,34 @@ declare module.exports: {
   differenceInWeeks: CurriedFn2<Date | number, Date | number, number>,
   differenceInYears: CurriedFn2<Date | number, Date | number, number>,
   eachDayOfInterval: CurriedFn1<Interval, Date[]>,
-  eachDayOfIntervalWithOptions: CurriedFn2<Object, Interval, Date[]>,
+  eachDayOfIntervalWithOptions: CurriedFn2<
+    {
+      step?: number
+    },
+    Interval,
+    Date[]
+  >,
   eachWeekendOfInterval: CurriedFn1<Interval, Date[]>,
   eachWeekendOfMonth: CurriedFn1<Date | number, Date[]>,
   eachWeekendOfYear: CurriedFn1<Date | number, Date[]>,
   eachWeekOfInterval: CurriedFn1<Interval, Date[]>,
-  eachWeekOfIntervalWithOptions: CurriedFn2<Object, Interval, Date[]>,
+  eachWeekOfIntervalWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Interval,
+    Date[]
+  >,
   endOfDay: CurriedFn1<Date | number, Date>,
   endOfDecade: CurriedFn1<Date | number, Date>,
-  endOfDecadeWithOptions: CurriedFn2<Object, Date | number, Date>,
+  endOfDecadeWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    Date | number,
+    Date
+  >,
   endOfHour: CurriedFn1<Date | number, Date>,
   endOfISOWeek: CurriedFn1<Date | number, Date>,
   endOfISOWeekYear: CurriedFn1<Date | number, Date>,
@@ -136,31 +158,61 @@ declare module.exports: {
   endOfQuarter: CurriedFn1<Date | number, Date>,
   endOfSecond: CurriedFn1<Date | number, Date>,
   endOfWeek: CurriedFn1<Date | number, Date>,
-  endOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>,
+  endOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >,
   endOfYear: CurriedFn1<Date | number, Date>,
   format: CurriedFn2<string, Date | number, string>,
   formatDistance: CurriedFn2<Date | number, Date | number, string>,
   formatDistanceStrict: CurriedFn2<Date | number, Date | number, string>,
   formatDistanceStrictWithOptions: CurriedFn3<
-    Object,
+    {
+      locale?: Locale,
+      roundingMethod?: 'floor' | 'ceil' | 'round',
+      unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year',
+      addSuffix?: boolean
+    },
     Date | number,
     Date | number,
     string
   >,
   formatDistanceWithOptions: CurriedFn3<
-    Object,
+    {
+      locale?: Locale,
+      addSuffix?: boolean,
+      includeSeconds?: boolean
+    },
     Date | number,
     Date | number,
     string
   >,
   formatRelative: CurriedFn2<Date | number, Date | number, string>,
   formatRelativeWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     string
   >,
-  formatWithOptions: CurriedFn3<Object, string, Date | number, string>,
+  formatWithOptions: CurriedFn3<
+    {
+      useAdditionalDayOfYearTokens?: boolean,
+      useAdditionalWeekYearTokens?: boolean,
+      firstWeekContainsDate?: number,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    string,
+    Date | number,
+    string
+  >,
   fromUnixTime: CurriedFn1<number, Date>,
   getDate: CurriedFn1<Date | number, number>,
   getDay: CurriedFn1<Date | number, number>,
@@ -183,12 +235,42 @@ declare module.exports: {
   getUnixTime: CurriedFn1<Date | number, number>,
   getWeek: CurriedFn1<Date | number, number>,
   getWeekOfMonth: CurriedFn1<Date | number, number>,
-  getWeekOfMonthWithOptions: CurriedFn2<Object, Date | number, number>,
+  getWeekOfMonthWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >,
   getWeeksInMonth: CurriedFn1<Date | number, number>,
-  getWeeksInMonthWithOptions: CurriedFn2<Object, Date | number, number>,
-  getWeekWithOptions: CurriedFn2<Object, Date | number, number>,
+  getWeeksInMonthWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >,
+  getWeekWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >,
   getWeekYear: CurriedFn1<Date | number, number>,
-  getWeekYearWithOptions: CurriedFn2<Object, Date | number, number>,
+  getWeekYearWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >,
   getYear: CurriedFn1<Date | number, number>,
   isAfter: CurriedFn2<Date | number, Date | number, boolean>,
   isBefore: CurriedFn2<Date | number, Date | number, boolean>,
@@ -209,7 +291,10 @@ declare module.exports: {
   isSameSecond: CurriedFn2<Date | number, Date | number, boolean>,
   isSameWeek: CurriedFn2<Date | number, Date | number, boolean>,
   isSameWeekWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     boolean
@@ -228,25 +313,82 @@ declare module.exports: {
   lastDayOfISOWeekYear: CurriedFn1<Date | number, Date>,
   lastDayOfMonth: CurriedFn1<Date | number, Date>,
   lastDayOfQuarter: CurriedFn1<Date | number, Date>,
-  lastDayOfQuarterWithOptions: CurriedFn2<Object, Date | number, Date>,
+  lastDayOfQuarterWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    Date | number,
+    Date
+  >,
   lastDayOfWeek: CurriedFn1<Date | number, Date>,
-  lastDayOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>,
+  lastDayOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >,
   lastDayOfYear: CurriedFn1<Date | number, Date>,
   lightFormat: CurriedFn2<string, Date | number, string>,
   max: CurriedFn1<(Date | number)[], Date>,
   min: CurriedFn1<(Date | number)[], Date>,
   parse: CurriedFn3<Date | number, string, string, Date>,
   parseISO: CurriedFn1<string, Date>,
-  parseISOWithOptions: CurriedFn2<Object, string, Date>,
+  parseISOWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    string,
+    Date
+  >,
   parseJSON: CurriedFn1<string | number | Date, Date>,
-  parseWithOptions: CurriedFn4<Object, Date | number, string, string, Date>,
+  parseWithOptions: CurriedFn4<
+    {
+      useAdditionalDayOfYearTokens?: boolean,
+      useAdditionalWeekYearTokens?: boolean,
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    string,
+    string,
+    Date
+  >,
   roundToNearestMinutes: CurriedFn1<Date | number, Date>,
-  roundToNearestMinutesWithOptions: CurriedFn2<Object, Date | number, Date>,
-  set: CurriedFn2<Object, Date | number, Date>,
+  roundToNearestMinutesWithOptions: CurriedFn2<
+    {
+      nearestTo?: number
+    },
+    Date | number,
+    Date
+  >,
+  set: CurriedFn2<
+    {
+      milliseconds?: number,
+      seconds?: number,
+      minutes?: number,
+      hours?: number,
+      date?: number,
+      month?: number,
+      year?: number
+    },
+    Date | number,
+    Date
+  >,
   setDate: CurriedFn2<number, Date | number, Date>,
   setDay: CurriedFn2<number, Date | number, Date>,
   setDayOfYear: CurriedFn2<number, Date | number, Date>,
-  setDayWithOptions: CurriedFn3<Object, number, Date | number, Date>,
+  setDayWithOptions: CurriedFn3<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >,
   setHours: CurriedFn2<number, Date | number, Date>,
   setISODay: CurriedFn2<number, Date | number, Date>,
   setISOWeek: CurriedFn2<number, Date | number, Date>,
@@ -257,9 +399,27 @@ declare module.exports: {
   setQuarter: CurriedFn2<number, Date | number, Date>,
   setSeconds: CurriedFn2<number, Date | number, Date>,
   setWeek: CurriedFn2<number, Date | number, Date>,
-  setWeekWithOptions: CurriedFn3<Object, number, Date | number, Date>,
+  setWeekWithOptions: CurriedFn3<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >,
   setWeekYear: CurriedFn2<number, Date | number, Date>,
-  setWeekYearWithOptions: CurriedFn3<Object, number, Date | number, Date>,
+  setWeekYearWithOptions: CurriedFn3<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >,
   setYear: CurriedFn2<number, Date | number, Date>,
   startOfDay: CurriedFn1<Date | number, Date>,
   startOfDecade: CurriedFn1<Date | number, Date>,
@@ -271,9 +431,24 @@ declare module.exports: {
   startOfQuarter: CurriedFn1<Date | number, Date>,
   startOfSecond: CurriedFn1<Date | number, Date>,
   startOfWeek: CurriedFn1<Date | number, Date>,
-  startOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>,
+  startOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >,
   startOfWeekYear: CurriedFn1<Date | number, Date>,
-  startOfWeekYearWithOptions: CurriedFn2<Object, Date | number, Date>,
+  startOfWeekYearWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >,
   startOfYear: CurriedFn1<Date | number, Date>,
   subBusinessDays: CurriedFn2<number, Date | number, Date>,
   subDays: CurriedFn2<number, Date | number, Date>,

--- a/src/fp/isSameWeekWithOptions/index.js.flow
+++ b/src/fp/isSameWeekWithOptions/index.js.flow
@@ -51,7 +51,10 @@ type CurriedFn3<A, B, C, R> = <A>(
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
 declare module.exports: CurriedFn3<
-  Object,
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
   Date | number,
   Date | number,
   boolean

--- a/src/fp/lastDayOfQuarterWithOptions/index.js.flow
+++ b/src/fp/lastDayOfQuarterWithOptions/index.js.flow
@@ -41,4 +41,10 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    additionalDigits?: 0 | 1 | 2
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/lastDayOfWeekWithOptions/index.js.flow
+++ b/src/fp/lastDayOfWeekWithOptions/index.js.flow
@@ -41,4 +41,11 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/parseISOWithOptions/index.js.flow
+++ b/src/fp/parseISOWithOptions/index.js.flow
@@ -41,4 +41,10 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, string, Date>
+declare module.exports: CurriedFn2<
+  {
+    additionalDigits?: 0 | 1 | 2
+  },
+  string,
+  Date
+>

--- a/src/fp/parseWithOptions/index.js.flow
+++ b/src/fp/parseWithOptions/index.js.flow
@@ -65,4 +65,16 @@ type CurriedFn4<A, B, C, D, R> = <A>(
           c: C
         ) => CurriedFn1<D, R> | (<A, B, C, D>(a: A, b: B, c: C, d: D) => R)))
 
-declare module.exports: CurriedFn4<Object, Date | number, string, string, Date>
+declare module.exports: CurriedFn4<
+  {
+    useAdditionalDayOfYearTokens?: boolean,
+    useAdditionalWeekYearTokens?: boolean,
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  string,
+  string,
+  Date
+>

--- a/src/fp/roundToNearestMinutesWithOptions/index.js.flow
+++ b/src/fp/roundToNearestMinutesWithOptions/index.js.flow
@@ -41,4 +41,10 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    nearestTo?: number
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/set/index.js.flow
+++ b/src/fp/set/index.js.flow
@@ -41,4 +41,16 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    milliseconds?: number,
+    seconds?: number,
+    minutes?: number,
+    hours?: number,
+    date?: number,
+    month?: number,
+    year?: number
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/setDayWithOptions/index.js.flow
+++ b/src/fp/setDayWithOptions/index.js.flow
@@ -50,4 +50,12 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, number, Date | number, Date>
+declare module.exports: CurriedFn3<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  number,
+  Date | number,
+  Date
+>

--- a/src/fp/setWeekWithOptions/index.js.flow
+++ b/src/fp/setWeekWithOptions/index.js.flow
@@ -50,4 +50,13 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, number, Date | number, Date>
+declare module.exports: CurriedFn3<
+  {
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  number,
+  Date | number,
+  Date
+>

--- a/src/fp/setWeekYearWithOptions/index.js.flow
+++ b/src/fp/setWeekYearWithOptions/index.js.flow
@@ -50,4 +50,13 @@ type CurriedFn3<A, B, C, R> = <A>(
       b: B
     ) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<Object, number, Date | number, Date>
+declare module.exports: CurriedFn3<
+  {
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  number,
+  Date | number,
+  Date
+>

--- a/src/fp/startOfWeekWithOptions/index.js.flow
+++ b/src/fp/startOfWeekWithOptions/index.js.flow
@@ -41,4 +41,11 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  Date
+>

--- a/src/fp/startOfWeekYearWithOptions/index.js.flow
+++ b/src/fp/startOfWeekYearWithOptions/index.js.flow
@@ -41,4 +41,12 @@ type CurriedFn2<A, B, R> = <A>(
   a: A
 ) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<Object, Date | number, Date>
+declare module.exports: CurriedFn2<
+  {
+    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
+    locale?: Locale
+  },
+  Date | number,
+  Date
+>

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -3697,7 +3697,10 @@ declare module 'date-fns/fp' {
   namespace differenceInCalendarWeeks {}
 
   const differenceInCalendarWeeksWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     number
@@ -3752,7 +3755,13 @@ declare module 'date-fns/fp' {
   const eachDayOfInterval: CurriedFn1<Interval, Date[]>
   namespace eachDayOfInterval {}
 
-  const eachDayOfIntervalWithOptions: CurriedFn2<Object, Interval, Date[]>
+  const eachDayOfIntervalWithOptions: CurriedFn2<
+    {
+      step?: number
+    },
+    Interval,
+    Date[]
+  >
   namespace eachDayOfIntervalWithOptions {}
 
   const eachWeekendOfInterval: CurriedFn1<Interval, Date[]>
@@ -3767,7 +3776,14 @@ declare module 'date-fns/fp' {
   const eachWeekOfInterval: CurriedFn1<Interval, Date[]>
   namespace eachWeekOfInterval {}
 
-  const eachWeekOfIntervalWithOptions: CurriedFn2<Object, Interval, Date[]>
+  const eachWeekOfIntervalWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Interval,
+    Date[]
+  >
   namespace eachWeekOfIntervalWithOptions {}
 
   const endOfDay: CurriedFn1<Date | number, Date>
@@ -3776,7 +3792,13 @@ declare module 'date-fns/fp' {
   const endOfDecade: CurriedFn1<Date | number, Date>
   namespace endOfDecade {}
 
-  const endOfDecadeWithOptions: CurriedFn2<Object, Date | number, Date>
+  const endOfDecadeWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    Date | number,
+    Date
+  >
   namespace endOfDecadeWithOptions {}
 
   const endOfHour: CurriedFn1<Date | number, Date>
@@ -3803,7 +3825,14 @@ declare module 'date-fns/fp' {
   const endOfWeek: CurriedFn1<Date | number, Date>
   namespace endOfWeek {}
 
-  const endOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>
+  const endOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace endOfWeekWithOptions {}
 
   const endOfYear: CurriedFn1<Date | number, Date>
@@ -3819,7 +3848,12 @@ declare module 'date-fns/fp' {
   namespace formatDistanceStrict {}
 
   const formatDistanceStrictWithOptions: CurriedFn3<
-    Object,
+    {
+      locale?: Locale
+      roundingMethod?: 'floor' | 'ceil' | 'round'
+      unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+      addSuffix?: boolean
+    },
     Date | number,
     Date | number,
     string
@@ -3827,7 +3861,11 @@ declare module 'date-fns/fp' {
   namespace formatDistanceStrictWithOptions {}
 
   const formatDistanceWithOptions: CurriedFn3<
-    Object,
+    {
+      locale?: Locale
+      addSuffix?: boolean
+      includeSeconds?: boolean
+    },
     Date | number,
     Date | number,
     string
@@ -3838,14 +3876,28 @@ declare module 'date-fns/fp' {
   namespace formatRelative {}
 
   const formatRelativeWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     string
   >
   namespace formatRelativeWithOptions {}
 
-  const formatWithOptions: CurriedFn3<Object, string, Date | number, string>
+  const formatWithOptions: CurriedFn3<
+    {
+      useAdditionalDayOfYearTokens?: boolean
+      useAdditionalWeekYearTokens?: boolean
+      firstWeekContainsDate?: number
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    string,
+    Date | number,
+    string
+  >
   namespace formatWithOptions {}
 
   const fromUnixTime: CurriedFn1<number, Date>
@@ -3914,22 +3966,52 @@ declare module 'date-fns/fp' {
   const getWeekOfMonth: CurriedFn1<Date | number, number>
   namespace getWeekOfMonth {}
 
-  const getWeekOfMonthWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeekOfMonthWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeekOfMonthWithOptions {}
 
   const getWeeksInMonth: CurriedFn1<Date | number, number>
   namespace getWeeksInMonth {}
 
-  const getWeeksInMonthWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeeksInMonthWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeeksInMonthWithOptions {}
 
-  const getWeekWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeekWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeekWithOptions {}
 
   const getWeekYear: CurriedFn1<Date | number, number>
   namespace getWeekYear {}
 
-  const getWeekYearWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeekYearWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeekYearWithOptions {}
 
   const getYear: CurriedFn1<Date | number, number>
@@ -3990,7 +4072,10 @@ declare module 'date-fns/fp' {
   namespace isSameWeek {}
 
   const isSameWeekWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     boolean
@@ -4039,13 +4124,26 @@ declare module 'date-fns/fp' {
   const lastDayOfQuarter: CurriedFn1<Date | number, Date>
   namespace lastDayOfQuarter {}
 
-  const lastDayOfQuarterWithOptions: CurriedFn2<Object, Date | number, Date>
+  const lastDayOfQuarterWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    Date | number,
+    Date
+  >
   namespace lastDayOfQuarterWithOptions {}
 
   const lastDayOfWeek: CurriedFn1<Date | number, Date>
   namespace lastDayOfWeek {}
 
-  const lastDayOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>
+  const lastDayOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace lastDayOfWeekWithOptions {}
 
   const lastDayOfYear: CurriedFn1<Date | number, Date>
@@ -4066,14 +4164,26 @@ declare module 'date-fns/fp' {
   const parseISO: CurriedFn1<string, Date>
   namespace parseISO {}
 
-  const parseISOWithOptions: CurriedFn2<Object, string, Date>
+  const parseISOWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    string,
+    Date
+  >
   namespace parseISOWithOptions {}
 
   const parseJSON: CurriedFn1<string | number | Date, Date>
   namespace parseJSON {}
 
   const parseWithOptions: CurriedFn4<
-    Object,
+    {
+      useAdditionalDayOfYearTokens?: boolean
+      useAdditionalWeekYearTokens?: boolean
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     string,
     string,
@@ -4085,13 +4195,27 @@ declare module 'date-fns/fp' {
   namespace roundToNearestMinutes {}
 
   const roundToNearestMinutesWithOptions: CurriedFn2<
-    Object,
+    {
+      nearestTo?: number
+    },
     Date | number,
     Date
   >
   namespace roundToNearestMinutesWithOptions {}
 
-  const set: CurriedFn2<Object, Date | number, Date>
+  const set: CurriedFn2<
+    {
+      milliseconds?: number
+      seconds?: number
+      minutes?: number
+      hours?: number
+      date?: number
+      month?: number
+      year?: number
+    },
+    Date | number,
+    Date
+  >
   namespace set {}
 
   const setDate: CurriedFn2<number, Date | number, Date>
@@ -4103,7 +4227,15 @@ declare module 'date-fns/fp' {
   const setDayOfYear: CurriedFn2<number, Date | number, Date>
   namespace setDayOfYear {}
 
-  const setDayWithOptions: CurriedFn3<Object, number, Date | number, Date>
+  const setDayWithOptions: CurriedFn3<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >
   namespace setDayWithOptions {}
 
   const setHours: CurriedFn2<number, Date | number, Date>
@@ -4136,13 +4268,31 @@ declare module 'date-fns/fp' {
   const setWeek: CurriedFn2<number, Date | number, Date>
   namespace setWeek {}
 
-  const setWeekWithOptions: CurriedFn3<Object, number, Date | number, Date>
+  const setWeekWithOptions: CurriedFn3<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >
   namespace setWeekWithOptions {}
 
   const setWeekYear: CurriedFn2<number, Date | number, Date>
   namespace setWeekYear {}
 
-  const setWeekYearWithOptions: CurriedFn3<Object, number, Date | number, Date>
+  const setWeekYearWithOptions: CurriedFn3<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >
   namespace setWeekYearWithOptions {}
 
   const setYear: CurriedFn2<number, Date | number, Date>
@@ -4178,13 +4328,28 @@ declare module 'date-fns/fp' {
   const startOfWeek: CurriedFn1<Date | number, Date>
   namespace startOfWeek {}
 
-  const startOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>
+  const startOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace startOfWeekWithOptions {}
 
   const startOfWeekYear: CurriedFn1<Date | number, Date>
   namespace startOfWeekYear {}
 
-  const startOfWeekYearWithOptions: CurriedFn2<Object, Date | number, Date>
+  const startOfWeekYearWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace startOfWeekYearWithOptions {}
 
   const startOfYear: CurriedFn1<Date | number, Date>
@@ -10618,7 +10783,10 @@ declare module 'date-fns/esm/fp' {
   namespace differenceInCalendarWeeks {}
 
   const differenceInCalendarWeeksWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     number
@@ -10673,7 +10841,13 @@ declare module 'date-fns/esm/fp' {
   const eachDayOfInterval: CurriedFn1<Interval, Date[]>
   namespace eachDayOfInterval {}
 
-  const eachDayOfIntervalWithOptions: CurriedFn2<Object, Interval, Date[]>
+  const eachDayOfIntervalWithOptions: CurriedFn2<
+    {
+      step?: number
+    },
+    Interval,
+    Date[]
+  >
   namespace eachDayOfIntervalWithOptions {}
 
   const eachWeekendOfInterval: CurriedFn1<Interval, Date[]>
@@ -10688,7 +10862,14 @@ declare module 'date-fns/esm/fp' {
   const eachWeekOfInterval: CurriedFn1<Interval, Date[]>
   namespace eachWeekOfInterval {}
 
-  const eachWeekOfIntervalWithOptions: CurriedFn2<Object, Interval, Date[]>
+  const eachWeekOfIntervalWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Interval,
+    Date[]
+  >
   namespace eachWeekOfIntervalWithOptions {}
 
   const endOfDay: CurriedFn1<Date | number, Date>
@@ -10697,7 +10878,13 @@ declare module 'date-fns/esm/fp' {
   const endOfDecade: CurriedFn1<Date | number, Date>
   namespace endOfDecade {}
 
-  const endOfDecadeWithOptions: CurriedFn2<Object, Date | number, Date>
+  const endOfDecadeWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    Date | number,
+    Date
+  >
   namespace endOfDecadeWithOptions {}
 
   const endOfHour: CurriedFn1<Date | number, Date>
@@ -10724,7 +10911,14 @@ declare module 'date-fns/esm/fp' {
   const endOfWeek: CurriedFn1<Date | number, Date>
   namespace endOfWeek {}
 
-  const endOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>
+  const endOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace endOfWeekWithOptions {}
 
   const endOfYear: CurriedFn1<Date | number, Date>
@@ -10740,7 +10934,12 @@ declare module 'date-fns/esm/fp' {
   namespace formatDistanceStrict {}
 
   const formatDistanceStrictWithOptions: CurriedFn3<
-    Object,
+    {
+      locale?: Locale
+      roundingMethod?: 'floor' | 'ceil' | 'round'
+      unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+      addSuffix?: boolean
+    },
     Date | number,
     Date | number,
     string
@@ -10748,7 +10947,11 @@ declare module 'date-fns/esm/fp' {
   namespace formatDistanceStrictWithOptions {}
 
   const formatDistanceWithOptions: CurriedFn3<
-    Object,
+    {
+      locale?: Locale
+      addSuffix?: boolean
+      includeSeconds?: boolean
+    },
     Date | number,
     Date | number,
     string
@@ -10759,14 +10962,28 @@ declare module 'date-fns/esm/fp' {
   namespace formatRelative {}
 
   const formatRelativeWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     string
   >
   namespace formatRelativeWithOptions {}
 
-  const formatWithOptions: CurriedFn3<Object, string, Date | number, string>
+  const formatWithOptions: CurriedFn3<
+    {
+      useAdditionalDayOfYearTokens?: boolean
+      useAdditionalWeekYearTokens?: boolean
+      firstWeekContainsDate?: number
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    string,
+    Date | number,
+    string
+  >
   namespace formatWithOptions {}
 
   const fromUnixTime: CurriedFn1<number, Date>
@@ -10835,22 +11052,52 @@ declare module 'date-fns/esm/fp' {
   const getWeekOfMonth: CurriedFn1<Date | number, number>
   namespace getWeekOfMonth {}
 
-  const getWeekOfMonthWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeekOfMonthWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeekOfMonthWithOptions {}
 
   const getWeeksInMonth: CurriedFn1<Date | number, number>
   namespace getWeeksInMonth {}
 
-  const getWeeksInMonthWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeeksInMonthWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeeksInMonthWithOptions {}
 
-  const getWeekWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeekWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeekWithOptions {}
 
   const getWeekYear: CurriedFn1<Date | number, number>
   namespace getWeekYear {}
 
-  const getWeekYearWithOptions: CurriedFn2<Object, Date | number, number>
+  const getWeekYearWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    number
+  >
   namespace getWeekYearWithOptions {}
 
   const getYear: CurriedFn1<Date | number, number>
@@ -10911,7 +11158,10 @@ declare module 'date-fns/esm/fp' {
   namespace isSameWeek {}
 
   const isSameWeekWithOptions: CurriedFn3<
-    Object,
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     Date | number,
     boolean
@@ -10960,13 +11210,26 @@ declare module 'date-fns/esm/fp' {
   const lastDayOfQuarter: CurriedFn1<Date | number, Date>
   namespace lastDayOfQuarter {}
 
-  const lastDayOfQuarterWithOptions: CurriedFn2<Object, Date | number, Date>
+  const lastDayOfQuarterWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    Date | number,
+    Date
+  >
   namespace lastDayOfQuarterWithOptions {}
 
   const lastDayOfWeek: CurriedFn1<Date | number, Date>
   namespace lastDayOfWeek {}
 
-  const lastDayOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>
+  const lastDayOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace lastDayOfWeekWithOptions {}
 
   const lastDayOfYear: CurriedFn1<Date | number, Date>
@@ -10987,14 +11250,26 @@ declare module 'date-fns/esm/fp' {
   const parseISO: CurriedFn1<string, Date>
   namespace parseISO {}
 
-  const parseISOWithOptions: CurriedFn2<Object, string, Date>
+  const parseISOWithOptions: CurriedFn2<
+    {
+      additionalDigits?: 0 | 1 | 2
+    },
+    string,
+    Date
+  >
   namespace parseISOWithOptions {}
 
   const parseJSON: CurriedFn1<string | number | Date, Date>
   namespace parseJSON {}
 
   const parseWithOptions: CurriedFn4<
-    Object,
+    {
+      useAdditionalDayOfYearTokens?: boolean
+      useAdditionalWeekYearTokens?: boolean
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
     Date | number,
     string,
     string,
@@ -11006,13 +11281,27 @@ declare module 'date-fns/esm/fp' {
   namespace roundToNearestMinutes {}
 
   const roundToNearestMinutesWithOptions: CurriedFn2<
-    Object,
+    {
+      nearestTo?: number
+    },
     Date | number,
     Date
   >
   namespace roundToNearestMinutesWithOptions {}
 
-  const set: CurriedFn2<Object, Date | number, Date>
+  const set: CurriedFn2<
+    {
+      milliseconds?: number
+      seconds?: number
+      minutes?: number
+      hours?: number
+      date?: number
+      month?: number
+      year?: number
+    },
+    Date | number,
+    Date
+  >
   namespace set {}
 
   const setDate: CurriedFn2<number, Date | number, Date>
@@ -11024,7 +11313,15 @@ declare module 'date-fns/esm/fp' {
   const setDayOfYear: CurriedFn2<number, Date | number, Date>
   namespace setDayOfYear {}
 
-  const setDayWithOptions: CurriedFn3<Object, number, Date | number, Date>
+  const setDayWithOptions: CurriedFn3<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >
   namespace setDayWithOptions {}
 
   const setHours: CurriedFn2<number, Date | number, Date>
@@ -11057,13 +11354,31 @@ declare module 'date-fns/esm/fp' {
   const setWeek: CurriedFn2<number, Date | number, Date>
   namespace setWeek {}
 
-  const setWeekWithOptions: CurriedFn3<Object, number, Date | number, Date>
+  const setWeekWithOptions: CurriedFn3<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >
   namespace setWeekWithOptions {}
 
   const setWeekYear: CurriedFn2<number, Date | number, Date>
   namespace setWeekYear {}
 
-  const setWeekYearWithOptions: CurriedFn3<Object, number, Date | number, Date>
+  const setWeekYearWithOptions: CurriedFn3<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    number,
+    Date | number,
+    Date
+  >
   namespace setWeekYearWithOptions {}
 
   const setYear: CurriedFn2<number, Date | number, Date>
@@ -11099,13 +11414,28 @@ declare module 'date-fns/esm/fp' {
   const startOfWeek: CurriedFn1<Date | number, Date>
   namespace startOfWeek {}
 
-  const startOfWeekWithOptions: CurriedFn2<Object, Date | number, Date>
+  const startOfWeekWithOptions: CurriedFn2<
+    {
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace startOfWeekWithOptions {}
 
   const startOfWeekYear: CurriedFn1<Date | number, Date>
   namespace startOfWeekYear {}
 
-  const startOfWeekYearWithOptions: CurriedFn2<Object, Date | number, Date>
+  const startOfWeekYearWithOptions: CurriedFn2<
+    {
+      firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+      weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+      locale?: Locale
+    },
+    Date | number,
+    Date
+  >
   namespace startOfWeekYearWithOptions {}
 
   const startOfYear: CurriedFn1<Date | number, Date>


### PR DESCRIPTION
`Object` type is deprecated in flow. Since we know the exact params of object arguments, we should just put those in typings instead of `Object`

👕👕👕