### PR TITLE
parseJSON supports a space time separator for SQL datetime

### DIFF
--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -18,7 +18,8 @@ import toDate from '../toDate/index.js'
  *     - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
  *     - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
  *     - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
- *     - `2000-03-15T05:20:10.134566`: Up to 6 digits in milliseconds field. Only first 3 are taken into account since JS does now allow fractional milliseconds
+ *     - `2000-03-15T05:20:10.1234567`: Up to 7 digits in milliseconds field. Only first 3 are taken into account since JS does not allow fractional milliseconds
+ *     - `2000-03-15 05:20:10`: With a space instead of a 'T' separator for APIs returning a SQL date without reformatting
  *
  * For convenience and ease of use these other input types are also supported
  * via [toDate]{@link https://date-fns.org/docs/toDate}:
@@ -41,7 +42,7 @@ export default function parseJSON(argument) {
 
   if (typeof argument === 'string') {
     var parts = argument.match(
-      /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,6}))?(?:Z|\+00:?00)?/
+      /(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,7}))?(?:Z|\+00:?00)?/
     )
     if (parts) {
       return new Date(

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -60,6 +60,27 @@ describe('parseJSON', function() {
     assert.equal(parsedDate.toISOString(), expectedDate)
   })
 
+  it('parses supported formats with a space time separator instead of a T', () => {
+    const date = '2000-03-15 05:20:10.123Z'
+    const expectedDate = '2000-03-15T05:20:10.123Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses the SQL datetime format without milliseconds', () => {
+    const date = '2000-03-15 05:20:10'
+    const expectedDate = '2000-03-15T05:20:10.000Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
+  it('parses the SQL datetime format with up to 7 millisecond digits', () => {
+    const date = '2000-03-15 05:20:10.1234567'
+    const expectedDate = '2000-03-15T05:20:10.123Z'
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate)
+  })
+
   it('clones a date object', () => {
     const date = new Date(2000, 2, 15, 5, 20, 10, 20)
     const parsedDate = parseJSON(date)


### PR DESCRIPTION
Many JSON APIs return the `datetime` retrieved from a SQL database without modification which is trivial to support in addition to ISO dates.

I also noticed that SQL Server supports up to 7 millisecond digits, so added one more digit to the regex for good measure.