### PR TITLE
Add colon between hour and minutes for formatRFC3339

### DIFF
--- a/src/formatRFC3339/index.js
+++ b/src/formatRFC3339/index.js
@@ -83,7 +83,7 @@ export default function formatRFC3339(dirtyDate, dirtyOptions) {
     // If less than 0, the sign is +, because it is ahead of time.
     const sign = tzOffset < 0 ? '+' : '-'
 
-    offset = `${sign}${hourOffset}${minuteOffset}`
+    offset = `${sign}${hourOffset}:${minuteOffset}`
   } else {
     offset = 'Z'
   }

--- a/src/formatRFC3339/test.js
+++ b/src/formatRFC3339/test.js
@@ -17,7 +17,7 @@ function generateOffset(date) {
     // If less than 0, the sign is +, because it is ahead of time.
     const sign = tzOffset < 0 ? '+' : '-'
 
-    offset = `${sign}${hourOffset}${minuteOffset}`
+    offset = `${sign}${hourOffset}:${minuteOffset}`
   } else {
     offset = 'Z'
   }


### PR DESCRIPTION
This fixes https://github.com/date-fns/date-fns/issues/1548.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>