### PR TITLE
Fix parseISO around time shift dates, fixes #1618

### DIFF
--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -1,5 +1,4 @@
 import toInteger from '../_lib/toInteger/index.js'
-import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.js'
 
 var MILLISECONDS_IN_HOUR = 3600000
@@ -128,23 +127,23 @@ export default function parseISO(argument, dirtyOptions) {
       return new Date(NaN)
     }
   } else {
-    var fullTime = timestamp + time
-    var fullTimeDate = new Date(fullTime)
-
-    offset = getTimezoneOffsetInMilliseconds(fullTimeDate)
-
-    // Adjust time when it's coming from DST
-    var fullTimeDateDiffDay = new Date(fullTime)
-    if (offset > 0) {
-      fullTimeDateDiffDay.setDate(fullTimeDate.getDate() + 1)
-    } else {
-      fullTimeDateDiffDay.setDate(fullTimeDate.getDate() - 1)
-    }
-    var offsetDiff =
-      getTimezoneOffsetInMilliseconds(fullTimeDateDiffDay) - offset
-    if (offsetDiff > 0) {
-      offset += offsetDiff
-    }
+    var dirtyDate = new Date(timestamp + time)
+    // js parsed string assuming it's in UTC timezone
+    // but we need it to be parsed in our timezone
+    // so we use utc values to build date in our timezone.
+    // Year values from 0 to 99 map to the years 1900 to 1999
+    // so set year explicitly with setFullYear.
+    var result = new Date(
+      dirtyDate.getUTCFullYear(),
+      dirtyDate.getUTCMonth(),
+      dirtyDate.getUTCDate(),
+      dirtyDate.getUTCHours(),
+      dirtyDate.getUTCMinutes(),
+      dirtyDate.getUTCSeconds(),
+      dirtyDate.getUTCMilliseconds()
+    )
+    result.setFullYear(dirtyDate.getUTCFullYear())
+    return result
   }
 
   return new Date(timestamp + time + offset)

--- a/test/dst/parseISO/sydney.js
+++ b/test/dst/parseISO/sydney.js
@@ -21,6 +21,11 @@ assert.equal(
   'Sun Oct 06 2019 03:00:00 GMT+1100 (Australian Eastern Daylight Time)'
 )
 
+assert.equal(
+  parseISO('2019-10-06T05:00:00').toString(),
+  'Sun Oct 06 2019 05:00:00 GMT+1100 (Australian Eastern Daylight Time)'
+)
+
 // Test DST end edge
 assert.equal(parseISO('2019-04-06').getDate(), 6)
 assert.equal(parseISO('2019-04-07').getDate(), 7) // DST end
@@ -31,4 +36,23 @@ assert.equal(
 assert.equal(
   parseISO('2019-04-07T11:00:00').toString(),
   'Sun Apr 07 2019 11:00:00 GMT+1000 (Australian Eastern Standard Time)'
+)
+
+assert.equal(
+  parseISO('2019-04-07T00:00:00').toString(),
+  'Sun Apr 07 2019 00:00:00 GMT+1100 (Australian Eastern Daylight Time)'
+)
+
+// test edge cases for months, years
+assert.equal(
+  parseISO('2020-01-01T00:00:00').toString(),
+  'Wed Jan 01 2020 00:00:00 GMT+1100 (Australian Eastern Daylight Time)'
+)
+assert.equal(
+  parseISO('2019-12-31T23:59:59').toString(),
+  'Tue Dec 31 2019 23:59:59 GMT+1100 (Australian Eastern Daylight Time)'
+)
+assert.equal(
+  parseISO('2020-02-29T23:59:59').toString(),
+  'Sat Feb 29 2020 23:59:59 GMT+1100 (Australian Eastern Daylight Time)'
 )


### PR DESCRIPTION
Handling offsets by hands during time shift is too hard, so I use utc values to build date in local timezone. Need testing for edge cases, I couldn't find issues. Fixes https://github.com/date-fns/date-fns/issues/1618