### PR TITLE
Fix error message thrown by requiredArgs

### DIFF
--- a/src/_lib/requiredArgs/index.js
+++ b/src/_lib/requiredArgs/index.js
@@ -1,9 +1,9 @@
 export default function requiredArgs(required, args) {
   if (args.length < required) {
     throw new TypeError(
-      required + ' argument' + required > 1
+      required + ' argument' + (required > 1
         ? 's'
-        : '' + ' required, but only ' + args.length + ' present'
+        : '') + ' required, but only ' + args.length + ' present'
     )
   }
 }


### PR DESCRIPTION
A logical error in the ternary operator causes the error message to be malformed. Adding parentheses around the ternary condition allows the correct error message to be displayed when insufficient arguments are provided to a function that calls `requiredArgs`.