### PR TITLE
isValid: use type predicate

### DIFF
--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -38,8 +38,8 @@ import toDate from '../toDate/index.js'
  *   that try to coerce arguments to the expected type
  *   (which is also the case with other *date-fns* functions).
  *
- * @param {*} date - the date to check
- * @returns {Boolean} the date is valid
+ * @param {*} dirtyDate - the date to check
+ * @returns {dirtyDate is number | Date} the date is valid
  * @throws {TypeError} 1 argument required
  *
  * @example


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates

Allows one to write `if (isValid(foo)) ...` instead of `if (foo && isValid(foo))` to check if foo is not undefined.