### PR TITLE
Fix a addBusinessDays bug (closes #1584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Thanks to [@mborgbrant](https://github.com/mborgbrant), [@saintplay](https://git
 
 ### Fixed
 
+- [Fixed a bug with addBusinessDays returning the Tuesday when adding 1 day on weekends. Now it returns the Monday](https://github.com/date-fns/date-fns/pull/1588).
 - [Removed dots from short day period names in the Kazakh locale](https://github.com/date-fns/date-fns/pull/1512).
 - [Fixed typo in formatDistance in the Czech locale](https://github.com/date-fns/date-fns/pull/1540).
 - [Fixed shortenings in the Bulgarian locale](https://github.com/date-fns/date-fns/pull/1560).

--- a/src/addBusinessDays/index.js
+++ b/src/addBusinessDays/index.js
@@ -24,25 +24,28 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
 export default function addBusinessDays(dirtyDate, dirtyAmount) {
   requiredArgs(2, arguments)
 
-  var date = toDate(dirtyDate)
-  var amount = toInteger(dirtyAmount)
+  const date = toDate(dirtyDate)
+  const amount = toInteger(dirtyAmount)
 
   if (isNaN(amount)) return new Date(NaN)
 
-  var hours = date.getHours()
-  var sign = amount < 0 ? -1 : 1
+  const hours = date.getHours()
+  const sign = amount < 0 ? -1 : 1
+  const fullWeeks = toInteger(amount / 5)
 
-  date.setDate(date.getDate() + toInteger(amount / 5) * 7)
-  amount %= 5 // to get remaining days not part of a full week
+  date.setDate(date.getDate() + fullWeeks * 7)
 
-  var shiftSize = Math.abs(amount)
+  // Get remaining days not part of a full week
+  let restDays = Math.abs(amount % 5)
 
-  // only loops over remaining days or if day is a weekend, ensures a business day is returned
-  while (shiftSize > 0 || isWeekend(date)) {
-    if (!isWeekend(date)) shiftSize -= 1
+  // Loops over remaining days
+  while (restDays > 0) {
     date.setDate(date.getDate() + sign)
+    if (!isWeekend(date)) restDays -= 1
   }
 
+  // Restore hours to avoid DST lag
   date.setHours(hours)
+
   return date
 }

--- a/src/addBusinessDays/test.js
+++ b/src/addBusinessDays/test.js
@@ -15,6 +15,27 @@ describe('addBusinessDays', function() {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
   })
 
+  it('returns the Monday when 1 day is added on the Friday', () => {
+    assert.deepEqual(
+      addBusinessDays(new Date(2020, 0 /* Jan */, 10), 1), // Friday
+      new Date(2020, 0 /* Jan */, 13) // Monday
+    )
+  })
+
+  it('returns the Monday when 1 day is added on the Satuday', () => {
+    assert.deepEqual(
+      addBusinessDays(new Date(2020, 0 /* Jan */, 11), 1), // Saturday
+      new Date(2020, 0 /* Jan */, 13) // Monday
+    )
+  })
+
+  it('returns the Monday when 1 day is added on the Sunday', () => {
+    assert.deepEqual(
+      addBusinessDays(new Date(2020, 0 /* Jan */, 12), 1), // Sunday
+      new Date(2020, 0 /* Jan */, 13) // Monday
+    )
+  })
+
   it('can handle a large number of business days', function() {
     if (typeof this.timeout === 'function') {
       this.timeout(500 /* 500 ms test timeout */)


### PR DESCRIPTION
Fix a bug with `addBusinessDays` returning the Tuesday when adding 1 day on weekends.
Now it returns the Monday.