### PR TITLE
Make all properties in Locale object optional

### DIFF
--- a/docs/Locale.js
+++ b/docs/Locale.js
@@ -9,16 +9,16 @@
  *
  * @typedef {Object} Locale
  *
- * @property {Function} formatDistance - the function that takes a token
+ * @property {Function} [formatDistance] - the function that takes a token
  *   passed by `formatDistance` or `formatDistanceStrict` and payload,
  *   and returns localized distance in words.
  *   Required by `formatDistance` and `formatDistanceStrict`
  *
- * @property {Function} formatRelative - the function that takes a token
+ * @property {Function} [formatRelative] - the function that takes a token
  *   passed by `formatRelative` and two dates and returns the localized relative date format.
  *   Required by `formatRelative`
  *
- * @property {Object} localize - the object with functions used to localize various values.
+ * @property {Object} [localize] - the object with functions used to localize various values.
  *   Required by `format` and `formatRelative`
  * @property {Function} localize.ordinalNumber - the function that localizes an ordinal number
  * @property {Function} localize.era - the function that takes 0 or 1 and returns localized era
@@ -29,12 +29,12 @@
  *   'am', 'pm', 'midnight', 'noon', 'morning', 'afternoon', 'evening' or 'night'
  *   and returns localized time of the day
  *
- * @property {Object} formatLong - the object with functions that return localized formats
- * @property {Function} date - the function that returns a localized long date format
- * @property {Function} time - the function that returns a localized long time format
- * @property {Function} dateTime - the function that returns a localized format of date and time combined
+ * @property {Object} [formatLong] - the object with functions that return localized formats
+ * @property {Function} formatLong.date - the function that returns a localized long date format
+ * @property {Function} formatLong.time - the function that returns a localized long time format
+ * @property {Function} formatLong.dateTime - the function that returns a localized format of date and time combined
  *
- * @property {Object} match — the object with functions used to match and parse various localized values.
+ * @property {Object} [match] — the object with functions used to match and parse various localized values.
  *   Required by `parse`
  * @property {Function} match.ordinalNumber - the function that parses a localized ordinal number
  * @property {Function} match.era - the function that parses a localized era

