### PR TITLE
Fix documentation examples for eachYearOfInterval and eachMonthOfInterval

### DIFF
--- a/src/eachMonthOfInterval/index.js
+++ b/src/eachMonthOfInterval/index.js
@@ -17,7 +17,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *
  * @example
  * // Each month between 6 February 2014 and 10 August 2014:
- * var result = eachDayOfInterval({
+ * var result = eachMonthOfInterval({
  *   start: new Date(2014, 1, 6),
  *   end: new Date(2014, 7, 10)
  * })

--- a/src/eachYearOfInterval/index.js
+++ b/src/eachYearOfInterval/index.js
@@ -17,7 +17,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *
  * @example
  * // Each year between 6 February 2014 and 10 August 2017:
- * var result = eachDayOfInterval({
+ * var result = eachYearOfInterval({
  *   start: new Date(2014, 1, 6),
  *   end: new Date(2017, 7, 10)
  * })


### PR DESCRIPTION
Fixed the name of the function in both examples as it calls eachDayOfInterval.