### PR TITLE
Move argument length requirement checks to a shared function to dedupe code

### DIFF
--- a/src/_lib/getUTCDayOfYear/index.js
+++ b/src/_lib/getUTCDayOfYear/index.js
@@ -1,15 +1,12 @@
 import toDate from '../../toDate/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 var MILLISECONDS_IN_DAY = 86400000
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function getUTCDayOfYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var timestamp = date.getTime()

--- a/src/_lib/getUTCISOWeek/index.js
+++ b/src/_lib/getUTCISOWeek/index.js
@@ -1,17 +1,14 @@
 import toDate from '../../toDate/index.js'
 import startOfUTCISOWeek from '../startOfUTCISOWeek/index.js'
 import startOfUTCISOWeekYear from '../startOfUTCISOWeekYear/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function getUTCISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var diff =

--- a/src/_lib/getUTCISOWeekYear/index.js
+++ b/src/_lib/getUTCISOWeekYear/index.js
@@ -1,14 +1,11 @@
 import toDate from '../../toDate/index.js'
 import startOfUTCISOWeek from '../startOfUTCISOWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function getUTCISOWeekYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getUTCFullYear()

--- a/src/_lib/getUTCWeek/index.js
+++ b/src/_lib/getUTCWeek/index.js
@@ -1,17 +1,14 @@
 import toDate from '../../toDate/index.js'
 import startOfUTCWeek from '../startOfUTCWeek/index.js'
 import startOfUTCWeekYear from '../startOfUTCWeekYear/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function getUTCWeek(dirtyDate, options) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var diff =

--- a/src/_lib/getUTCWeekYear/index.js
+++ b/src/_lib/getUTCWeekYear/index.js
@@ -1,13 +1,12 @@
 import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 import startOfUTCWeek from '../startOfUTCWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
-export default function getUTCWeekYear (dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
-  }
+export default function getUTCWeekYear(dirtyDate, dirtyOptions) {
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate, dirtyOptions)
   var year = date.getUTCFullYear()

--- a/src/_lib/isSameUTCWeek/index.js
+++ b/src/_lib/isSameUTCWeek/index.js
@@ -1,13 +1,10 @@
 import startOfUTCWeek from '../startOfUTCWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function isSameUTCWeek(dirtyDateLeft, dirtyDateRight, options) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfWeek = startOfUTCWeek(dirtyDateLeft, options)
   var dateRightStartOfWeek = startOfUTCWeek(dirtyDateRight, options)

--- a/src/_lib/requiredArgs/index.js
+++ b/src/_lib/requiredArgs/index.js
@@ -1,0 +1,9 @@
+export default function requiredArgs(required, args) {
+  if (args.length < required) {
+    throw new TypeError(
+      required + ' argument' + required > 1
+        ? 's'
+        : '' + ' required, but only ' + args.length + ' present'
+    )
+  }
+}

