### PR TITLE
Correct typo: ISO1806 to ISO8601

### DIFF
--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -30,7 +30,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *
  * Any other input type or invalid date strings will return an `Invalid Date`.
  *
- * @param {String|Number|Date} argument A fully formed ISO1806 date string to convert
+ * @param {String|Number|Date} argument A fully formed ISO8601 date string to convert
  * @returns {Date} the parsed date in the local time zone
  * @throws {TypeError} 1 argument required
  */


### PR DESCRIPTION
ISO1806 specifies a method of determining the mesh-breaking force of netting for fishing! ISO8601 is an international standard covering the exchange of date-and time-related data.