### PR TITLE
Aligning Czech and Slovak short date fmt with the rest of locales

### DIFF
--- a/src/locale/cs/_lib/formatLong/index.js
+++ b/src/locale/cs/_lib/formatLong/index.js
@@ -3,8 +3,8 @@ import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 var dateFormats = {
   full: 'EEEE, d. MMMM yyyy',
   long: 'd. MMMM yyyy',
-  medium: 'd.M.yyyy',
-  short: 'd.M.yy'
+  medium: 'd. MMM. yyyy',
+  short: 'dd.MM.y'
 }
 
 var timeFormats = {

--- a/src/locale/sk/_lib/formatLong/index.js
+++ b/src/locale/sk/_lib/formatLong/index.js
@@ -4,8 +4,8 @@ import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index.js'
 var dateFormats = {
   full: 'EEEE d. MMMM y',
   long: 'd. MMMM y',
-  medium: 'd. M. y',
-  short: 'd. M. y'
+  medium: 'd. MMM. y',
+  short: 'dd.MM.y'
 }
 
 // https://www.unicode.org/cldr/charts/32/summary/sk.html?hide#2149


### PR DESCRIPTION
Just wanted to align Czech and Slovak "short" and "medium" formats with the rest.
My understanding of types:

- *Short*: expecting date with full year
- *Medium*: expecting date with some form of month name
- *Long*: date with full month name
- *Full*: wee day full name, date with full month name

If we can keep formats somehow aligned then switching between locales won't be such pain...