--- a/src/_lib/setUTCDay/index.js
+++ b/src/_lib/setUTCDay/index.js
@@ -1,14 +1,11 @@
 import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function setUTCDay(dirtyDate, dirtyDay, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/_lib/setUTCISODay/index.js
+++ b/src/_lib/setUTCISODay/index.js
@@ -1,14 +1,11 @@
 import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function setUTCISODay(dirtyDate, dirtyDay) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var day = toInteger(dirtyDay)
 

--- a/src/_lib/setUTCISOWeek/index.js
+++ b/src/_lib/setUTCISOWeek/index.js
@@ -1,15 +1,12 @@
 import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 import getUTCISOWeek from '../getUTCISOWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function setUTCISOWeek(dirtyDate, dirtyISOWeek) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var isoWeek = toInteger(dirtyISOWeek)

--- a/src/_lib/setUTCWeek/index.js
+++ b/src/_lib/setUTCWeek/index.js
@@ -1,15 +1,12 @@
 import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
 import getUTCWeek from '../getUTCWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function setUTCWeek(dirtyDate, dirtyWeek, options) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var week = toInteger(dirtyWeek)

--- a/src/_lib/startOfUTCISOWeek/index.js
+++ b/src/_lib/startOfUTCISOWeek/index.js
@@ -1,13 +1,10 @@
 import toDate from '../../toDate/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function startOfUTCISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var weekStartsOn = 1
 

--- a/src/_lib/startOfUTCISOWeekYear/index.js
+++ b/src/_lib/startOfUTCISOWeekYear/index.js
@@ -1,14 +1,11 @@
 import getUTCISOWeekYear from '../getUTCISOWeekYear/index.js'
 import startOfUTCISOWeek from '../startOfUTCISOWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function startOfUTCISOWeekYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var year = getUTCISOWeekYear(dirtyDate)
   var fourthOfJanuary = new Date(0)

--- a/src/_lib/startOfUTCWeek/index.js
+++ b/src/_lib/startOfUTCWeek/index.js
@@ -1,14 +1,11 @@
 import toInteger from '../toInteger/index.js'
 import toDate from '../../toDate/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
 export default function startOfUTCWeek(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/_lib/startOfUTCWeekYear/index.js
+++ b/src/_lib/startOfUTCWeekYear/index.js
@@ -1,13 +1,12 @@
 import toInteger from '../toInteger/index.js'
 import getUTCWeekYear from '../getUTCWeekYear/index.js'
 import startOfUTCWeek from '../startOfUTCWeek/index.js'
+import requiredArgs from '../requiredArgs/index.js'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
-export default function startOfUTCWeekYear (dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError('1 argument required, but only ' + arguments.length + ' present')
-  }
+export default function startOfUTCWeekYear(dirtyDate, dirtyOptions) {
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/addBusinessDays/index.js
+++ b/src/addBusinessDays/index.js
@@ -1,6 +1,7 @@
 import isWeekend from '../isWeekend/index.js'
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addBusinessDays
@@ -21,11 +22,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Mon Sep 15 2014 00:00:00 (skipped weekend days)
  */
 export default function addBusinessDays(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var amount = toInteger(dirtyAmount)

--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addDays
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Thu Sep 11 2014 00:00:00
  */
 export default function addDays(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var amount = toInteger(dirtyAmount)

--- a/src/addHours/index.js
+++ b/src/addHours/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_HOUR = 3600000
 
@@ -26,11 +27,7 @@ var MILLISECONDS_IN_HOUR = 3600000
  * //=> Fri Jul 11 2014 01:00:00
  */
 export default function addHours(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, amount * MILLISECONDS_IN_HOUR)

--- a/src/addISOWeekYears/index.js
+++ b/src/addISOWeekYears/index.js
@@ -1,6 +1,7 @@
 import toInteger from '../_lib/toInteger/index.js'
 import getISOWeekYear from '../getISOWeekYear/index.js'
 import setISOWeekYear from '../setISOWeekYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addISOWeekYears
@@ -32,11 +33,7 @@ import setISOWeekYear from '../setISOWeekYear/index.js'
  * //=> Fri Jun 26 2015 00:00:00
  */
 export default function addISOWeekYears(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return setISOWeekYear(dirtyDate, getISOWeekYear(dirtyDate) + amount)

--- a/src/addMilliseconds/index.js
+++ b/src/addMilliseconds/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addMilliseconds
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Thu Jul 10 2014 12:45:30.750
  */
 export default function addMilliseconds(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var timestamp = toDate(dirtyDate).getTime()
   var amount = toInteger(dirtyAmount)

--- a/src/addMinutes/index.js
+++ b/src/addMinutes/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_MINUTE = 60000
 
@@ -26,11 +27,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  * //=> Thu Jul 10 2014 12:30:00
  */
 export default function addMinutes(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, amount * MILLISECONDS_IN_MINUTE)

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -1,6 +1,7 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getDaysInMonth from '../getDaysInMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addMonths
@@ -25,11 +26,7 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  * //=> Sun Feb 01 2015 00:00:00
  */
 export default function addMonths(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var amount = toInteger(dirtyAmount)

--- a/src/addQuarters/index.js
+++ b/src/addQuarters/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMonths from '../addMonths/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addQuarters
@@ -24,11 +25,7 @@ import addMonths from '../addMonths/index.js'
  * //=> Mon Dec 01 2014 00:00:00
  */
 export default function addQuarters(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   var months = amount * 3

--- a/src/addSeconds/index.js
+++ b/src/addSeconds/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addSeconds
@@ -24,11 +25,7 @@ import addMilliseconds from '../addMilliseconds/index.js'
  * //=> Thu Jul 10 2014 12:45:30
  */
 export default function addSeconds(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, amount * 1000)

--- a/src/addWeeks/index.js
+++ b/src/addWeeks/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addDays from '../addDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addWeeks
@@ -24,11 +25,7 @@ import addDays from '../addDays/index.js'
  * //=> Mon Sep 29 2014 00:00:00
  */
 export default function addWeeks(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   var days = amount * 7

--- a/src/addYears/index.js
+++ b/src/addYears/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMonths from '../addMonths/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name addYears
@@ -24,11 +25,7 @@ import addMonths from '../addMonths/index.js'
  * //=> Sun Sep 01 2019 00:00:00
  */
 export default function addYears(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMonths(dirtyDate, amount * 12)

--- a/src/areIntervalsOverlapping/index.js
+++ b/src/areIntervalsOverlapping/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name areIntervalsOverlapping
@@ -77,11 +78,7 @@ export default function areIntervalsOverlapping(
   dirtyIntervalLeft,
   dirtyIntervalRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var intervalLeft = dirtyIntervalLeft || {}
   var intervalRight = dirtyIntervalRight || {}

--- a/src/closestIndexTo/index.js
+++ b/src/closestIndexTo/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name closestIndexTo
@@ -32,11 +33,7 @@ import toDate from '../toDate/index.js'
  * //=> 1
  */
 export default function closestIndexTo(dirtyDateToCompare, dirtyDatesArray) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateToCompare = toDate(dirtyDateToCompare)
 

--- a/src/closestTo/index.js
+++ b/src/closestTo/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name closestTo
@@ -30,11 +31,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Jan 01 2030 00:00:00
  */
 export default function closestTo(dirtyDateToCompare, dirtyDatesArray) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateToCompare = toDate(dirtyDateToCompare)
 

--- a/src/compareAsc/index.js
+++ b/src/compareAsc/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name compareAsc
@@ -37,11 +38,7 @@ import toDate from '../toDate/index.js'
  * // ]
  */
 export default function compareAsc(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/compareDesc/index.js
+++ b/src/compareDesc/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name compareDesc
@@ -37,11 +38,7 @@ import toDate from '../toDate/index.js'
  * // ]
  */
 export default function compareDesc(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInBusinessDays/index.js
+++ b/src/differenceInBusinessDays/index.js
@@ -5,6 +5,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
 import addDays from '../addDays/index.js'
 import isSameDay from '../isSameDay/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInBusinessDays
@@ -35,11 +36,7 @@ export default function differenceInBusinessDays(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInCalendarDays/index.js
+++ b/src/differenceInCalendarDays/index.js
@@ -1,5 +1,6 @@
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
 import startOfDay from '../startOfDay/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_DAY = 86400000
 
@@ -41,11 +42,7 @@ export default function differenceInCalendarDays(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var startOfDayLeft = startOfDay(dirtyDateLeft)
   var startOfDayRight = startOfDay(dirtyDateRight)

--- a/src/differenceInCalendarISOWeekYears/index.js
+++ b/src/differenceInCalendarISOWeekYears/index.js
@@ -1,4 +1,5 @@
 import getISOWeekYear from '../getISOWeekYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInCalendarISOWeekYears
@@ -36,11 +37,7 @@ export default function differenceInCalendarISOWeekYears(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   return getISOWeekYear(dirtyDateLeft) - getISOWeekYear(dirtyDateRight)
 }

--- a/src/differenceInCalendarISOWeeks/index.js
+++ b/src/differenceInCalendarISOWeeks/index.js
@@ -1,5 +1,6 @@
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
 import startOfISOWeek from '../startOfISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
@@ -34,11 +35,7 @@ export default function differenceInCalendarISOWeeks(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var startOfISOWeekLeft = startOfISOWeek(dirtyDateLeft)
   var startOfISOWeekRight = startOfISOWeek(dirtyDateRight)

--- a/src/differenceInCalendarMonths/index.js
+++ b/src/differenceInCalendarMonths/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInCalendarMonths
@@ -29,11 +30,7 @@ export default function differenceInCalendarMonths(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInCalendarQuarters/index.js
+++ b/src/differenceInCalendarQuarters/index.js
@@ -1,5 +1,6 @@
 import getQuarter from '../getQuarter/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInCalendarQuarters
@@ -30,11 +31,7 @@ export default function differenceInCalendarQuarters(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInCalendarWeeks/index.js
+++ b/src/differenceInCalendarWeeks/index.js
@@ -1,5 +1,6 @@
 import startOfWeek from '../startOfWeek/index.js'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
@@ -47,11 +48,7 @@ export default function differenceInCalendarWeeks(
   dirtyDateRight,
   dirtyOptions
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var startOfWeekLeft = startOfWeek(dirtyDateLeft, dirtyOptions)
   var startOfWeekRight = startOfWeek(dirtyDateRight, dirtyOptions)

--- a/src/differenceInCalendarYears/index.js
+++ b/src/differenceInCalendarYears/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInCalendarYears
@@ -29,11 +30,7 @@ export default function differenceInCalendarYears(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInDays/index.js
+++ b/src/differenceInDays/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
 import compareAsc from '../compareAsc/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInDays
@@ -36,11 +37,7 @@ import compareAsc from '../compareAsc/index.js'
  * //=> 0
  */
 export default function differenceInDays(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInHours/index.js
+++ b/src/differenceInHours/index.js
@@ -1,4 +1,5 @@
 import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_HOUR = 3600000
 
@@ -28,11 +29,7 @@ var MILLISECONDS_IN_HOUR = 3600000
  * //=> 12
  */
 export default function differenceInHours(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var diff =
     differenceInMilliseconds(dirtyDateLeft, dirtyDateRight) /

--- a/src/differenceInISOWeekYears/index.js
+++ b/src/differenceInISOWeekYears/index.js
@@ -2,6 +2,7 @@ import toDate from '../toDate/index.js'
 import differenceInCalendarISOWeekYears from '../differenceInCalendarISOWeekYears/index.js'
 import compareAsc from '../compareAsc/index.js'
 import subISOWeekYears from '../subISOWeekYears/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInISOWeekYears
@@ -39,11 +40,7 @@ export default function differenceInISOWeekYears(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInMilliseconds/index.js
+++ b/src/differenceInMilliseconds/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInMilliseconds
@@ -30,11 +31,7 @@ export default function differenceInMilliseconds(
   dirtyDateLeft,
   dirtyDateRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInMinutes/index.js
+++ b/src/differenceInMinutes/index.js
@@ -1,4 +1,5 @@
 import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_MINUTE = 60000
 
@@ -36,11 +37,7 @@ var MILLISECONDS_IN_MINUTE = 60000
  * //=> -1
  */
 export default function differenceInMinutes(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var diff =
     differenceInMilliseconds(dirtyDateLeft, dirtyDateRight) /

--- a/src/differenceInMonths/index.js
+++ b/src/differenceInMonths/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import differenceInCalendarMonths from '../differenceInCalendarMonths/index.js'
 import compareAsc from '../compareAsc/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInMonths
@@ -25,11 +26,7 @@ import compareAsc from '../compareAsc/index.js'
  * //=> 7
  */
 export default function differenceInMonths(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/differenceInQuarters/index.js
+++ b/src/differenceInQuarters/index.js
@@ -1,4 +1,5 @@
 import differenceInMonths from '../differenceInMonths/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInQuarters
@@ -23,11 +24,7 @@ import differenceInMonths from '../differenceInMonths/index.js'
  * //=> 2
  */
 export default function differenceInQuarters(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var diff = differenceInMonths(dirtyDateLeft, dirtyDateRight) / 3
   return diff > 0 ? Math.floor(diff) : Math.ceil(diff)

--- a/src/differenceInSeconds/index.js
+++ b/src/differenceInSeconds/index.js
@@ -1,4 +1,5 @@
 import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInSeconds
@@ -27,11 +28,7 @@ import differenceInMilliseconds from '../differenceInMilliseconds/index.js'
  * //=> 12
  */
 export default function differenceInSeconds(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var diff = differenceInMilliseconds(dirtyDateLeft, dirtyDateRight) / 1000
   return diff > 0 ? Math.floor(diff) : Math.ceil(diff)

--- a/src/differenceInWeeks/index.js
+++ b/src/differenceInWeeks/index.js
@@ -1,4 +1,5 @@
 import differenceInDays from '../differenceInDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInWeeks
@@ -23,11 +24,7 @@ import differenceInDays from '../differenceInDays/index.js'
  * //=> 2
  */
 export default function differenceInWeeks(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var diff = differenceInDays(dirtyDateLeft, dirtyDateRight) / 7
   return diff > 0 ? Math.floor(diff) : Math.ceil(diff)

--- a/src/differenceInYears/index.js
+++ b/src/differenceInYears/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import differenceInCalendarYears from '../differenceInCalendarYears/index.js'
 import compareAsc from '../compareAsc/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name differenceInYears
@@ -25,11 +26,7 @@ import compareAsc from '../compareAsc/index.js'
  * //=> 1
  */
 export default function differenceInYears(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/eachDayOfInterval/index.js
+++ b/src/eachDayOfInterval/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachDayOfInterval
@@ -62,11 +63,7 @@ import toDate from '../toDate/index.js'
  * // ]
  */
 export default function eachDayOfInterval(dirtyInterval, options) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var interval = dirtyInterval || {}
   var startDate = toDate(interval.start)

--- a/src/eachMonthOfInterval/index.js
+++ b/src/eachMonthOfInterval/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachMonthOfInterval
@@ -31,11 +32,7 @@ import toDate from '../toDate/index.js'
  * // ]
  */
 export default function eachMonthOfInterval(dirtyInterval) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var interval = dirtyInterval || {}
   var startDate = toDate(interval.start)

--- a/src/eachWeekOfInterval/index.js
+++ b/src/eachWeekOfInterval/index.js
@@ -1,6 +1,7 @@
 import addWeeks from '../addWeeks/index.js'
 import startOfWeek from '../startOfWeek/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachWeekOfInterval
@@ -42,11 +43,7 @@ import toDate from '../toDate/index.js'
  * // ]
  */
 export default function eachWeekOfInterval(dirtyInterval, options) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var interval = dirtyInterval || {}
   var startDate = toDate(interval.start)

--- a/src/eachWeekendOfInterval/index.js
+++ b/src/eachWeekendOfInterval/index.js
@@ -1,6 +1,7 @@
 import eachDayOfInterval from '../eachDayOfInterval/index.js'
 import isSunday from '../isSunday/index.js'
 import isWeekend from '../isWeekend/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachWeekendOfInterval
@@ -30,11 +31,7 @@ import isWeekend from '../isWeekend/index.js'
  * // ]
  */
 export default function eachWeekendOfInterval(interval) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var dateInterval = eachDayOfInterval(interval)
   var weekends = []

--- a/src/eachWeekendOfMonth/index.js
+++ b/src/eachWeekendOfMonth/index.js
@@ -1,6 +1,7 @@
 import eachWeekendOfInterval from '../eachWeekendOfInterval/index.js'
 import startOfMonth from '../startOfMonth/index.js'
 import endOfMonth from '../endOfMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachWeekendOfMonth
@@ -30,11 +31,7 @@ import endOfMonth from '../endOfMonth/index.js'
  * // ]
  */
 export default function eachWeekendOfMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var startDate = startOfMonth(dirtyDate)
   if (isNaN(startDate)) throw new RangeError('The passed date is invalid')

--- a/src/eachWeekendOfYear/index.js
+++ b/src/eachWeekendOfYear/index.js
@@ -1,6 +1,7 @@
 import eachWeekendOfInterval from '../eachWeekendOfInterval/index.js'
 import startOfYear from '../startOfYear/index.js'
 import endOfYear from '../endOfYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachWeekendOfYear
@@ -27,11 +28,7 @@ import endOfYear from '../endOfYear/index.js'
  * ]
  */
 export default function eachWeekendOfYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var startDate = startOfYear(dirtyDate)
   if (isNaN(startDate)) throw new RangeError('The passed date is invalid')

--- a/src/eachYearOfInterval/index.js
+++ b/src/eachYearOfInterval/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name eachYearOfInterval
@@ -28,11 +29,7 @@ import toDate from '../toDate/index.js'
  * // ]
  */
 export default function eachYearOfInterval(dirtyInterval) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var interval = dirtyInterval || {}
   var startDate = toDate(interval.start)

--- a/src/endOfDay/index.js
+++ b/src/endOfDay/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfDay
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 02 2014 23:59:59.999
  */
 export default function endOfDay(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setHours(23, 59, 59, 999)

--- a/src/endOfDecade/index.js
+++ b/src/endOfDecade/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfDecade
@@ -25,11 +26,7 @@ import toDate from '../toDate/index.js'
  * //=> Dec 31 1989 23:59:59.999
  */
 export default function endOfDecade(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/endOfHour/index.js
+++ b/src/endOfHour/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfHour
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 02 2014 11:59:59.999
  */
 export default function endOfHour(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setMinutes(59, 59, 999)

--- a/src/endOfISOWeek/index.js
+++ b/src/endOfISOWeek/index.js
@@ -1,4 +1,5 @@
 import endOfWeek from '../endOfWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfISOWeek
@@ -25,11 +26,7 @@ import endOfWeek from '../endOfWeek/index.js'
  * //=> Sun Sep 07 2014 23:59:59.999
  */
 export default function endOfISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return endOfWeek(dirtyDate, { weekStartsOn: 1 })
 }

--- a/src/endOfISOWeekYear/index.js
+++ b/src/endOfISOWeekYear/index.js
@@ -1,5 +1,6 @@
 import getISOWeekYear from '../getISOWeekYear/index.js'
 import startOfISOWeek from '../startOfISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfISOWeekYear
@@ -32,11 +33,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  * //=> Sun Jan 01 2006 23:59:59.999
  */
 export default function endOfISOWeekYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var year = getISOWeekYear(dirtyDate)
   var fourthOfJanuaryOfNextYear = new Date(0)

--- a/src/endOfMinute/index.js
+++ b/src/endOfMinute/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfMinute
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Dec 01 2014 22:15:59.999
  */
 export default function endOfMinute(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setSeconds(59, 999)

--- a/src/endOfMonth/index.js
+++ b/src/endOfMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfMonth
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 30 2014 23:59:59.999
  */
 export default function endOfMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var month = date.getMonth()

--- a/src/endOfQuarter/index.js
+++ b/src/endOfQuarter/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfQuarter
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 30 2014 23:59:59.999
  */
 export default function endOfQuarter(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var currentMonth = date.getMonth()

--- a/src/endOfSecond/index.js
+++ b/src/endOfSecond/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfSecond
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Dec 01 2014 22:15:45.999
  */
 export default function endOfSecond(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setMilliseconds(999)

--- a/src/endOfWeek/index.js
+++ b/src/endOfWeek/index.js
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfWeek
@@ -33,11 +34,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Sun Sep 07 2014 23:59:59.999
  */
 export default function endOfWeek(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
 

--- a/src/endOfYear/index.js
+++ b/src/endOfYear/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name endOfYear
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Wed Dec 31 2014 23:59:59.999
  */
 export default function endOfYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -11,6 +11,7 @@ import {
   throwProtectedError
 } from '../_lib/protectedTokens/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 // This RegExp consists of three parts separated by `|`:
 // - [yYQqMLwIdDecihHKkms]o matches any available ordinal number token
@@ -343,11 +344,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * //=> "3 o'clock"
  */
 export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var formatStr = String(dirtyFormatStr)
   var options = dirtyOptions || {}

--- a/src/formatDistance/index.js
+++ b/src/formatDistance/index.js
@@ -5,6 +5,7 @@ import defaultLocale from '../locale/en-US/index.js'
 import toDate from '../toDate/index.js'
 import cloneObject from '../_lib/cloneObject/index.js'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MINUTES_IN_DAY = 1440
 var MINUTES_IN_ALMOST_TWO_DAYS = 2520
@@ -120,11 +121,7 @@ var MINUTES_IN_TWO_MONTHS = 86400
  * //=> 'pli ol 1 jaro'
  */
 export default function formatDistance(dirtyDate, dirtyBaseDate, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale || defaultLocale

--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -4,6 +4,7 @@ import toDate from '../toDate/index.js'
 import differenceInSeconds from '../differenceInSeconds/index.js'
 import cloneObject from '../_lib/cloneObject/index.js'
 import defaultLocale from '../locale/en-US/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MINUTES_IN_DAY = 1440
 var MINUTES_IN_MONTH = 43200
@@ -164,11 +165,7 @@ export default function formatDistanceStrict(
   dirtyBaseDate,
   dirtyOptions
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale || defaultLocale

--- a/src/formatDistanceToNow/index.js
+++ b/src/formatDistanceToNow/index.js
@@ -1,4 +1,5 @@
 import distanceInWords from '../formatDistance/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name formatDistanceToNow
@@ -106,11 +107,7 @@ import distanceInWords from '../formatDistance/index.js'
  * //=> 'pli ol 1 jaro'
  */
 export default function formatDistanceToNow(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return distanceInWords(dirtyDate, Date.now(), dirtyOptions)
 }

--- a/src/formatRelative/index.js
+++ b/src/formatRelative/index.js
@@ -4,6 +4,7 @@ import defaultLocale from '../locale/en-US/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
 import toDate from '../toDate/index.js'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name formatRelative
@@ -41,11 +42,7 @@ import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMillisec
  * @throws {RangeError} `options.locale` must contain `formatRelative` property
  */
 export default function formatRelative(dirtyDate, dirtyBaseDate, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var baseDate = toDate(dirtyBaseDate)

--- a/src/fromUnixTime/index.js
+++ b/src/fromUnixTime/index.js
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name fromUnixTime
@@ -23,11 +24,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Wed Feb 29 2012 11:45:05
  */
 export default function fromUnixTime(dirtyUnixTime) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var unixTime = toInteger(dirtyUnixTime)
 

--- a/src/getDate/index.js
+++ b/src/getDate/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getDate
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 29
  */
 export default function getDate(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var dayOfMonth = date.getDate()

--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getDay
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 3
  */
 export default function getDay(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var day = date.getDay()

--- a/src/getDayOfYear/index.js
+++ b/src/getDayOfYear/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import startOfYear from '../startOfYear/index.js'
 import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getDayOfYear
@@ -24,11 +25,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  * //=> 183
  */
 export default function getDayOfYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var diff = differenceInCalendarDays(date, startOfYear(date))

--- a/src/getDaysInMonth/index.js
+++ b/src/getDaysInMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getDaysInMonth
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 29
  */
 export default function getDaysInMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/getDaysInYear/index.js
+++ b/src/getDaysInYear/index.js
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.js'
 import isLeapYear from '../isLeapYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getDaysInYear
@@ -23,11 +24,7 @@ import isLeapYear from '../isLeapYear/index.js'
  * //=> 366
  */
 export default function getDaysInYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
 

--- a/src/getDecade/index.js
+++ b/src/getDecade/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getDecade
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 1940
  */
 export default function getDecade(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/getHours/index.js
+++ b/src/getHours/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getHours
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 11
  */
 export default function getHours(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var hours = date.getHours()

--- a/src/getISODay/index.js
+++ b/src/getISODay/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getISODay
@@ -25,11 +26,7 @@ import toDate from '../toDate/index.js'
  * //=> 7
  */
 export default function getISODay(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var day = date.getDay()

--- a/src/getISOWeek/index.js
+++ b/src/getISOWeek/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import startOfISOWeek from '../startOfISOWeek/index.js'
 import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
@@ -28,11 +29,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  * //=> 53
  */
 export default function getISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var diff = startOfISOWeek(date).getTime() - startOfISOWeekYear(date).getTime()

--- a/src/getISOWeekYear/index.js
+++ b/src/getISOWeekYear/index.js
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.js'
 import startOfISOWeek from '../startOfISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getISOWeekYear
@@ -31,11 +32,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  * //=> 2004
  */
 export default function getISOWeekYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/getISOWeeksInYear/index.js
+++ b/src/getISOWeeksInYear/index.js
@@ -1,5 +1,6 @@
 import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
 import addWeeks from '../addWeeks/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
@@ -27,11 +28,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  * //=> 53
  */
 export default function getISOWeeksInYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var thisYear = startOfISOWeekYear(dirtyDate)
   var nextYear = startOfISOWeekYear(addWeeks(thisYear, 60))

--- a/src/getMilliseconds/index.js
+++ b/src/getMilliseconds/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getMilliseconds
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 123
  */
 export default function getMilliseconds(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var milliseconds = date.getMilliseconds()

--- a/src/getMinutes/index.js
+++ b/src/getMinutes/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getMinutes
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 45
  */
 export default function getMinutes(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var minutes = date.getMinutes()

--- a/src/getMonth/index.js
+++ b/src/getMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getMonth
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 1
  */
 export default function getMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var month = date.getMonth()

--- a/src/getOverlappingDaysInIntervals/index.js
+++ b/src/getOverlappingDaysInIntervals/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
 
@@ -71,11 +72,7 @@ export default function getOverlappingDaysInIntervals(
   dirtyIntervalLeft,
   dirtyIntervalRight
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var intervalLeft = dirtyIntervalLeft || {}
   var intervalRight = dirtyIntervalRight || {}

--- a/src/getQuarter/index.js
+++ b/src/getQuarter/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getQuarter
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 3
  */
 export default function getQuarter(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var quarter = Math.floor(date.getMonth() / 3) + 1

--- a/src/getSeconds/index.js
+++ b/src/getSeconds/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getSeconds
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 5
  */
 export default function getSeconds(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var seconds = date.getSeconds()

--- a/src/getTime/index.js
+++ b/src/getTime/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getTime
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 1330515905123
  */
 export default function getTime(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var timestamp = date.getTime()

--- a/src/getUnixTime/index.js
+++ b/src/getUnixTime/index.js
@@ -1,4 +1,5 @@
 import getTime from '../getTime/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getUnixTime
@@ -22,11 +23,7 @@ import getTime from '../getTime/index.js'
  * //=> 1330512305
  */
 export default function getUnixTime(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return Math.floor(getTime(dirtyDate) / 1000)
 }

--- a/src/getWeek/index.js
+++ b/src/getWeek/index.js
@@ -1,6 +1,7 @@
 import startOfWeek from '../startOfWeek/index.js'
 import startOfWeekYear from '../startOfWeekYear/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_WEEK = 604800000
 
@@ -48,11 +49,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  */
 
 export default function getWeek(dirtyDate, options) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var diff =

--- a/src/getWeekOfMonth/index.js
+++ b/src/getWeekOfMonth/index.js
@@ -2,6 +2,7 @@ import getDate from '../getDate/index.js'
 import getDay from '../getDay/index.js'
 import startOfMonth from '../startOfMonth/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getWeekOfMonth
@@ -29,11 +30,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> 2
  */
 export default function getWeekOfMonth(date, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/getWeekYear/index.js
+++ b/src/getWeekYear/index.js
@@ -1,6 +1,7 @@
 import startOfWeek from '../startOfWeek/index.js'
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getWeekYear
@@ -46,11 +47,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> 2004
  */
 export default function getWeekYear(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/getWeeksInMonth/index.js
+++ b/src/getWeeksInMonth/index.js
@@ -1,6 +1,7 @@
 import differenceInCalendarWeeks from '../differenceInCalendarWeeks/index.js'
 import lastDayOfMonth from '../lastDayOfMonth/index.js'
 import startOfMonth from '../startOfMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getWeeksInMonth
@@ -34,11 +35,7 @@ import startOfMonth from '../startOfMonth/index.js'
  * //=> 6
  */
 export default function getWeeksInMonth(date, options) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return (
     differenceInCalendarWeeks(

--- a/src/getYear/index.js
+++ b/src/getYear/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name getYear
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> 2014
  */
 export default function getYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/isAfter/index.js
+++ b/src/isAfter/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isAfter
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isAfter(dirtyDate, dirtyDateToCompare) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var dateToCompare = toDate(dirtyDateToCompare)

--- a/src/isBefore/index.js
+++ b/src/isBefore/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isBefore
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> false
  */
 export default function isBefore(dirtyDate, dirtyDateToCompare) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var dateToCompare = toDate(dirtyDateToCompare)

--- a/src/isDate/index.js
+++ b/src/isDate/index.js
@@ -1,3 +1,5 @@
+import requiredArgs from '../_lib/requiredArgs/index.js'
+
 /**
  * @name isDate
  * @category Common Helpers
@@ -35,11 +37,7 @@
  * //=> false
  */
 export default function isDate(value) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return (
     value instanceof Date ||

--- a/src/isEqual/index.js
+++ b/src/isEqual/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isEqual
@@ -26,11 +27,7 @@ import toDate from '../toDate/index.js'
  * //=> false
  */
 export default function isEqual(dirtyLeftDate, dirtyRightDate) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyLeftDate)
   var dateRight = toDate(dirtyRightDate)

--- a/src/isFirstDayOfMonth/index.js
+++ b/src/isFirstDayOfMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isFirstDayOfMonth
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isFirstDayOfMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDate() === 1
 }

--- a/src/isFriday/index.js
+++ b/src/isFriday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isFriday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isFriday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 5
 }

--- a/src/isFuture/index.js
+++ b/src/isFuture/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isFuture
@@ -26,11 +27,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isFuture(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getTime() > Date.now()
 }

--- a/src/isLastDayOfMonth/index.js
+++ b/src/isLastDayOfMonth/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import endOfDay from '../endOfDay/index.js'
 import endOfMonth from '../endOfMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isLastDayOfMonth
@@ -24,11 +25,7 @@ import endOfMonth from '../endOfMonth/index.js'
  * //=> true
  */
 export default function isLastDayOfMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   return endOfDay(date).getTime() === endOfMonth(date).getTime()

--- a/src/isLeapYear/index.js
+++ b/src/isLeapYear/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isLeapYear
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isLeapYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/isMonday/index.js
+++ b/src/isMonday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isMonday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isMonday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 1
 }

--- a/src/isPast/index.js
+++ b/src/isPast/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isPast
@@ -26,11 +27,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isPast(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getTime() < Date.now()
 }

--- a/src/isSameDay/index.js
+++ b/src/isSameDay/index.js
@@ -1,4 +1,5 @@
 import startOfDay from '../startOfDay/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameDay
@@ -23,11 +24,7 @@ import startOfDay from '../startOfDay/index.js'
  * //=> true
  */
 export default function isSameDay(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfDay = startOfDay(dirtyDateLeft)
   var dateRightStartOfDay = startOfDay(dirtyDateRight)

--- a/src/isSameHour/index.js
+++ b/src/isSameHour/index.js
@@ -1,4 +1,5 @@
 import startOfHour from '../startOfHour/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameHour
@@ -23,11 +24,7 @@ import startOfHour from '../startOfHour/index.js'
  * //=> true
  */
 export default function isSameHour(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfHour = startOfHour(dirtyDateLeft)
   var dateRightStartOfHour = startOfHour(dirtyDateRight)

--- a/src/isSameISOWeek/index.js
+++ b/src/isSameISOWeek/index.js
@@ -1,4 +1,5 @@
 import isSameWeek from '../isSameWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameISOWeek
@@ -25,11 +26,7 @@ import isSameWeek from '../isSameWeek/index.js'
  * //=> true
  */
 export default function isSameISOWeek(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   return isSameWeek(dirtyDateLeft, dirtyDateRight, { weekStartsOn: 1 })
 }

--- a/src/isSameISOWeekYear/index.js
+++ b/src/isSameISOWeekYear/index.js
@@ -1,4 +1,5 @@
 import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameISOWeekYear
@@ -30,11 +31,7 @@ import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
  * //=> true
  */
 export default function isSameISOWeekYear(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfYear = startOfISOWeekYear(dirtyDateLeft)
   var dateRightStartOfYear = startOfISOWeekYear(dirtyDateRight)

--- a/src/isSameMinute/index.js
+++ b/src/isSameMinute/index.js
@@ -1,4 +1,5 @@
 import startOfMinute from '../startOfMinute/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameMinute
@@ -27,11 +28,7 @@ import startOfMinute from '../startOfMinute/index.js'
  * //=> true
  */
 export default function isSameMinute(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfMinute = startOfMinute(dirtyDateLeft)
   var dateRightStartOfMinute = startOfMinute(dirtyDateRight)

--- a/src/isSameMonth/index.js
+++ b/src/isSameMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameMonth
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isSameMonth(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/isSameQuarter/index.js
+++ b/src/isSameQuarter/index.js
@@ -1,4 +1,5 @@
 import startOfQuarter from '../startOfQuarter/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameQuarter
@@ -23,11 +24,7 @@ import startOfQuarter from '../startOfQuarter/index.js'
  * //=> true
  */
 export default function isSameQuarter(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfQuarter = startOfQuarter(dirtyDateLeft)
   var dateRightStartOfQuarter = startOfQuarter(dirtyDateRight)

--- a/src/isSameSecond/index.js
+++ b/src/isSameSecond/index.js
@@ -1,4 +1,5 @@
 import startOfSecond from '../startOfSecond/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameSecond
@@ -27,11 +28,7 @@ import startOfSecond from '../startOfSecond/index.js'
  * //=> true
  */
 export default function isSameSecond(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfSecond = startOfSecond(dirtyDateLeft)
   var dateRightStartOfSecond = startOfSecond(dirtyDateRight)

--- a/src/isSameWeek/index.js
+++ b/src/isSameWeek/index.js
@@ -1,4 +1,5 @@
 import startOfWeek from '../startOfWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameWeek
@@ -39,11 +40,7 @@ export default function isSameWeek(
   dirtyDateRight,
   dirtyOptions
 ) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeftStartOfWeek = startOfWeek(dirtyDateLeft, dirtyOptions)
   var dateRightStartOfWeek = startOfWeek(dirtyDateRight, dirtyOptions)

--- a/src/isSameYear/index.js
+++ b/src/isSameYear/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSameYear
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isSameYear(dirtyDateLeft, dirtyDateRight) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)

--- a/src/isSaturday/index.js
+++ b/src/isSaturday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSaturday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isSaturday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 6
 }

--- a/src/isSunday/index.js
+++ b/src/isSunday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isSunday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isSunday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 0
 }

--- a/src/isThisHour/index.js
+++ b/src/isThisHour/index.js
@@ -1,4 +1,5 @@
 import isSameHour from '../isSameHour/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisHour
@@ -27,11 +28,7 @@ import isSameHour from '../isSameHour/index.js'
  * //=> true
  */
 export default function isThisHour(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameHour(Date.now(), dirtyDate)
 }

--- a/src/isThisISOWeek/index.js
+++ b/src/isThisISOWeek/index.js
@@ -1,4 +1,5 @@
 import isSameISOWeek from '../isSameISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisISOWeek
@@ -29,11 +30,7 @@ import isSameISOWeek from '../isSameISOWeek/index.js'
  */
 
 export default function isThisISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameISOWeek(dirtyDate, Date.now())
 }

--- a/src/isThisMinute/index.js
+++ b/src/isThisMinute/index.js
@@ -1,4 +1,5 @@
 import isSameMinute from '../isSameMinute/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisMinute
@@ -28,11 +29,7 @@ import isSameMinute from '../isSameMinute/index.js'
  */
 
 export default function isThisMinute(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameMinute(Date.now(), dirtyDate)
 }

--- a/src/isThisMonth/index.js
+++ b/src/isThisMonth/index.js
@@ -1,4 +1,5 @@
 import isSameMonth from '../isSameMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisMonth
@@ -27,11 +28,7 @@ import isSameMonth from '../isSameMonth/index.js'
  */
 
 export default function isThisMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameMonth(Date.now(), dirtyDate)
 }

--- a/src/isThisQuarter/index.js
+++ b/src/isThisQuarter/index.js
@@ -1,4 +1,5 @@
 import isSameQuarter from '../isSameQuarter/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisQuarter
@@ -26,11 +27,7 @@ import isSameQuarter from '../isSameQuarter/index.js'
  * //=> true
  */
 export default function isThisQuarter(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameQuarter(Date.now(), dirtyDate)
 }

--- a/src/isThisSecond/index.js
+++ b/src/isThisSecond/index.js
@@ -1,4 +1,5 @@
 import isSameSecond from '../isSameSecond/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisSecond
@@ -27,11 +28,7 @@ import isSameSecond from '../isSameSecond/index.js'
  * //=> true
  */
 export default function isThisSecond(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameSecond(Date.now(), dirtyDate)
 }

--- a/src/isThisWeek/index.js
+++ b/src/isThisWeek/index.js
@@ -1,4 +1,5 @@
 import isSameWeek from '../isSameWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisWeek
@@ -37,11 +38,7 @@ import isSameWeek from '../isSameWeek/index.js'
  */
 
 export default function isThisWeek(dirtyDate, options) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameWeek(dirtyDate, Date.now(), options)
 }

--- a/src/isThisYear/index.js
+++ b/src/isThisYear/index.js
@@ -1,4 +1,5 @@
 import isSameYear from '../isSameYear/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThisYear
@@ -26,11 +27,7 @@ import isSameYear from '../isSameYear/index.js'
  * //=> true
  */
 export default function isThisYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameYear(dirtyDate, Date.now())
 }

--- a/src/isThursday/index.js
+++ b/src/isThursday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isThursday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isThursday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 4
 }

--- a/src/isToday/index.js
+++ b/src/isToday/index.js
@@ -1,4 +1,5 @@
 import isSameDay from '../isSameDay/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isToday
@@ -26,11 +27,7 @@ import isSameDay from '../isSameDay/index.js'
  * //=> true
  */
 export default function isToday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameDay(dirtyDate, Date.now())
 }

--- a/src/isTomorrow/index.js
+++ b/src/isTomorrow/index.js
@@ -1,5 +1,6 @@
 import addDays from '../addDays/index.js'
 import isSameDay from '../isSameDay/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isTomorrow
@@ -27,11 +28,7 @@ import isSameDay from '../isSameDay/index.js'
  * //=> true
  */
 export default function isTomorrow(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameDay(dirtyDate, addDays(Date.now(), 1))
 }

--- a/src/isTuesday/index.js
+++ b/src/isTuesday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isTuesday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isTuesday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 2
 }

--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isValid
@@ -58,11 +59,7 @@ import toDate from '../toDate/index.js'
  * //=> false
  */
 export default function isValid(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   return !isNaN(date)

--- a/src/isWednesday/index.js
+++ b/src/isWednesday/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isWednesday
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isWednesday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return toDate(dirtyDate).getDay() === 3
 }

--- a/src/isWeekend/index.js
+++ b/src/isWeekend/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isWeekend
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> true
  */
 export default function isWeekend(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var day = date.getDay()

--- a/src/isWithinInterval/index.js
+++ b/src/isWithinInterval/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isWithinInterval
@@ -74,11 +75,7 @@ import toDate from '../toDate/index.js'
  * isWithinInterval(date, { start: date, end }) // => true
  */
 export default function isWithinInterval(dirtyDate, dirtyInterval) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var interval = dirtyInterval || {}
   var time = toDate(dirtyDate).getTime()

--- a/src/isYesterday/index.js
+++ b/src/isYesterday/index.js
@@ -1,5 +1,6 @@
 import isSameDay from '../isSameDay/index.js'
 import subDays from '../subDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name isYesterday
@@ -27,11 +28,7 @@ import subDays from '../subDays/index.js'
  * //=> true
  */
 export default function isYesterday(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return isSameDay(dirtyDate, subDays(Date.now(), 1))
 }

--- a/src/lastDayOfDecade/index.js
+++ b/src/lastDayOfDecade/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfDecade
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> Wed Dec 31 2019 00:00:00
  */
 export default function lastDayOfDecade(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/lastDayOfISOWeek/index.js
+++ b/src/lastDayOfISOWeek/index.js
@@ -1,4 +1,5 @@
 import lastDayOfWeek from '../lastDayOfWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfISOWeek
@@ -25,11 +26,7 @@ import lastDayOfWeek from '../lastDayOfWeek/index.js'
  * //=> Sun Sep 07 2014 00:00:00
  */
 export default function lastDayOfISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return lastDayOfWeek(dirtyDate, { weekStartsOn: 1 })
 }

--- a/src/lastDayOfISOWeekYear/index.js
+++ b/src/lastDayOfISOWeekYear/index.js
@@ -1,5 +1,6 @@
 import getISOWeekYear from '../getISOWeekYear/index.js'
 import startOfISOWeek from '../startOfISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfISOWeekYear
@@ -32,11 +33,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  * //=> Sun Jan 01 2006 00:00:00
  */
 export default function lastDayOfISOWeekYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var year = getISOWeekYear(dirtyDate)
   var fourthOfJanuary = new Date(0)

--- a/src/lastDayOfMonth/index.js
+++ b/src/lastDayOfMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfMonth
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 30 2014 00:00:00
  */
 export default function lastDayOfMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var month = date.getMonth()

--- a/src/lastDayOfQuarter/index.js
+++ b/src/lastDayOfQuarter/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfQuarter
@@ -26,11 +27,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 30 2014 00:00:00
  */
 export default function lastDayOfQuarter(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var currentMonth = date.getMonth()

--- a/src/lastDayOfWeek/index.js
+++ b/src/lastDayOfWeek/index.js
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfWeek
@@ -33,11 +34,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Sun Sep 07 2014 00:00:00
  */
 export default function lastDayOfWeek(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/lastDayOfYear/index.js
+++ b/src/lastDayOfYear/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name lastDayOfYear
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Wed Dec 31 2014 00:00:00
  */
 export default function lastDayOfYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/lightFormat/index.js
+++ b/src/lightFormat/index.js
@@ -3,6 +3,7 @@ import formatters from '../_lib/format/lightFormatters/index.js'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
 import isValid from '../isValid/index.js'
 import subMilliseconds from '../subMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 // This RegExp consists of three parts separated by `|`:
 // - (\w)\1* matches any sequences of the same letter
@@ -75,11 +76,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * //=> '1987-02-11'
  */
 export default function lightFormat(dirtyDate, dirtyFormatStr) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var formatStr = String(dirtyFormatStr)
 

--- a/src/max/index.js
+++ b/src/max/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name max
@@ -40,11 +41,7 @@ import toDate from '../toDate/index.js'
  * //=> Sun Jul 02 1995 00:00:00
  */
 export default function max(dirtyDatesArray) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var datesArray
   // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method

--- a/src/min/index.js
+++ b/src/min/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name min
@@ -40,11 +41,7 @@ import toDate from '../toDate/index.js'
  * //=> Wed Feb 11 1987 00:00:00
  */
 export default function min(dirtyDatesArray) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var datesArray
   // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -11,6 +11,7 @@ import {
 } from '../_lib/protectedTokens/index.js'
 import toInteger from '../_lib/toInteger/index.js'
 import parsers from './_lib/parsers/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var TIMEZONE_UNIT_PRIORITY = 10
 
@@ -360,11 +361,7 @@ export default function parse(
   dirtyBackupDate,
   dirtyOptions
 ) {
-  if (arguments.length < 3) {
-    throw new TypeError(
-      '3 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(3, arguments)
 
   var dateString = String(dirtyDateString)
   var formatString = String(dirtyFormatString)

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_HOUR = 3600000
 var MILLISECONDS_IN_MINUTE = 60000
@@ -73,11 +74,7 @@ var timezoneRegex = /^([+-])(\d{2})(?::?(\d{2}))?$/
  * //=> Fri Apr 11 2014 00:00:00
  */
 export default function parseISO(argument, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
 

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name parseJSON
@@ -33,11 +34,7 @@ import toDate from '../toDate/index.js'
  * @throws {TypeError} 1 argument required
  */
 export default function parseJSON(argument) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   if (typeof argument === 'string') {
     var parts = argument.match(

--- a/src/set/index.js
+++ b/src/set/index.js
@@ -1,6 +1,7 @@
 import toDate from '../toDate/index.js'
 import setMonth from '../setMonth/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name set
@@ -42,11 +43,7 @@ import toInteger from '../_lib/toInteger/index.js'
  */
 
 export default function set(dirtyDate, values) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   if (typeof values !== 'object' || values === null) {
     throw new RangeError('values parameter must be an object')

--- a/src/setDate/index.js
+++ b/src/setDate/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setDate
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 30 2014 00:00:00
  */
 export default function setDate(dirtyDate, dirtyDayOfMonth) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var dayOfMonth = toInteger(dirtyDayOfMonth)

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -1,6 +1,7 @@
 import addDays from '../addDays/index.js'
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setDay
@@ -34,11 +35,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Sun Sep 07 2014 00:00:00
  */
 export default function setDay(dirtyDate, dirtyDay, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/setDayOfYear/index.js
+++ b/src/setDayOfYear/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setDayOfYear
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Thu Jan 02 2014 00:00:00
  */
 export default function setDayOfYear(dirtyDate, dirtyDayOfYear) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var dayOfYear = toInteger(dirtyDayOfYear)

--- a/src/setHours/index.js
+++ b/src/setHours/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setHours
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Sep 01 2014 04:30:00
  */
 export default function setHours(dirtyDate, dirtyHours) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var hours = toInteger(dirtyHours)

--- a/src/setISODay/index.js
+++ b/src/setISODay/index.js
@@ -2,6 +2,7 @@ import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import addDays from '../addDays/index.js'
 import getISODay from '../getISODay/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setISODay
@@ -28,11 +29,7 @@ import getISODay from '../getISODay/index.js'
  * //=> Sun Sep 07 2014 00:00:00
  */
 export default function setISODay(dirtyDate, dirtyDay) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var day = toInteger(dirtyDay)

--- a/src/setISOWeek/index.js
+++ b/src/setISOWeek/index.js
@@ -1,6 +1,7 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getISOWeek from '../getISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setISOWeek
@@ -27,11 +28,7 @@ import getISOWeek from '../getISOWeek/index.js'
  * //=> Sat Jan 01 2005 00:00:00
  */
 export default function setISOWeek(dirtyDate, dirtyISOWeek) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var isoWeek = toInteger(dirtyISOWeek)

--- a/src/setISOWeekYear/index.js
+++ b/src/setISOWeekYear/index.js
@@ -2,6 +2,7 @@ import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import startOfISOWeekYear from '../startOfISOWeekYear/index.js'
 import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setISOWeekYear
@@ -34,11 +35,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
  * //=> Mon Jan 01 2007 00:00:00
  */
 export default function setISOWeekYear(dirtyDate, dirtyISOWeekYear) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var isoWeekYear = toInteger(dirtyISOWeekYear)

--- a/src/setMilliseconds/index.js
+++ b/src/setMilliseconds/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setMilliseconds
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Sep 01 2014 11:30:40.300
  */
 export default function setMilliseconds(dirtyDate, dirtyMilliseconds) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var milliseconds = toInteger(dirtyMilliseconds)

--- a/src/setMinutes/index.js
+++ b/src/setMinutes/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setMinutes
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Sep 01 2014 11:45:40
  */
 export default function setMinutes(dirtyDate, dirtyMinutes) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var minutes = toInteger(dirtyMinutes)

--- a/src/setMonth/index.js
+++ b/src/setMonth/index.js
@@ -1,6 +1,7 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import getDaysInMonth from '../getDaysInMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setMonth
@@ -25,11 +26,7 @@ import getDaysInMonth from '../getDaysInMonth/index.js'
  * //=> Sat Feb 01 2014 00:00:00
  */
 export default function setMonth(dirtyDate, dirtyMonth) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var month = toInteger(dirtyMonth)

--- a/src/setQuarter/index.js
+++ b/src/setQuarter/index.js
@@ -1,6 +1,7 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
 import setMonth from '../setMonth/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setQuarter
@@ -25,11 +26,7 @@ import setMonth from '../setMonth/index.js'
  * //=> Wed Apr 02 2014 00:00:00
  */
 export default function setQuarter(dirtyDate, dirtyQuarter) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var quarter = toInteger(dirtyQuarter)

--- a/src/setSeconds/index.js
+++ b/src/setSeconds/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setSeconds
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Sep 01 2014 11:30:45
  */
 export default function setSeconds(dirtyDate, dirtySeconds) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var seconds = toInteger(dirtySeconds)

--- a/src/setWeek/index.js
+++ b/src/setWeek/index.js
@@ -1,6 +1,7 @@
 import getWeek from '../getWeek/index.js'
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setWeek
@@ -47,11 +48,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Sun Jan 4 2004 00:00:00
  */
 export default function setWeek(dirtyDate, dirtyWeek, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var week = toInteger(dirtyWeek)

--- a/src/setWeekYear/index.js
+++ b/src/setWeekYear/index.js
@@ -2,6 +2,7 @@ import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
 import startOfWeekYear from '../startOfWeekYear/index.js'
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setWeekYear
@@ -49,11 +50,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Sat Jan 01 2005 00:00:00
  */
 export default function setWeekYear(dirtyDate, dirtyWeekYear, dirtyOptions) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/setYear/index.js
+++ b/src/setYear/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name setYear
@@ -24,11 +25,7 @@ import toDate from '../toDate/index.js'
  * //=> Sun Sep 01 2013 00:00:00
  */
 export default function setYear(dirtyDate, dirtyYear) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var date = toDate(dirtyDate)
   var year = toInteger(dirtyYear)

--- a/src/startOfDay/index.js
+++ b/src/startOfDay/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfDay
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 02 2014 00:00:00
  */
 export default function startOfDay(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setHours(0, 0, 0, 0)

--- a/src/startOfDecade/index.js
+++ b/src/startOfDecade/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfDecade
@@ -22,11 +23,7 @@ import toDate from '../toDate/index.js'
  * //=> Jan 01 2010 00:00:00
  */
 export default function startOfDecade(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var year = date.getFullYear()

--- a/src/startOfHour/index.js
+++ b/src/startOfHour/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfHour
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Sep 02 2014 11:00:00
  */
 export default function startOfHour(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setMinutes(0, 0, 0)

--- a/src/startOfISOWeek/index.js
+++ b/src/startOfISOWeek/index.js
@@ -1,4 +1,5 @@
 import startOfWeek from '../startOfWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfISOWeek
@@ -25,11 +26,7 @@ import startOfWeek from '../startOfWeek/index.js'
  * //=> Mon Sep 01 2014 00:00:00
  */
 export default function startOfISOWeek(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   return startOfWeek(dirtyDate, { weekStartsOn: 1 })
 }

--- a/src/startOfISOWeekYear/index.js
+++ b/src/startOfISOWeekYear/index.js
@@ -1,5 +1,6 @@
 import getISOWeekYear from '../getISOWeekYear/index.js'
 import startOfISOWeek from '../startOfISOWeek/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfISOWeekYear
@@ -27,11 +28,7 @@ import startOfISOWeek from '../startOfISOWeek/index.js'
  * //=> Mon Jan 03 2005 00:00:00
  */
 export default function startOfISOWeekYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var year = getISOWeekYear(dirtyDate)
   var fourthOfJanuary = new Date(0)

--- a/src/startOfMinute/index.js
+++ b/src/startOfMinute/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfMinute
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Dec 01 2014 22:15:00
  */
 export default function startOfMinute(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setSeconds(0, 0)

--- a/src/startOfMonth/index.js
+++ b/src/startOfMonth/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfMonth
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Sep 01 2014 00:00:00
  */
 export default function startOfMonth(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setDate(1)

--- a/src/startOfQuarter/index.js
+++ b/src/startOfQuarter/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfQuarter
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Tue Jul 01 2014 00:00:00
  */
 export default function startOfQuarter(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   var currentMonth = date.getMonth()

--- a/src/startOfSecond/index.js
+++ b/src/startOfSecond/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfSecond
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Mon Dec 01 2014 22:15:45.000
  */
 export default function startOfSecond(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var date = toDate(dirtyDate)
   date.setMilliseconds(0)

--- a/src/startOfWeek/index.js
+++ b/src/startOfWeek/index.js
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfWeek
@@ -33,11 +34,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Mon Sep 01 2014 00:00:00
  */
 export default function startOfWeek(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -1,6 +1,7 @@
 import getWeekYear from '../getWeekYear/index.js'
 import startOfWeek from '../startOfWeek/index.js'
 import toInteger from '../_lib/toInteger/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfWeekYear
@@ -46,11 +47,7 @@ import toInteger from '../_lib/toInteger/index.js'
  * //=> Mon Jan 03 2005 00:00:00
  */
 export default function startOfWeekYear(dirtyDate, dirtyOptions) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var options = dirtyOptions || {}
   var locale = options.locale

--- a/src/startOfYear/index.js
+++ b/src/startOfYear/index.js
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name startOfYear
@@ -23,11 +24,7 @@ import toDate from '../toDate/index.js'
  * //=> Wed Jan 01 2014 00:00:00
  */
 export default function startOfYear(dirtyDate) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   var cleanDate = toDate(dirtyDate)
   var date = new Date(0)

--- a/src/subBusinessDays/index.js
+++ b/src/subBusinessDays/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addBusinessDays from '../addBusinessDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subBusinessDays
@@ -20,11 +21,7 @@ import addBusinessDays from '../addBusinessDays/index.js'
  * //=> Mon Aug 18 2014 00:00:00 (skipped weekend days)
  */
 export default function subBusinessDays(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addBusinessDays(dirtyDate, -amount)

--- a/src/subDays/index.js
+++ b/src/subDays/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addDays from '../addDays/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subDays
@@ -24,11 +25,7 @@ import addDays from '../addDays/index.js'
  * //=> Fri Aug 22 2014 00:00:00
  */
 export default function subDays(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addDays(dirtyDate, -amount)

--- a/src/subHours/index.js
+++ b/src/subHours/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addHours from '../addHours/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subHours
@@ -24,11 +25,7 @@ import addHours from '../addHours/index.js'
  * //=> Thu Jul 10 2014 23:00:00
  */
 export default function subHours(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addHours(dirtyDate, -amount)

--- a/src/subISOWeekYears/index.js
+++ b/src/subISOWeekYears/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addISOWeekYears from '../addISOWeekYears/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subISOWeekYears
@@ -31,11 +32,7 @@ import addISOWeekYears from '../addISOWeekYears/index.js'
  * //=> Mon Aug 31 2009 00:00:00
  */
 export default function subISOWeekYears(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addISOWeekYears(dirtyDate, -amount)

--- a/src/subMilliseconds/index.js
+++ b/src/subMilliseconds/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMilliseconds from '../addMilliseconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subMilliseconds
@@ -24,11 +25,7 @@ import addMilliseconds from '../addMilliseconds/index.js'
  * //=> Thu Jul 10 2014 12:45:29.250
  */
 export default function subMilliseconds(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMilliseconds(dirtyDate, -amount)

--- a/src/subMinutes/index.js
+++ b/src/subMinutes/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMinutes from '../addMinutes/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subMinutes
@@ -24,11 +25,7 @@ import addMinutes from '../addMinutes/index.js'
  * //=> Thu Jul 10 2014 11:30:00
  */
 export default function subMinutes(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMinutes(dirtyDate, -amount)

--- a/src/subMonths/index.js
+++ b/src/subMonths/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addMonths from '../addMonths/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subMonths
@@ -24,11 +25,7 @@ import addMonths from '../addMonths/index.js'
  * //=> Mon Sep 01 2014 00:00:00
  */
 export default function subMonths(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addMonths(dirtyDate, -amount)

--- a/src/subQuarters/index.js
+++ b/src/subQuarters/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addQuarters from '../addQuarters/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subQuarters
@@ -24,11 +25,7 @@ import addQuarters from '../addQuarters/index.js'
  * //=> Sun Dec 01 2013 00:00:00
  */
 export default function subQuarters(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addQuarters(dirtyDate, -amount)

--- a/src/subSeconds/index.js
+++ b/src/subSeconds/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addSeconds from '../addSeconds/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subSeconds
@@ -24,11 +25,7 @@ import addSeconds from '../addSeconds/index.js'
  * //=> Thu Jul 10 2014 12:44:30
  */
 export default function subSeconds(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addSeconds(dirtyDate, -amount)

--- a/src/subWeeks/index.js
+++ b/src/subWeeks/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addWeeks from '../addWeeks/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subWeeks
@@ -24,11 +25,7 @@ import addWeeks from '../addWeeks/index.js'
  * //=> Mon Aug 04 2014 00:00:00
  */
 export default function subWeeks(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addWeeks(dirtyDate, -amount)

--- a/src/subYears/index.js
+++ b/src/subYears/index.js
@@ -1,5 +1,6 @@
 import toInteger from '../_lib/toInteger/index.js'
 import addYears from '../addYears/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
  * @name subYears
@@ -24,11 +25,7 @@ import addYears from '../addYears/index.js'
  * //=> Tue Sep 01 2009 00:00:00
  */
 export default function subYears(dirtyDate, dirtyAmount) {
-  if (arguments.length < 2) {
-    throw new TypeError(
-      '2 arguments required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(2, arguments)
 
   var amount = toInteger(dirtyAmount)
   return addYears(dirtyDate, -amount)

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -1,3 +1,5 @@
+import requiredArgs from '../_lib/requiredArgs/index.js'
+
 /**
  * @name toDate
  * @category Common Helpers
@@ -29,11 +31,7 @@
  * //=> Tue Feb 11 2014 11:30:30
  */
 export default function toDate(argument) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      '1 argument required, but only ' + arguments.length + ' present'
-    )
-  }
+  requiredArgs(1, arguments)
 
   const argStr = Object.prototype.toString.call(argument)
 


### PR DESCRIPTION
I noticed in a compiled bundle that there were a lot of duplicated strings which were used for argument length validation, so I was interested to see what effect deduplicating these would have on bundle size.

Bundle | Bytes
-------|--------
Before | `25474`
After   | `24528`

That's a reduction of **946 bytes** (3.71%) from a complete minified bundle.