### PR TITLE
Fix issue #1637: setDay with weekStartsOn != 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Kudos to [@oakhan3](https://github.com/oakhan3), [@Mukhammadali](https://github.
 
 - [Fixed `formatISO` when formatting time with timezones with minute offsets > 0](https://github.com/date-fns/date-fns/pull/1599). Kudos to [@dcRUSTy](https://github.com/dcRUSTy).
 
+### Fixed
+
+- Fixed a bug in setDay when using weekStartsOn that is not 0
+
 ### Added
 
 - [Added `weeks` to `Duration`](https://github.com/date-fns/date-fns/pull/1592).

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -25,12 +25,12 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  *
  * @example
- * // Set Sunday to 1 September 2014:
+ * // Set week day to Sunday, with the default weekStartsOn of Sunday:
  * var result = setDay(new Date(2014, 8, 1), 0)
  * //=> Sun Aug 31 2014 00:00:00
  *
  * @example
- * // If week starts with Monday, set Sunday to 1 September 2014:
+ * // Set week day to Sunday, with a weekStartsOn of Monday:
  * var result = setDay(new Date(2014, 8, 1), 0, { weekStartsOn: 1 })
  * //=> Sun Sep 07 2014 00:00:00
  */

--- a/src/setDay/index.js
+++ b/src/setDay/index.js
@@ -60,6 +60,10 @@ export default function setDay(dirtyDate, dirtyDay, dirtyOptions) {
   var remainder = day % 7
   var dayIndex = (remainder + 7) % 7
 
-  var diff = (dayIndex < weekStartsOn ? 7 : 0) + day - currentDay
+  var delta = 7 - weekStartsOn
+  var diff =
+    day < 0 || day > 6
+      ? day - ((currentDay + delta) % 7)
+      : ((dayIndex + delta) % 7) - ((currentDay + delta) % 7)
   return addDays(date, diff, options)
 }

--- a/src/setDay/test.js
+++ b/src/setDay/test.js
@@ -49,6 +49,20 @@ describe('setDay', function() {
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 7))
   })
 
+  it('specifies Monday as the first day of the week', function() {
+    var result = setDay(new Date(2014, 8 /* Sep */, 7), 1, {
+      weekStartsOn: '1'
+    })
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
+  })
+
+  it('specifies Tuesday as the first day of the week', function() {
+    var result = setDay(new Date(2014, 8 /* Sep */, 7), 1, {
+      weekStartsOn: '2'
+    })
+    assert.deepEqual(result, new Date(2014, 8 /* Sep */, 8))
+  })
+
   context('the day index is more than 6', function() {
     it('sets the day of the next week', function() {
       var result = setDay(new Date(2014, 8 /* Sep */, 1), 8)
@@ -59,14 +73,14 @@ describe('setDay', function() {
       var result = setDay(new Date(2014, 8 /* Sep */, 1), 7, {
         weekStartsOn: 1
       })
-      assert.deepEqual(result, new Date(2014, 8 /* Sep */, 14))
+      assert.deepEqual(result, new Date(2014, 8 /* Sep */, 8))
     })
 
     it('sets the day of another week in the future', function() {
       var result = setDay(new Date(2014, 8 /* Sep */, 1), 14, {
         weekStartsOn: 1
       })
-      assert.deepEqual(result, new Date(2014, 8 /* Sep */, 21))
+      assert.deepEqual(result, new Date(2014, 8 /* Sep */, 15))
     })
   })
 
@@ -80,14 +94,14 @@ describe('setDay', function() {
       var result = setDay(new Date(2014, 8 /* Sep */, 1), -7, {
         weekStartsOn: 1
       })
-      assert.deepEqual(result, new Date(2014, 7 /* Aug */, 31))
+      assert.deepEqual(result, new Date(2014, 7 /* Aug */, 25))
     })
 
     it('set the day of another week in the past', function() {
       var result = setDay(new Date(2014, 8 /* Sep */, 1), -14, {
         weekStartsOn: 1
       })
-      assert.deepEqual(result, new Date(2014, 7 /* Aug */, 24))
+      assert.deepEqual(result, new Date(2014, 7 /* Aug */, 18))
     })
   })
 

--- a/src/setDay/test.js
+++ b/src/setDay/test.js
@@ -51,14 +51,14 @@ describe('setDay', function() {
 
   it('specifies Monday as the first day of the week', function() {
     var result = setDay(new Date(2014, 8 /* Sep */, 7), 1, {
-      weekStartsOn: '1'
+      weekStartsOn: 1
     })
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
   })
 
   it('specifies Tuesday as the first day of the week', function() {
     var result = setDay(new Date(2014, 8 /* Sep */, 7), 1, {
-      weekStartsOn: '2'
+      weekStartsOn: 2
     })
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 8))
   })

--- a/src/setDay/test.js
+++ b/src/setDay/test.js
@@ -50,14 +50,14 @@ describe('setDay', function() {
   })
 
   it('specifies Monday as the first day of the week', function() {
-    var result = setDay(new Date(2014, 8 /* Sep */, 7), 1, {
+    var result = setDay(new Date(2014, 8 /* Sep */, 6), 1, {
       weekStartsOn: 1
     })
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 1))
   })
 
   it('specifies Tuesday as the first day of the week', function() {
-    var result = setDay(new Date(2014, 8 /* Sep */, 7), 1, {
+    var result = setDay(new Date(2014, 8 /* Sep */, 6), 1, {
       weekStartsOn: 2
     })
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 8))


### PR DESCRIPTION
As demonstrated in the issue, setDay(date, day, [option]) returns an
incorrect value if date is on a Sunday and option.weekStartsOn is != 0.
This includes a fix (there's probably a nicer way to code this) and
2 corresponding test cases.

I also found 4 test cases that I believe to be incorrect, all using
the argument {weekStartsOn: 1}. I hope I'm not mistaken here, but I
changed the test cases accordingly.

- All tests completed

- Build script run

- Added entry to Unreleased section of CHANGELOG