--- a/src/addBusinessDays/index.js.flow
+++ b/src/addBusinessDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addDays/index.js.flow
+++ b/src/addDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addHours/index.js.flow
+++ b/src/addHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addISOWeekYears/index.js.flow
+++ b/src/addISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addMilliseconds/index.js.flow
+++ b/src/addMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addMinutes/index.js.flow
+++ b/src/addMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addMonths/index.js.flow
+++ b/src/addMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addQuarters/index.js.flow
+++ b/src/addQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addSeconds/index.js.flow
+++ b/src/addSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addWeeks/index.js.flow
+++ b/src/addWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/addYears/index.js.flow
+++ b/src/addYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/areIntervalsOverlapping/index.js.flow
+++ b/src/areIntervalsOverlapping/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/closestIndexTo/index.js.flow
+++ b/src/closestIndexTo/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/closestTo/index.js.flow
+++ b/src/closestTo/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/compareAsc/index.js.flow
+++ b/src/compareAsc/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/compareDesc/index.js.flow
+++ b/src/compareDesc/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInBusinessDays/index.js.flow
+++ b/src/differenceInBusinessDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarDays/index.js.flow
+++ b/src/differenceInCalendarDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarISOWeekYears/index.js.flow
+++ b/src/differenceInCalendarISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarISOWeeks/index.js.flow
+++ b/src/differenceInCalendarISOWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarMonths/index.js.flow
+++ b/src/differenceInCalendarMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarQuarters/index.js.flow
+++ b/src/differenceInCalendarQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarWeeks/index.js.flow
+++ b/src/differenceInCalendarWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInCalendarYears/index.js.flow
+++ b/src/differenceInCalendarYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInDays/index.js.flow
+++ b/src/differenceInDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInHours/index.js.flow
+++ b/src/differenceInHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInISOWeekYears/index.js.flow
+++ b/src/differenceInISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInMilliseconds/index.js.flow
+++ b/src/differenceInMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInMinutes/index.js.flow
+++ b/src/differenceInMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInMonths/index.js.flow
+++ b/src/differenceInMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInQuarters/index.js.flow
+++ b/src/differenceInQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInSeconds/index.js.flow
+++ b/src/differenceInSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInWeeks/index.js.flow
+++ b/src/differenceInWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/differenceInYears/index.js.flow
+++ b/src/differenceInYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/eachDayOfInterval/index.js.flow
+++ b/src/eachDayOfInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/eachWeekOfInterval/index.js.flow
+++ b/src/eachWeekOfInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/eachWeekendOfInterval/index.js.flow
+++ b/src/eachWeekendOfInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/eachWeekendOfMonth/index.js.flow
+++ b/src/eachWeekendOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/eachWeekendOfYear/index.js.flow
+++ b/src/eachWeekendOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfDay/index.js.flow
+++ b/src/endOfDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfDecade/index.js.flow
+++ b/src/endOfDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfHour/index.js.flow
+++ b/src/endOfHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfISOWeek/index.js.flow
+++ b/src/endOfISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfISOWeekYear/index.js.flow
+++ b/src/endOfISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfMinute/index.js.flow
+++ b/src/endOfMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfMonth/index.js.flow
+++ b/src/endOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfQuarter/index.js.flow
+++ b/src/endOfQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfSecond/index.js.flow
+++ b/src/endOfSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfToday/index.js.flow
+++ b/src/endOfToday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfTomorrow/index.js.flow
+++ b/src/endOfTomorrow/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfWeek/index.js.flow
+++ b/src/endOfWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfYear/index.js.flow
+++ b/src/endOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/endOfYesterday/index.js.flow
+++ b/src/endOfYesterday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/format/index.js.flow
+++ b/src/format/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/formatDistance/index.js.flow
+++ b/src/formatDistance/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/formatDistanceStrict/index.js.flow
+++ b/src/formatDistanceStrict/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/formatDistanceToNow/index.js.flow
+++ b/src/formatDistanceToNow/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/formatRelative/index.js.flow
+++ b/src/formatRelative/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addBusinessDays/index.js.flow
+++ b/src/fp/addBusinessDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addDays/index.js.flow
+++ b/src/fp/addDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addHours/index.js.flow
+++ b/src/fp/addHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addISOWeekYears/index.js.flow
+++ b/src/fp/addISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addMilliseconds/index.js.flow
+++ b/src/fp/addMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addMinutes/index.js.flow
+++ b/src/fp/addMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addMonths/index.js.flow
+++ b/src/fp/addMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addQuarters/index.js.flow
+++ b/src/fp/addQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addSeconds/index.js.flow
+++ b/src/fp/addSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addWeeks/index.js.flow
+++ b/src/fp/addWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/addYears/index.js.flow
+++ b/src/fp/addYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/areIntervalsOverlapping/index.js.flow
+++ b/src/fp/areIntervalsOverlapping/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/closestIndexTo/index.js.flow
+++ b/src/fp/closestIndexTo/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/closestTo/index.js.flow
+++ b/src/fp/closestTo/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/compareAsc/index.js.flow
+++ b/src/fp/compareAsc/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/compareDesc/index.js.flow
+++ b/src/fp/compareDesc/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInBusinessDays/index.js.flow
+++ b/src/fp/differenceInBusinessDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarDays/index.js.flow
+++ b/src/fp/differenceInCalendarDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarISOWeekYears/index.js.flow
+++ b/src/fp/differenceInCalendarISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarISOWeeks/index.js.flow
+++ b/src/fp/differenceInCalendarISOWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarMonths/index.js.flow
+++ b/src/fp/differenceInCalendarMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarQuarters/index.js.flow
+++ b/src/fp/differenceInCalendarQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarWeeks/index.js.flow
+++ b/src/fp/differenceInCalendarWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarWeeksWithOptions/index.js.flow
+++ b/src/fp/differenceInCalendarWeeksWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInCalendarYears/index.js.flow
+++ b/src/fp/differenceInCalendarYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInDays/index.js.flow
+++ b/src/fp/differenceInDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInHours/index.js.flow
+++ b/src/fp/differenceInHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInISOWeekYears/index.js.flow
+++ b/src/fp/differenceInISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInMilliseconds/index.js.flow
+++ b/src/fp/differenceInMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInMinutes/index.js.flow
+++ b/src/fp/differenceInMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInMonths/index.js.flow
+++ b/src/fp/differenceInMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInQuarters/index.js.flow
+++ b/src/fp/differenceInQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInSeconds/index.js.flow
+++ b/src/fp/differenceInSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInWeeks/index.js.flow
+++ b/src/fp/differenceInWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/differenceInYears/index.js.flow
+++ b/src/fp/differenceInYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachDayOfInterval/index.js.flow
+++ b/src/fp/eachDayOfInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachDayOfIntervalWithOptions/index.js.flow
+++ b/src/fp/eachDayOfIntervalWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachWeekOfInterval/index.js.flow
+++ b/src/fp/eachWeekOfInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachWeekOfIntervalWithOptions/index.js.flow
+++ b/src/fp/eachWeekOfIntervalWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachWeekendOfInterval/index.js.flow
+++ b/src/fp/eachWeekendOfInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachWeekendOfMonth/index.js.flow
+++ b/src/fp/eachWeekendOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/eachWeekendOfYear/index.js.flow
+++ b/src/fp/eachWeekendOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfDay/index.js.flow
+++ b/src/fp/endOfDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfDecade/index.js.flow
+++ b/src/fp/endOfDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfDecadeWithOptions/index.js.flow
+++ b/src/fp/endOfDecadeWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfHour/index.js.flow
+++ b/src/fp/endOfHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfISOWeek/index.js.flow
+++ b/src/fp/endOfISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfISOWeekYear/index.js.flow
+++ b/src/fp/endOfISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfMinute/index.js.flow
+++ b/src/fp/endOfMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfMonth/index.js.flow
+++ b/src/fp/endOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfQuarter/index.js.flow
+++ b/src/fp/endOfQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfSecond/index.js.flow
+++ b/src/fp/endOfSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfWeek/index.js.flow
+++ b/src/fp/endOfWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfWeekWithOptions/index.js.flow
+++ b/src/fp/endOfWeekWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/endOfYear/index.js.flow
+++ b/src/fp/endOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/format/index.js.flow
+++ b/src/fp/format/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatDistance/index.js.flow
+++ b/src/fp/formatDistance/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatDistanceStrict/index.js.flow
+++ b/src/fp/formatDistanceStrict/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatDistanceStrictWithOptions/index.js.flow
+++ b/src/fp/formatDistanceStrictWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatDistanceWithOptions/index.js.flow
+++ b/src/fp/formatDistanceWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatRelative/index.js.flow
+++ b/src/fp/formatRelative/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatRelativeWithOptions/index.js.flow
+++ b/src/fp/formatRelativeWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/formatWithOptions/index.js.flow
+++ b/src/fp/formatWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/fromUnixTime/index.js.flow
+++ b/src/fp/fromUnixTime/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getDate/index.js.flow
+++ b/src/fp/getDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getDay/index.js.flow
+++ b/src/fp/getDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getDayOfYear/index.js.flow
+++ b/src/fp/getDayOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getDaysInMonth/index.js.flow
+++ b/src/fp/getDaysInMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getDaysInYear/index.js.flow
+++ b/src/fp/getDaysInYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getDecade/index.js.flow
+++ b/src/fp/getDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getHours/index.js.flow
+++ b/src/fp/getHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getISODay/index.js.flow
+++ b/src/fp/getISODay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getISOWeek/index.js.flow
+++ b/src/fp/getISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getISOWeekYear/index.js.flow
+++ b/src/fp/getISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getISOWeeksInYear/index.js.flow
+++ b/src/fp/getISOWeeksInYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getMilliseconds/index.js.flow
+++ b/src/fp/getMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getMinutes/index.js.flow
+++ b/src/fp/getMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getMonth/index.js.flow
+++ b/src/fp/getMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getOverlappingDaysInIntervals/index.js.flow
+++ b/src/fp/getOverlappingDaysInIntervals/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getQuarter/index.js.flow
+++ b/src/fp/getQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getSeconds/index.js.flow
+++ b/src/fp/getSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getTime/index.js.flow
+++ b/src/fp/getTime/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getUnixTime/index.js.flow
+++ b/src/fp/getUnixTime/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeek/index.js.flow
+++ b/src/fp/getWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeekOfMonth/index.js.flow
+++ b/src/fp/getWeekOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeekOfMonthWithOptions/index.js.flow
+++ b/src/fp/getWeekOfMonthWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeekWithOptions/index.js.flow
+++ b/src/fp/getWeekWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeekYear/index.js.flow
+++ b/src/fp/getWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeekYearWithOptions/index.js.flow
+++ b/src/fp/getWeekYearWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeeksInMonth/index.js.flow
+++ b/src/fp/getWeeksInMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getWeeksInMonthWithOptions/index.js.flow
+++ b/src/fp/getWeeksInMonthWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/getYear/index.js.flow
+++ b/src/fp/getYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isAfter/index.js.flow
+++ b/src/fp/isAfter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isBefore/index.js.flow
+++ b/src/fp/isBefore/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isDate/index.js.flow
+++ b/src/fp/isDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isEqual/index.js.flow
+++ b/src/fp/isEqual/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isFirstDayOfMonth/index.js.flow
+++ b/src/fp/isFirstDayOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isFriday/index.js.flow
+++ b/src/fp/isFriday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isLastDayOfMonth/index.js.flow
+++ b/src/fp/isLastDayOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isLeapYear/index.js.flow
+++ b/src/fp/isLeapYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isMonday/index.js.flow
+++ b/src/fp/isMonday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameDay/index.js.flow
+++ b/src/fp/isSameDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameHour/index.js.flow
+++ b/src/fp/isSameHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameISOWeek/index.js.flow
+++ b/src/fp/isSameISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameISOWeekYear/index.js.flow
+++ b/src/fp/isSameISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameMinute/index.js.flow
+++ b/src/fp/isSameMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameMonth/index.js.flow
+++ b/src/fp/isSameMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameQuarter/index.js.flow
+++ b/src/fp/isSameQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameSecond/index.js.flow
+++ b/src/fp/isSameSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameWeek/index.js.flow
+++ b/src/fp/isSameWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameWeekWithOptions/index.js.flow
+++ b/src/fp/isSameWeekWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSameYear/index.js.flow
+++ b/src/fp/isSameYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSaturday/index.js.flow
+++ b/src/fp/isSaturday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isSunday/index.js.flow
+++ b/src/fp/isSunday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isThursday/index.js.flow
+++ b/src/fp/isThursday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isTuesday/index.js.flow
+++ b/src/fp/isTuesday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isValid/index.js.flow
+++ b/src/fp/isValid/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isWednesday/index.js.flow
+++ b/src/fp/isWednesday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isWeekend/index.js.flow
+++ b/src/fp/isWeekend/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/isWithinInterval/index.js.flow
+++ b/src/fp/isWithinInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfDecade/index.js.flow
+++ b/src/fp/lastDayOfDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfISOWeek/index.js.flow
+++ b/src/fp/lastDayOfISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfISOWeekYear/index.js.flow
+++ b/src/fp/lastDayOfISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfMonth/index.js.flow
+++ b/src/fp/lastDayOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfQuarter/index.js.flow
+++ b/src/fp/lastDayOfQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfQuarterWithOptions/index.js.flow
+++ b/src/fp/lastDayOfQuarterWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfWeek/index.js.flow
+++ b/src/fp/lastDayOfWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfWeekWithOptions/index.js.flow
+++ b/src/fp/lastDayOfWeekWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lastDayOfYear/index.js.flow
+++ b/src/fp/lastDayOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/lightFormat/index.js.flow
+++ b/src/fp/lightFormat/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/max/index.js.flow
+++ b/src/fp/max/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/min/index.js.flow
+++ b/src/fp/min/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/parse/index.js.flow
+++ b/src/fp/parse/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/parseISO/index.js.flow
+++ b/src/fp/parseISO/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/parseISOWithOptions/index.js.flow
+++ b/src/fp/parseISOWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/parseJSON/index.js.flow
+++ b/src/fp/parseJSON/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/parseWithOptions/index.js.flow
+++ b/src/fp/parseWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/roundToNearestMinutes/index.js.flow
+++ b/src/fp/roundToNearestMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/roundToNearestMinutesWithOptions/index.js.flow
+++ b/src/fp/roundToNearestMinutesWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/set/index.js.flow
+++ b/src/fp/set/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setDate/index.js.flow
+++ b/src/fp/setDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setDay/index.js.flow
+++ b/src/fp/setDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setDayOfYear/index.js.flow
+++ b/src/fp/setDayOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setDayWithOptions/index.js.flow
+++ b/src/fp/setDayWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setHours/index.js.flow
+++ b/src/fp/setHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setISODay/index.js.flow
+++ b/src/fp/setISODay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setISOWeek/index.js.flow
+++ b/src/fp/setISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setISOWeekYear/index.js.flow
+++ b/src/fp/setISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setMilliseconds/index.js.flow
+++ b/src/fp/setMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setMinutes/index.js.flow
+++ b/src/fp/setMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setMonth/index.js.flow
+++ b/src/fp/setMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setQuarter/index.js.flow
+++ b/src/fp/setQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setSeconds/index.js.flow
+++ b/src/fp/setSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setWeek/index.js.flow
+++ b/src/fp/setWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setWeekWithOptions/index.js.flow
+++ b/src/fp/setWeekWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setWeekYear/index.js.flow
+++ b/src/fp/setWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setWeekYearWithOptions/index.js.flow
+++ b/src/fp/setWeekYearWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/setYear/index.js.flow
+++ b/src/fp/setYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfDay/index.js.flow
+++ b/src/fp/startOfDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfDecade/index.js.flow
+++ b/src/fp/startOfDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfHour/index.js.flow
+++ b/src/fp/startOfHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfISOWeek/index.js.flow
+++ b/src/fp/startOfISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfISOWeekYear/index.js.flow
+++ b/src/fp/startOfISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfMinute/index.js.flow
+++ b/src/fp/startOfMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfMonth/index.js.flow
+++ b/src/fp/startOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfQuarter/index.js.flow
+++ b/src/fp/startOfQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfSecond/index.js.flow
+++ b/src/fp/startOfSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfWeek/index.js.flow
+++ b/src/fp/startOfWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfWeekWithOptions/index.js.flow
+++ b/src/fp/startOfWeekWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfWeekYear/index.js.flow
+++ b/src/fp/startOfWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfWeekYearWithOptions/index.js.flow
+++ b/src/fp/startOfWeekYearWithOptions/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/startOfYear/index.js.flow
+++ b/src/fp/startOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subBusinessDays/index.js.flow
+++ b/src/fp/subBusinessDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subDays/index.js.flow
+++ b/src/fp/subDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subHours/index.js.flow
+++ b/src/fp/subHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subISOWeekYears/index.js.flow
+++ b/src/fp/subISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subMilliseconds/index.js.flow
+++ b/src/fp/subMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subMinutes/index.js.flow
+++ b/src/fp/subMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subMonths/index.js.flow
+++ b/src/fp/subMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subQuarters/index.js.flow
+++ b/src/fp/subQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subSeconds/index.js.flow
+++ b/src/fp/subSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subWeeks/index.js.flow
+++ b/src/fp/subWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/subYears/index.js.flow
+++ b/src/fp/subYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fp/toDate/index.js.flow
+++ b/src/fp/toDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/fromUnixTime/index.js.flow
+++ b/src/fromUnixTime/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getDate/index.js.flow
+++ b/src/getDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getDay/index.js.flow
+++ b/src/getDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getDayOfYear/index.js.flow
+++ b/src/getDayOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getDaysInMonth/index.js.flow
+++ b/src/getDaysInMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getDaysInYear/index.js.flow
+++ b/src/getDaysInYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getDecade/index.js.flow
+++ b/src/getDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getHours/index.js.flow
+++ b/src/getHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getISODay/index.js.flow
+++ b/src/getISODay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getISOWeek/index.js.flow
+++ b/src/getISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getISOWeekYear/index.js.flow
+++ b/src/getISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getISOWeeksInYear/index.js.flow
+++ b/src/getISOWeeksInYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getMilliseconds/index.js.flow
+++ b/src/getMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getMinutes/index.js.flow
+++ b/src/getMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getMonth/index.js.flow
+++ b/src/getMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getOverlappingDaysInIntervals/index.js.flow
+++ b/src/getOverlappingDaysInIntervals/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getQuarter/index.js.flow
+++ b/src/getQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getSeconds/index.js.flow
+++ b/src/getSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getTime/index.js.flow
+++ b/src/getTime/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getUnixTime/index.js.flow
+++ b/src/getUnixTime/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getWeek/index.js.flow
+++ b/src/getWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getWeekOfMonth/index.js.flow
+++ b/src/getWeekOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getWeekYear/index.js.flow
+++ b/src/getWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getWeeksInMonth/index.js.flow
+++ b/src/getWeeksInMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/getYear/index.js.flow
+++ b/src/getYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isAfter/index.js.flow
+++ b/src/isAfter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isBefore/index.js.flow
+++ b/src/isBefore/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isDate/index.js.flow
+++ b/src/isDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isEqual/index.js.flow
+++ b/src/isEqual/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isFirstDayOfMonth/index.js.flow
+++ b/src/isFirstDayOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isFriday/index.js.flow
+++ b/src/isFriday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isFuture/index.js.flow
+++ b/src/isFuture/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isLastDayOfMonth/index.js.flow
+++ b/src/isLastDayOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isLeapYear/index.js.flow
+++ b/src/isLeapYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isMonday/index.js.flow
+++ b/src/isMonday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isPast/index.js.flow
+++ b/src/isPast/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameDay/index.js.flow
+++ b/src/isSameDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameHour/index.js.flow
+++ b/src/isSameHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameISOWeek/index.js.flow
+++ b/src/isSameISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameISOWeekYear/index.js.flow
+++ b/src/isSameISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameMinute/index.js.flow
+++ b/src/isSameMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameMonth/index.js.flow
+++ b/src/isSameMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameQuarter/index.js.flow
+++ b/src/isSameQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameSecond/index.js.flow
+++ b/src/isSameSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameWeek/index.js.flow
+++ b/src/isSameWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSameYear/index.js.flow
+++ b/src/isSameYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSaturday/index.js.flow
+++ b/src/isSaturday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isSunday/index.js.flow
+++ b/src/isSunday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisHour/index.js.flow
+++ b/src/isThisHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisISOWeek/index.js.flow
+++ b/src/isThisISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisMinute/index.js.flow
+++ b/src/isThisMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisMonth/index.js.flow
+++ b/src/isThisMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisQuarter/index.js.flow
+++ b/src/isThisQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisSecond/index.js.flow
+++ b/src/isThisSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisWeek/index.js.flow
+++ b/src/isThisWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThisYear/index.js.flow
+++ b/src/isThisYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isThursday/index.js.flow
+++ b/src/isThursday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isToday/index.js.flow
+++ b/src/isToday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isTomorrow/index.js.flow
+++ b/src/isTomorrow/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isTuesday/index.js.flow
+++ b/src/isTuesday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isValid/index.js.flow
+++ b/src/isValid/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isWednesday/index.js.flow
+++ b/src/isWednesday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isWeekend/index.js.flow
+++ b/src/isWeekend/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isWithinInterval/index.js.flow
+++ b/src/isWithinInterval/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/isYesterday/index.js.flow
+++ b/src/isYesterday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfDecade/index.js.flow
+++ b/src/lastDayOfDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfISOWeek/index.js.flow
+++ b/src/lastDayOfISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfISOWeekYear/index.js.flow
+++ b/src/lastDayOfISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfMonth/index.js.flow
+++ b/src/lastDayOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfQuarter/index.js.flow
+++ b/src/lastDayOfQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfWeek/index.js.flow
+++ b/src/lastDayOfWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lastDayOfYear/index.js.flow
+++ b/src/lastDayOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/lightFormat/index.js.flow
+++ b/src/lightFormat/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/af/index.js.flow
+++ b/src/locale/af/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ar-DZ/index.js.flow
+++ b/src/locale/ar-DZ/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ar-SA/index.js.flow
+++ b/src/locale/ar-SA/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ar/index.js.flow
+++ b/src/locale/ar/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/be/index.js.flow
+++ b/src/locale/be/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/bg/index.js.flow
+++ b/src/locale/bg/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/bn/index.js.flow
+++ b/src/locale/bn/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ca/index.js.flow
+++ b/src/locale/ca/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/cs/index.js.flow
+++ b/src/locale/cs/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/cy/index.js.flow
+++ b/src/locale/cy/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/da/index.js.flow
+++ b/src/locale/da/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/de/index.js.flow
+++ b/src/locale/de/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/el/index.js.flow
+++ b/src/locale/el/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/en-AU/index.js.flow
+++ b/src/locale/en-AU/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/en-CA/index.js.flow
+++ b/src/locale/en-CA/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/en-GB/index.js.flow
+++ b/src/locale/en-GB/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/en-US/index.js.flow
+++ b/src/locale/en-US/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/eo/index.js.flow
+++ b/src/locale/eo/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/es/index.js.flow
+++ b/src/locale/es/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/et/index.js.flow
+++ b/src/locale/et/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/fa-IR/index.js.flow
+++ b/src/locale/fa-IR/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/fi/index.js.flow
+++ b/src/locale/fi/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/fil/index.js.flow
+++ b/src/locale/fil/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/fr-CA/index.js.flow
+++ b/src/locale/fr-CA/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/fr-CH/index.js.flow
+++ b/src/locale/fr-CH/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/fr/index.js.flow
+++ b/src/locale/fr/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/gl/index.js.flow
+++ b/src/locale/gl/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/gu/index.js.flow
+++ b/src/locale/gu/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/he/index.js.flow
+++ b/src/locale/he/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/hi/index.js.flow
+++ b/src/locale/hi/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/hr/index.js.flow
+++ b/src/locale/hr/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/hu/index.js.flow
+++ b/src/locale/hu/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/hy/index.js.flow
+++ b/src/locale/hy/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/id/index.js.flow
+++ b/src/locale/id/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/index.js.flow
+++ b/src/locale/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/is/index.js.flow
+++ b/src/locale/is/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/it/index.js.flow
+++ b/src/locale/it/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ja/index.js.flow
+++ b/src/locale/ja/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ka/index.js.flow
+++ b/src/locale/ka/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/kk/index.js.flow
+++ b/src/locale/kk/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ko/index.js.flow
+++ b/src/locale/ko/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/lt/index.js.flow
+++ b/src/locale/lt/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/lv/index.js.flow
+++ b/src/locale/lv/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/mk/index.js.flow
+++ b/src/locale/mk/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ms/index.js.flow
+++ b/src/locale/ms/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/nb/index.js.flow
+++ b/src/locale/nb/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/nl-BE/index.js.flow
+++ b/src/locale/nl-BE/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/nl/index.js.flow
+++ b/src/locale/nl/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/nn/index.js.flow
+++ b/src/locale/nn/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/pl/index.js.flow
+++ b/src/locale/pl/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/pt-BR/index.js.flow
+++ b/src/locale/pt-BR/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/pt/index.js.flow
+++ b/src/locale/pt/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ro/index.js.flow
+++ b/src/locale/ro/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ru/index.js.flow
+++ b/src/locale/ru/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/sk/index.js.flow
+++ b/src/locale/sk/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/sl/index.js.flow
+++ b/src/locale/sl/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/sr-Latn/index.js.flow
+++ b/src/locale/sr-Latn/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/sr/index.js.flow
+++ b/src/locale/sr/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/sv/index.js.flow
+++ b/src/locale/sv/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ta/index.js.flow
+++ b/src/locale/ta/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/te/index.js.flow
+++ b/src/locale/te/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/th/index.js.flow
+++ b/src/locale/th/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/tr/index.js.flow
+++ b/src/locale/tr/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/ug/index.js.flow
+++ b/src/locale/ug/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/uk/index.js.flow
+++ b/src/locale/uk/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/vi/index.js.flow
+++ b/src/locale/vi/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/zh-CN/index.js.flow
+++ b/src/locale/zh-CN/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/locale/zh-TW/index.js.flow
+++ b/src/locale/zh-TW/index.js.flow
@@ -2,9 +2,9 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -12,11 +12,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/max/index.js.flow
+++ b/src/max/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/min/index.js.flow
+++ b/src/min/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/parse/index.js.flow
+++ b/src/parse/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/parseISO/index.js.flow
+++ b/src/parseISO/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/parseJSON/index.js.flow
+++ b/src/parseJSON/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/roundToNearestMinutes/index.js.flow
+++ b/src/roundToNearestMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/set/index.js.flow
+++ b/src/set/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setDate/index.js.flow
+++ b/src/setDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setDay/index.js.flow
+++ b/src/setDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setDayOfYear/index.js.flow
+++ b/src/setDayOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setHours/index.js.flow
+++ b/src/setHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setISODay/index.js.flow
+++ b/src/setISODay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setISOWeek/index.js.flow
+++ b/src/setISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setISOWeekYear/index.js.flow
+++ b/src/setISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setMilliseconds/index.js.flow
+++ b/src/setMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setMinutes/index.js.flow
+++ b/src/setMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setMonth/index.js.flow
+++ b/src/setMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setQuarter/index.js.flow
+++ b/src/setQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setSeconds/index.js.flow
+++ b/src/setSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setWeek/index.js.flow
+++ b/src/setWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setWeekYear/index.js.flow
+++ b/src/setWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/setYear/index.js.flow
+++ b/src/setYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfDay/index.js.flow
+++ b/src/startOfDay/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfDecade/index.js.flow
+++ b/src/startOfDecade/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfHour/index.js.flow
+++ b/src/startOfHour/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfISOWeek/index.js.flow
+++ b/src/startOfISOWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfISOWeekYear/index.js.flow
+++ b/src/startOfISOWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfMinute/index.js.flow
+++ b/src/startOfMinute/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfMonth/index.js.flow
+++ b/src/startOfMonth/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfQuarter/index.js.flow
+++ b/src/startOfQuarter/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfSecond/index.js.flow
+++ b/src/startOfSecond/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfToday/index.js.flow
+++ b/src/startOfToday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfTomorrow/index.js.flow
+++ b/src/startOfTomorrow/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfWeek/index.js.flow
+++ b/src/startOfWeek/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfWeekYear/index.js.flow
+++ b/src/startOfWeekYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfYear/index.js.flow
+++ b/src/startOfYear/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/startOfYesterday/index.js.flow
+++ b/src/startOfYesterday/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subBusinessDays/index.js.flow
+++ b/src/subBusinessDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subDays/index.js.flow
+++ b/src/subDays/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subHours/index.js.flow
+++ b/src/subHours/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subISOWeekYears/index.js.flow
+++ b/src/subISOWeekYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subMilliseconds/index.js.flow
+++ b/src/subMilliseconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subMinutes/index.js.flow
+++ b/src/subMinutes/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subMonths/index.js.flow
+++ b/src/subMonths/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subQuarters/index.js.flow
+++ b/src/subQuarters/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subSeconds/index.js.flow
+++ b/src/subSeconds/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subWeeks/index.js.flow
+++ b/src/subWeeks/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/subYears/index.js.flow
+++ b/src/subYears/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/src/toDate/index.js.flow
+++ b/src/toDate/index.js.flow
@@ -7,9 +7,9 @@ export type Interval = {
 }
 
 export type Locale = {
-  formatDistance: (...args: Array<any>) => any,
-  formatRelative: (...args: Array<any>) => any,
-  localize: {
+  formatDistance?: (...args: Array<any>) => any,
+  formatRelative?: (...args: Array<any>) => any,
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
@@ -17,11 +17,12 @@ export type Locale = {
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any
   },
-  formatLong: Object,
-  date: (...args: Array<any>) => any,
-  time: (...args: Array<any>) => any,
-  dateTime: (...args: Array<any>) => any,
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any,
+    time: (...args: Array<any>) => any,
+    dateTime: (...args: Array<any>) => any
+  },
+  match?: {
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -33,9 +33,9 @@ type Interval = {
 type IntervalAliased = Interval
 
 type Locale = {
-  formatDistance: (...args: Array<any>) => any
-  formatRelative: (...args: Array<any>) => any
-  localize: {
+  formatDistance?: (...args: Array<any>) => any
+  formatRelative?: (...args: Array<any>) => any
+  localize?: {
     ordinalNumber: (...args: Array<any>) => any
     era: (...args: Array<any>) => any
     quarter: (...args: Array<any>) => any
@@ -43,11 +43,12 @@ type Locale = {
     day: (...args: Array<any>) => any
     dayPeriod: (...args: Array<any>) => any
   }
-  formatLong: Object
-  date: (...args: Array<any>) => any
-  time: (...args: Array<any>) => any
-  dateTime: (...args: Array<any>) => any
-  match: {
+  formatLong?: {
+    date: (...args: Array<any>) => any
+    time: (...args: Array<any>) => any
+    dateTime: (...args: Array<any>) => any
+  }
+  match?: {
     ordinalNumber: (...args: Array<any>) => any
     era: (...args: Array<any>) => any
     quarter: (...args: Array<any>) => any


### PR DESCRIPTION
Fixes #1503.

This also adds the missing `formatLong.` prefix to `date`, `time`, and
`dateTime` options.