### PR TITLE
Update getDay doc to return `0|1|2|3|4|5|6` instead of `number`

### DIFF
--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -14,7 +14,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the given date
- * @returns {Number} the day of week
+ * @returns {0|1|2|3|4|5|6} the day of week
  * @throws {TypeError} 1 argument required
  *
  * @example


### PR DESCRIPTION
The PR addresses the issue discussed in #1663.