### PR TITLE
update docs to expand on changes to v1 parse in v2

### DIFF
--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -308,17 +308,10 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * - Old `parse` was renamed to `toDate`.
- *   Now `parse` is a new function which parses a string using a provided format.
- *
- *   ```javascript
- *   // Before v2.0.0
- *   parse('2016-01-01')
- *
- *   // v2.0.0 onward
- *   toDate('2016-01-01')
- *   parse('2016-01-01', 'yyyy-MM-dd', new Date())
- *   ```
+ * - The v1 `parse` implementation was split into two functions.
+ *   If you have a date|timestamp you should use `toDate`.
+ *   If you have a string in ISO 8601 format then you should use `parseISO`.
+ *   For strings in other formats you should use the new `parse` implementation which will parse the string using a provided format.
  *
  * @param {String} dateString - the string to parse
  * @param {String} formatString - the string of tokens

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -34,16 +34,6 @@ var timezoneRegex = /^([+-])(\d{2})(?::?(\d{2}))?$/
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * - The previous `parse` implementation was renamed to `parseISO`.
- *
- *   ```javascript
- *   // Before v2.0.0
- *   parse('2016-01-01')
- *
- *   // v2.0.0 onward
- *   parseISO('2016-01-01')
- *   ```
- *
  * - `parseISO` now validates separate date and time values in ISO-8601 strings
  *   and returns `Invalid Date` if the date is invalid.
  *

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -15,22 +15,29 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * The following formats are supported:
  *
  *     - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`
+ *
  *     - `2000-03-15T05:20:10Z`: Without milliseconds
+ *
  *     - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
+ *
  *     - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
+ *
  *     - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
+ *
  *     - `2000-03-15T05:20:10.1234567`: Up to 7 digits in milliseconds field. Only first 3 are taken into account since JS does not allow fractional milliseconds
+ *
  *     - `2000-03-15 05:20:10`: With a space instead of a 'T' separator for APIs returning a SQL date without reformatting
  *
  * For convenience and ease of use these other input types are also supported
  * via [toDate]{@link https://date-fns.org/docs/toDate}:
  *
  *     - A `Date` instance will be cloned
+ *
  *     - A `number` will be treated as a timestamp
  *
  * Any other input type or invalid date strings will return an `Invalid Date`.
  *
- * @param {String|Number|Date} argument A fully formed ISO1806 date string to convert
+ * @param {String|Number|Date} argument A fully formed ISO 8601 date string to convert
  * @returns {Date} the parsed date in the local time zone
  * @throws {TypeError} 1 argument required
  */


### PR DESCRIPTION
Expands on existing comment in parse, to help direct users currently using v1 parse to the right function in v2.

Removes comment from parseISO as there isn't an equivalent comment in toDate. Doesn't make sense to have it in one but not the other.  Alternatively I can update PR with a comment in both parseISO and toDate if that is preferred.

Fixes https://github.com/date-fns/date-fns/issues/1601

Also fixed formatting and typo in parseJSON documentation.