### PR TITLE
Fix issue: #1642 - differenceInYears leap day fix

### DIFF
--- a/src/differenceInYears/index.js
+++ b/src/differenceInYears/index.js
@@ -2,6 +2,7 @@ import toDate from '../toDate/index.js'
 import differenceInCalendarYears from '../differenceInCalendarYears/index.js'
 import compareAsc from '../compareAsc/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.js'
+import isLeapYear from '../isLeapYear'
 
 /**
  * @name differenceInYears
@@ -33,7 +34,11 @@ export default function differenceInYears(dirtyDateLeft, dirtyDateRight) {
 
   var sign = compareAsc(dateLeft, dateRight)
   var difference = Math.abs(differenceInCalendarYears(dateLeft, dateRight))
-  dateLeft.setFullYear(dateLeft.getFullYear() - sign * difference)
+
+  // Set both dates to a valid leap year for accurate comparison when dealing
+  // with leap days
+  dateLeft.setFullYear('1584')
+  dateRight.setFullYear('1584')
 
   // Math.abs(diff in full years - diff in calendar years) === 1 if last calendar year is not full
   // If so, result must be decreased by 1 in absolute value

--- a/src/differenceInYears/index.js
+++ b/src/differenceInYears/index.js
@@ -2,7 +2,6 @@ import toDate from '../toDate/index.js'
 import differenceInCalendarYears from '../differenceInCalendarYears/index.js'
 import compareAsc from '../compareAsc/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.js'
-import isLeapYear from '../isLeapYear'
 
 /**
  * @name differenceInYears

--- a/src/differenceInYears/test.js
+++ b/src/differenceInYears/test.js
@@ -54,12 +54,20 @@ describe('differenceInYears', function() {
       assert(result === -2)
     })
 
-    it('supports equal dates', () => {
+    it('supports equal dates of same year', () => {
       var result = differenceInYears(
         new Date(2004, 1 /* Feb */, 29, 0, 0),
         new Date(2004, 1 /* Feb */, 29, 0, 0)
       )
       assert(result === 0)
+    })
+
+    it('supports equal dates of different years', () => {
+      var result = differenceInYears(
+        new Date(2008, 1 /* Feb */, 29, 0, 0),
+        new Date(2004, 1 /* Feb */, 29, 0, 0)
+      )
+      assert(result === 4)
     })
   })
 

--- a/src/differenceInYears/test.js
+++ b/src/differenceInYears/test.js
@@ -30,12 +30,20 @@ describe('differenceInYears', function() {
   })
 
   describe('leap days', function() {
-    it('supports past dates', () => {
+    it('supports past dates with right side larger', () => {
       var result = differenceInYears(
         new Date(2004, 1 /* Feb */, 29, 0, 0),
         new Date(2002, 2 /* Mar */, 1, 0, 0)
       )
       assert(result === 1)
+    })
+
+    it('supports past dates with right side smaller', () => {
+      var result = differenceInYears(
+        new Date(2004, 1 /* Feb */, 29, 0, 0),
+        new Date(2002, 1 /* Feb */, 28, 0, 0)
+      )
+      assert(result === 2)
     })
 
     it('supports future dates', () => {

--- a/src/differenceInYears/test.js
+++ b/src/differenceInYears/test.js
@@ -29,6 +29,32 @@ describe('differenceInYears', function() {
     assert(result === 4)
   })
 
+  describe('leap days', function() {
+    it('supports past dates', () => {
+      var result = differenceInYears(
+        new Date(2004, 1 /* Feb */, 29, 0, 0),
+        new Date(2002, 2 /* Mar */, 1, 0, 0)
+      )
+      assert(result === 1)
+    })
+
+    it('supports future dates', () => {
+      var result = differenceInYears(
+        new Date(2004, 1 /* Feb */, 29, 0, 0),
+        new Date(2006, 2 /* Mar */, 1, 0, 0)
+      )
+      assert(result === -2)
+    })
+
+    it('supports equal dates', () => {
+      var result = differenceInYears(
+        new Date(2004, 1 /* Feb */, 29, 0, 0),
+        new Date(2004, 1 /* Feb */, 29, 0, 0)
+      )
+      assert(result === 0)
+    })
+  })
+
   describe('edge cases', function() {
     it('the difference is less than a year, but the given dates are in different calendar years', function() {
       var result = differenceInYears(

--- a/src/differenceInYears/test.js
+++ b/src/differenceInYears/test.js
@@ -30,7 +30,7 @@ describe('differenceInYears', function() {
   })
 
   describe('leap days', function() {
-    it('supports past dates with right side larger', () => {
+    it('supports past dates with right side after leap day', () => {
       var result = differenceInYears(
         new Date(2004, 1 /* Feb */, 29, 0, 0),
         new Date(2002, 2 /* Mar */, 1, 0, 0)
@@ -38,7 +38,7 @@ describe('differenceInYears', function() {
       assert(result === 1)
     })
 
-    it('supports past dates with right side smaller', () => {
+    it('supports past dates with right side before leap day', () => {
       var result = differenceInYears(
         new Date(2004, 1 /* Feb */, 29, 0, 0),
         new Date(2002, 1 /* Feb */, 28, 0, 0)


### PR DESCRIPTION
As reported in the bug report, `differenceInYears` does not work as expected when dealing with a left hand date which is a leap day.

Consider the following:
```
const result = differenceInYears(new Date(2024, 1, 29), new Date(2005, 02, 01));
```
This would have returned the result of `19`. This is incorrect and should be `18`. The reason for this is the following:
```
// Line 36
dateLeft.setFullYear(dateLeft.getFullYear() - sign * difference)
```
In this instance, if the `sign * difference` end up reassigning the date to a non-leap year i.e. 2023, then internally the date is advanced to `1st March 2023`. While this is the default behaviour of the spec for this utility it is creating invalid results.

The setting of the year was only meant to align the two dates to the same year, so the rest of the date could be compared to see if it fell within a full year. To work around this I'm proposing we assign BOTH dates to a leap year to prevent any incorrect date reassignment.