### PR TITLE
Fix inconsistent typing across getDay fn and weekStartsOn option. #1663

### DIFF
--- a/src/fp/getDay/index.js.flow
+++ b/src/fp/getDay/index.js.flow
@@ -49,4 +49,4 @@ export type Duration = {
 
 type CurriedFn1<A, R> = <A>(a: A) => R
 
-declare module.exports: CurriedFn1<Date | number, number>
+declare module.exports: CurriedFn1<Date | number, 0 | 1 | 2 | 3 | 4 | 5 | 6>

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -265,7 +265,7 @@ declare module.exports: {
   >,
   fromUnixTime: CurriedFn1<number, Date>,
   getDate: CurriedFn1<Date | number, number>,
-  getDay: CurriedFn1<Date | number, number>,
+  getDay: CurriedFn1<Date | number, 0 | 1 | 2 | 3 | 4 | 5 | 6>,
   getDayOfYear: CurriedFn1<Date | number, number>,
   getDaysInMonth: CurriedFn1<Date | number, number>,
   getDaysInYear: CurriedFn1<Date | number, number>,

--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -14,7 +14,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the given date
- * @returns {Number} the day of week
+ * @returns {0|1|2|3|4|5|6} the day of week
  * @throws {TypeError} 1 argument required
  *
  * @example

--- a/src/getDay/index.js.flow
+++ b/src/getDay/index.js.flow
@@ -47,4 +47,4 @@ export type Duration = {
   seconds?: number
 }
 
-declare module.exports: (date: Date | number) => number
+declare module.exports: (date: Date | number) => 0 | 1 | 2 | 3 | 4 | 5 | 6

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -332,7 +332,7 @@ declare module.exports: {
 
   getDate: (date: Date | number) => number,
 
-  getDay: (date: Date | number) => number,
+  getDay: (date: Date | number) => 0 | 1 | 2 | 3 | 4 | 5 | 6,
 
   getDayOfYear: (date: Date | number) => number,
 
@@ -539,7 +539,7 @@ declare module.exports: {
   parse: (
     dateString: string,
     formatString: string,
-    backupDate: Date | number,
+    referenceDate: Date | number,
     options?: {
       locale?: Locale,
       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -442,7 +442,7 @@ declare module 'date-fns' {
   function getDate(date: Date | number): number
   namespace getDate {}
 
-  function getDay(date: Date | number): number
+  function getDay(date: Date | number): 0 | 1 | 2 | 3 | 4 | 5 | 6
   namespace getDay {}
 
   function getDayOfYear(date: Date | number): number
@@ -744,7 +744,7 @@ declare module 'date-fns' {
   function parse(
     dateString: string,
     formatString: string,
-    backupDate: Date | number,
+    referenceDate: Date | number,
     options?: {
       locale?: Locale
       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
@@ -4163,7 +4163,7 @@ declare module 'date-fns/fp' {
   const getDate: CurriedFn1<Date | number, number>
   namespace getDate {}
 
-  const getDay: CurriedFn1<Date | number, number>
+  const getDay: CurriedFn1<Date | number, 0 | 1 | 2 | 3 | 4 | 5 | 6>
   namespace getDay {}
 
   const getDayOfYear: CurriedFn1<Date | number, number>
@@ -7971,7 +7971,7 @@ declare module 'date-fns/esm' {
   function getDate(date: Date | number): number
   namespace getDate {}
 
-  function getDay(date: Date | number): number
+  function getDay(date: Date | number): 0 | 1 | 2 | 3 | 4 | 5 | 6
   namespace getDay {}
 
   function getDayOfYear(date: Date | number): number
@@ -8273,7 +8273,7 @@ declare module 'date-fns/esm' {
   function parse(
     dateString: string,
     formatString: string,
-    backupDate: Date | number,
+    referenceDate: Date | number,
     options?: {
       locale?: Locale
       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
@@ -11692,7 +11692,7 @@ declare module 'date-fns/esm/fp' {
   const getDate: CurriedFn1<Date | number, number>
   namespace getDate {}
 
-  const getDay: CurriedFn1<Date | number, number>
+  const getDay: CurriedFn1<Date | number, 0 | 1 | 2 | 3 | 4 | 5 | 6>
   namespace getDay {}
 
   const getDayOfYear: CurriedFn1<Date | number, number>
@@ -17898,7 +17898,7 @@ interface dateFns {
 
   getDate(date: Date | number): number
 
-  getDay(date: Date | number): number
+  getDay(date: Date | number): 0 | 1 | 2 | 3 | 4 | 5 | 6
 
   getDayOfYear(date: Date | number): number
 
@@ -18102,7 +18102,7 @@ interface dateFns {
   parse(
     dateString: string,
     formatString: string,
-    backupDate: Date | number,
+    referenceDate: Date | number,
     options?: {
       locale?: Locale
       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6


### PR DESCRIPTION
It looks like backupDate was changed to referenceDate at some point in master but FP functions, typings and indices were never rebuilt via `./scripts/build/build.sh`.