### PR TITLE
Fix mistake in Slovenian translation

### DIFF
--- a/src/locale/sl/_lib/formatDistance/index.js
+++ b/src/locale/sl/_lib/formatDistance/index.js
@@ -250,7 +250,7 @@ var distanceInWordsLocaleFuture = {
   xMonths: {
     one: '{{count}} mesec',
     two: '{{count}} meseca',
-    few: '{{count}} meseci',
+    few: '{{count}} mesece',
     other: '{{count}} mesecev'
   },
 


### PR DESCRIPTION
Noticed a mistake I made when I initially translated the Slovenian locale (I guess I don't need to explain that Slavic languages can get complicated :blush:).