### PR TITLE
Add formatDuration function

### DIFF
--- a/src/formatDuration/test.js
+++ b/src/formatDuration/test.js
@@ -4,7 +4,7 @@
 import assert from 'power-assert'
 import formatDuration from '.'
 
-describe.only('formatDuration', () => {
+describe('formatDuration', () => {
   it('formats full duration', () => {
     assert(
       formatDuration({

--- a/src/fp/formatDuration/index.d.ts
+++ b/src/fp/formatDuration/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
-import { formatDuration } from 'date-fns'
+import { formatDuration } from 'date-fns/fp'
 export default formatDuration

--- a/src/fp/formatDuration/index.js
+++ b/src/fp/formatDuration/index.js
@@ -1,0 +1,8 @@
+// This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
+
+import fn from '../../formatDuration/index.js'
+import convertToFP from '../_lib/convertToFP/index.js'
+
+var formatDuration = convertToFP(fn, 1)
+
+export default formatDuration

--- a/src/fp/formatDuration/index.js.flow
+++ b/src/fp/formatDuration/index.js.flow
@@ -47,11 +47,6 @@ export type Duration = {
   seconds?: number
 }
 
-declare module.exports: (
-  duration: Duration,
-  options?: {
-    format?: string[],
-    zero?: boolean,
-    delimiter?: string
-  }
-) => string
+type CurriedFn1<A, R> = <A>(a: A) => R
+
+declare module.exports: CurriedFn1<Duration, string>

--- a/src/fp/formatDurationWithOptions/index.d.ts
+++ b/src/fp/formatDurationWithOptions/index.d.ts
@@ -1,4 +1,4 @@
 // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
 
-import { formatDuration } from 'date-fns'
-export default formatDuration
+import { formatDurationWithOptions } from 'date-fns/fp'
+export default formatDurationWithOptions

--- a/src/fp/formatDurationWithOptions/index.js
+++ b/src/fp/formatDurationWithOptions/index.js
@@ -1,0 +1,8 @@
+// This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
+
+import fn from '../../formatDuration/index.js'
+import convertToFP from '../_lib/convertToFP/index.js'
+
+var formatDurationWithOptions = convertToFP(fn, 2)
+
+export default formatDurationWithOptions

--- a/src/fp/formatDurationWithOptions/index.js.flow
+++ b/src/fp/formatDurationWithOptions/index.js.flow
@@ -47,11 +47,18 @@ export type Duration = {
   seconds?: number
 }
 
-declare module.exports: (
-  duration: Duration,
-  options?: {
-    format?: string[],
+type CurriedFn1<A, R> = <A>(a: A) => R
+
+type CurriedFn2<A, B, R> = <A>(
+  a: A
+) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
+
+declare module.exports: CurriedFn2<
+  {
+    delimiter?: string,
     zero?: boolean,
-    delimiter?: string
-  }
-) => string
+    format?: string[]
+  },
+  Duration,
+  string
+>

--- a/src/fp/index.js
+++ b/src/fp/index.js
@@ -108,6 +108,10 @@ export {
 export {
   default as formatDistanceWithOptions
 } from './formatDistanceWithOptions/index.js'
+export { default as formatDuration } from './formatDuration/index.js'
+export {
+  default as formatDurationWithOptions
+} from './formatDurationWithOptions/index.js'
 export { default as formatISO } from './formatISO/index.js'
 export { default as formatISO9075 } from './formatISO9075/index.js'
 export {

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -214,6 +214,16 @@ declare module.exports: {
     Date | number,
     string
   >,
+  formatDuration: CurriedFn1<Duration, string>,
+  formatDurationWithOptions: CurriedFn2<
+    {
+      delimiter?: string,
+      zero?: boolean,
+      format?: string[]
+    },
+    Duration,
+    string
+  >,
   formatISO: CurriedFn1<Date | number, string>,
   formatISO9075: CurriedFn1<Date | number, string>,
   formatISO9075WithOptions: CurriedFn2<

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ export { default as formatDistanceToNow } from './formatDistanceToNow/index.js'
 export {
   default as formatDistanceToNowStrict
 } from './formatDistanceToNowStrict/index.js'
+export { default as formatDuration } from './formatDuration/index.js'
 export { default as formatISO } from './formatISO/index.js'
 export { default as formatISO9075 } from './formatISO9075/index.js'
 export { default as formatISODuration } from './formatISODuration/index.js'

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -304,6 +304,15 @@ declare module.exports: {
     }
   ) => string,
 
+  formatDuration: (
+    duration: Duration,
+    options?: {
+      format?: string[],
+      zero?: boolean,
+      delimiter?: string
+    }
+  ) => string,
+
   formatISO: (
     date: Date | number,
     options?: {

--- a/src/locale/af/_lib/formatDistance/index.js
+++ b/src/locale/af/_lib/formatDistance/index.js
@@ -1,6 +1,6 @@
 var formatDistanceLocale = {
   lessThanXSeconds: {
-    one: 'minder as \'n sekonde',
+    one: "minder as 'n sekonde",
     other: 'minder as {{count}} sekondes'
   },
 
@@ -9,15 +9,15 @@ var formatDistanceLocale = {
     other: '{{count}} sekondes'
   },
 
-  halfAMinute: '\'n halwe minuut',
+  halfAMinute: "'n halwe minuut",
 
   lessThanXMinutes: {
-    one: 'minder as \'n minuut',
+    one: "minder as 'n minuut",
     other: 'minder as {{count}} minute'
   },
 
   xMinutes: {
-    one: '\'n minuut',
+    one: "'n minuut",
     other: '{{count}} minute'
   },
 
@@ -34,6 +34,16 @@ var formatDistanceLocale = {
   xDays: {
     one: '1 dag',
     other: '{{count}} dae'
+  },
+
+  aboutXWeeks: {
+    one: 'ongeveer 1 week',
+    other: 'ongeveer {{count}} weke'
+  },
+
+  xWeeks: {
+    one: '1 week',
+    other: '{{count}} weke'
   },
 
   aboutXMonths: {
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/ar-DZ/_lib/formatDistance/index.js
+++ b/src/locale/ar-DZ/_lib/formatDistance/index.js
@@ -50,25 +50,25 @@ var formatDistanceLocale = {
     other: '{{count}} يوم'
   },
 
+  aboutXWeeks: {
+    one: 'أسبوع واحد تقريباً',
+    two: 'أسبوعين تقريباً',
+    threeToTen: '{{count}} أسابيع تقريباً',
+    other: '{{count}} أسبوع تقريباً'
+  },
+
+  xWeeks: {
+    one: 'أسبوع واحد',
+    two: 'أسبوعين',
+    threeToTen: '{{count}} أسابيع',
+    other: '{{count}} أسبوع'
+  },
+
   aboutXMonths: {
     one: 'شهر واحد تقريباً',
     two: 'شهرين تقريباً',
     threeToTen: '{{count}} أشهر تقريباً',
     other: '{{count}} شهر تقريباً'
-  },
-
-  aboutXWeeks: {
-    one: 'شهر واحد تقريباً', // TODO
-    two: 'شهرين تقريباً', // TODO
-    threeToTen: '{{count}} أشهر تقريباً', // TODO
-    other: '{{count}} شهر تقريباً' // TODO
-  },
-
-  xWeeks: {
-    one: 'شهر واحد', // TODO
-    two: 'شهرين', // TODO
-    threeToTen: '{{count}} أشهر', // TODO
-    other: '{{count}} شهر' // TODO
   },
 
   xMonths: {

--- a/src/locale/ar-DZ/_lib/formatDistance/index.js
+++ b/src/locale/ar-DZ/_lib/formatDistance/index.js
@@ -57,6 +57,20 @@ var formatDistanceLocale = {
     other: '{{count}} شهر تقريباً'
   },
 
+  aboutXWeeks: {
+    one: 'شهر واحد تقريباً', // TODO
+    two: 'شهرين تقريباً', // TODO
+    threeToTen: '{{count}} أشهر تقريباً', // TODO
+    other: '{{count}} شهر تقريباً' // TODO
+  },
+
+  xWeeks: {
+    one: 'شهر واحد', // TODO
+    two: 'شهرين', // TODO
+    threeToTen: '{{count}} أشهر', // TODO
+    other: '{{count}} شهر' // TODO
+  },
+
   xMonths: {
     one: 'شهر واحد',
     two: 'شهرين',

--- a/src/locale/ar-MA/_lib/formatDistance/index.js
+++ b/src/locale/ar-MA/_lib/formatDistance/index.js
@@ -51,17 +51,17 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'شهر واحد تقريباً', // TODO
-    two: 'شهرين تقريباً', // TODO
-    threeToTen: '{{count}} أشهر تقريباً', // TODO
-    other: '{{count}} شهر تقريباً' // TODO
+    one: 'أسبوع واحد تقريباً',
+    two: 'أسبوعين تقريباً',
+    threeToTen: '{{count}} أسابيع تقريباً',
+    other: '{{count}} أسبوع تقريباً'
   },
 
   xWeeks: {
-    one: 'شهر واحد', // TODO
-    two: 'شهرين', // TODO
-    threeToTen: '{{count}} أشهر', // TODO
-    other: '{{count}} شهر' // TODO
+    one: 'أسبوع واحد',
+    two: 'أسبوعين',
+    threeToTen: '{{count}} أسابيع',
+    other: '{{count}} أسبوع'
   },
 
   aboutXMonths: {

--- a/src/locale/ar-MA/_lib/formatDistance/index.js
+++ b/src/locale/ar-MA/_lib/formatDistance/index.js
@@ -50,6 +50,20 @@ var formatDistanceLocale = {
     other: '{{count}} يوم'
   },
 
+  aboutXWeeks: {
+    one: 'شهر واحد تقريباً', // TODO
+    two: 'شهرين تقريباً', // TODO
+    threeToTen: '{{count}} أشهر تقريباً', // TODO
+    other: '{{count}} شهر تقريباً' // TODO
+  },
+
+  xWeeks: {
+    one: 'شهر واحد', // TODO
+    two: 'شهرين', // TODO
+    threeToTen: '{{count}} أشهر', // TODO
+    other: '{{count}} شهر' // TODO
+  },
+
   aboutXMonths: {
     one: 'شهر واحد تقريباً',
     two: 'شهرين تقريباً',

--- a/src/locale/ar-SA/_lib/formatDistance/index.js
+++ b/src/locale/ar-SA/_lib/formatDistance/index.js
@@ -51,18 +51,19 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'شهر واحد تقريباً', // TODO
-    two: 'شهرين تقريباً', // TODO
-    threeToTen: '{{count}} أشهر تقريباً', // TODO
-    other: '{{count}} شهر تقريباً' // TODO
+    one: 'أسبوع واحد تقريباً',
+    two: 'أسبوعين تقريباً',
+    threeToTen: '{{count}} أسابيع تقريباً',
+    other: '{{count}} أسبوع تقريباً'
   },
 
   xWeeks: {
-    one: 'شهر واحد', // TODO
-    two: 'شهرين', // TODO
-    threeToTen: '{{count}} أشهر', // TODO
-    other: '{{count}} شهر' // TODO
-  },
+    one: 'أسبوع واحد',
+    two: 'أسبوعين',
+    threeToTen: '{{count}} أسابيع',
+    other: '{{count}} أسبوع',
+  
+},
 
   aboutXMonths: {
     one: 'شهر واحد تقريباً',

--- a/src/locale/ar-SA/_lib/formatDistance/index.js
+++ b/src/locale/ar-SA/_lib/formatDistance/index.js
@@ -61,9 +61,8 @@ var formatDistanceLocale = {
     one: 'أسبوع واحد',
     two: 'أسبوعين',
     threeToTen: '{{count}} أسابيع',
-    other: '{{count}} أسبوع',
-  
-},
+    other: '{{count}} أسبوع'
+  },
 
   aboutXMonths: {
     one: 'شهر واحد تقريباً',

--- a/src/locale/ar-SA/_lib/formatDistance/index.js
+++ b/src/locale/ar-SA/_lib/formatDistance/index.js
@@ -50,6 +50,20 @@ var formatDistanceLocale = {
     other: '{{count}} يوم'
   },
 
+  aboutXWeeks: {
+    one: 'شهر واحد تقريباً', // TODO
+    two: 'شهرين تقريباً', // TODO
+    threeToTen: '{{count}} أشهر تقريباً', // TODO
+    other: '{{count}} شهر تقريباً' // TODO
+  },
+
+  xWeeks: {
+    one: 'شهر واحد', // TODO
+    two: 'شهرين', // TODO
+    threeToTen: '{{count}} أشهر', // TODO
+    other: '{{count}} شهر' // TODO
+  },
+
   aboutXMonths: {
     one: 'شهر واحد تقريباً',
     two: 'شهرين تقريباً',

--- a/src/locale/az/_lib/formatDistance/index.js
+++ b/src/locale/az/_lib/formatDistance/index.js
@@ -3,51 +3,74 @@ var formatDistanceLocale = {
     one: 'bir saniyədən az',
     other: '{{count}} bir saniyədən az'
   },
+
   xSeconds: {
     one: '1 saniyə',
     other: '{{count}} saniyə'
   },
+
   halfAMinute: 'yarım dəqiqə',
+
   lessThanXMinutes: {
     one: 'bir dəqiqədən az',
     other: '{{count}} bir dəqiqədən az'
   },
+
   xMinutes: {
     one: 'bir dəqiqə',
     other: '{{count}} dəqiqə'
   },
+
   aboutXHours: {
     one: 'təxminən 1 saat',
     other: 'təxminən {{count}} saat'
   },
+
   xHours: {
     one: '1 saat',
     other: '{{count}} saat'
   },
+
   xDays: {
     one: '1 gün',
     other: '{{count}} gün'
   },
+
+  aboutXWeeks: {
+    one: 'təxminən 1 həftə',
+    other: 'təxminən {{count}} həftə'
+  },
+
+  xWeeks: {
+    one: '1 həftə',
+    other: '{{count}} həftə'
+  },
+
   aboutXMonths: {
     one: 'təxminən 1 ay',
     other: 'təxminən {{count}} ay'
   },
+
   xMonths: {
     one: '1 ay',
     other: '{{count}} ay'
   },
+
   aboutXYears: {
     one: 'təxminən 1 il',
     other: 'təxminən {{count}} il'
   },
+
   xYears: {
     one: '1 il',
     other: '{{count}} il'
   },
+
   overXYears: {
     one: '1 ildən çox',
     other: '{{count}} ildən çox'
   },
+
   almostXYears: {
     one: 'demək olar ki 1 il',
     other: 'demək olar ki {{count}} il'

--- a/src/locale/be/_lib/formatDistance/index.js
+++ b/src/locale/be/_lib/formatDistance/index.js
@@ -161,6 +161,27 @@ var formatDistanceLocale = {
     }
   }),
 
+  aboutXWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: 'каля {{count}} месяца', // TODO
+      singularGenitive: 'каля {{count}} месяцаў', // TODO
+      pluralGenitive: 'каля {{count}} месяцаў' // TODO
+    },
+    future: {
+      singularNominative: 'прыблізна праз {{count}} месяц', // TODO
+      singularGenitive: 'прыблізна праз {{count}} месяцы', // TODO
+      pluralGenitive: 'прыблізна праз {{count}} месяцаў' // TODO
+    }
+  }),
+
+  xWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: '{{count}} месяц',
+      singularGenitive: '{{count}} месяцы',
+      pluralGenitive: '{{count}} месяцаў'
+    }
+  }),
+
   aboutXMonths: buildLocalizeTokenFn({
     regular: {
       singularNominative: 'каля {{count}} месяца',

--- a/src/locale/bg/_lib/formatDistance/index.js
+++ b/src/locale/bg/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} дни'
   },
 
+  aboutXWeeks: {
+    one: 'около месец', // TODO
+    other: 'около {{count}} месеца' // TODO
+  },
+
+  xWeeks: {
+    one: '1 месец', // TODO
+    other: '{{count}} месеца' // TODO
+  },
+
   aboutXMonths: {
     one: 'около месец',
     other: 'около {{count}} месеца'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/bg/_lib/formatDistance/index.js
+++ b/src/locale/bg/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'около месец', // TODO
-    other: 'около {{count}} месеца' // TODO
+    one: 'около седмица',
+    other: 'около {{count}} седмици'
   },
 
   xWeeks: {
-    one: '1 месец', // TODO
-    other: '{{count}} месеца' // TODO
+    one: '1 седмица',
+    other: '{{count}} седмици'
   },
 
   aboutXMonths: {

--- a/src/locale/bn/_lib/formatDistance/index.js
+++ b/src/locale/bn/_lib/formatDistance/index.js
@@ -38,6 +38,16 @@ var formatDistanceLocale = {
     other: '{{count}} দিন'
   },
 
+  aboutXWeeks: {
+    one: 'প্রায় ১ মাস', // TODO
+    other: 'প্রায় {{count}} মাস' // TODO
+  },
+
+  xWeeks: {
+    one: '১ মাস', // TODO
+    other: '{{count}} মাস' // TODO
+  },
+
   aboutXMonths: {
     one: 'প্রায় ১ মাস',
     other: 'প্রায় {{count}} মাস'
@@ -69,7 +79,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result
@@ -78,7 +88,10 @@ export default function formatDistance (token, count, options) {
   } else if (count === 1) {
     result = formatDistanceLocale[token].one
   } else {
-    result = formatDistanceLocale[token].other.replace('{{count}}', localize.numberToLocale(count))
+    result = formatDistanceLocale[token].other.replace(
+      '{{count}}',
+      localize.numberToLocale(count)
+    )
   }
 
   if (options.addSuffix) {

--- a/src/locale/bn/_lib/formatDistance/index.js
+++ b/src/locale/bn/_lib/formatDistance/index.js
@@ -39,13 +39,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'প্রায় ১ মাস', // TODO
-    other: 'প্রায় {{count}} মাস' // TODO
+    one: 'প্রায় ১ সপ্তাহ',
+    other: 'প্রায় {{count}} সপ্তাহ'
   },
 
   xWeeks: {
-    one: '১ মাস', // TODO
-    other: '{{count}} মাস' // TODO
+    one: '১ সপ্তাহ',
+    other: '{{count}} সপ্তাহ'
   },
 
   aboutXMonths: {

--- a/src/locale/ca/_lib/formatDistance/index.js
+++ b/src/locale/ca/_lib/formatDistance/index.js
@@ -49,18 +49,18 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'aproximadament un mes',
-    other: 'aproximadament {{count}} mesos'
+    one: 'aproximadament una setmana',
+    other: 'aproximadament {{count}} setmanes'
   },
 
   xWeeks: {
-    one: '1 mes', // TODO
-    other: '{{count}} mesos' // TODO
+    one: '1 setmana',
+    other: '{{count}} setmanes'
   },
 
   aboutXMonths: {
-    one: 'aproximadament un mes', // TODO
-    other: 'aproximadament {{count}} mesos' // TODO
+    one: 'aproximadament un mes',
+    other: 'aproximadament {{count}} mesos'
   },
 
   xMonths: {

--- a/src/locale/ca/_lib/formatDistance/index.js
+++ b/src/locale/ca/_lib/formatDistance/index.js
@@ -48,9 +48,19 @@ var formatDistanceLocale = {
     other: '{{count}} dies'
   },
 
-  aboutXMonths: {
+  aboutXWeeks: {
     one: 'aproximadament un mes',
     other: 'aproximadament {{count}} mesos'
+  },
+
+  xWeeks: {
+    one: '1 mes', // TODO
+    other: '{{count}} mesos' // TODO
+  },
+
+  aboutXMonths: {
+    one: 'aproximadament un mes', // TODO
+    other: 'aproximadament {{count}} mesos' // TODO
   },
 
   xMonths: {

--- a/src/locale/cs/_lib/formatDistance/index.js
+++ b/src/locale/cs/_lib/formatDistance/index.js
@@ -135,41 +135,41 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     one: {
-      regular: 'přibližně měsíc', // TODO
-      past: 'přibližně před měsícem', // TODO
-      future: 'přibližně za měsíc' // TODO
+      regular: 'přibližně týden',
+      past: 'přibližně před týdnem',
+      future: 'přibližně za týden'
     },
 
     few: {
-      regular: 'přibližně {{count}} měsíce', // TODO
-      past: 'přibližně před {{count}} měsíci', // TODO
-      future: 'přibližně za {{count}} měsíce' // TODO
+      regular: 'přibližně {{count}} týdny',
+      past: 'přibližně před {{count}} týdny',
+      future: 'přibližně za {{count}} týdny'
     },
 
     many: {
-      regular: 'přibližně {{count}} měsíců', // TODO
-      past: 'přibližně před {{count}} měsíci', // TODO
-      future: 'přibližně za {{count}} měsíců' // TODO
+      regular: 'přibližně {{count}} týdnů',
+      past: 'přibližně před {{count}} týdny',
+      future: 'přibližně za {{count}} týdnů'
     }
   },
 
   xWeeks: {
     one: {
-      regular: 'měsíc', // TODO
-      past: 'před měsícem', // TODO
-      future: 'za měsíc' // TODO
+      regular: 'týden',
+      past: 'před týdnem',
+      future: 'za týden'
     },
 
     few: {
-      regular: '{{count}} měsíce', // TODO
-      past: 'před {{count}} měsíci', // TODO
-      future: 'za {{count}} měsíce' // TODO
+      regular: '{{count}} týdny',
+      past: 'před {{count}} týdny',
+      future: 'za {{count}} týdny'
     },
 
     many: {
-      regular: '{{count}} měsíců', // TODO
-      past: 'před {{count}} měsíci', // TODO
-      future: 'za {{count}} měsíců' // TODO
+      regular: '{{count}} týdnů',
+      past: 'před {{count}} týdny',
+      future: 'za {{count}} týdnů'
     }
   },
 

--- a/src/locale/cs/_lib/formatDistance/index.js
+++ b/src/locale/cs/_lib/formatDistance/index.js
@@ -132,17 +132,60 @@ var formatDistanceLocale = {
       future: 'za {{count}} dní'
     }
   },
+
+  aboutXWeeks: {
+    one: {
+      regular: 'přibližně měsíc', // TODO
+      past: 'přibližně před měsícem', // TODO
+      future: 'přibližně za měsíc' // TODO
+    },
+
+    few: {
+      regular: 'přibližně {{count}} měsíce', // TODO
+      past: 'přibližně před {{count}} měsíci', // TODO
+      future: 'přibližně za {{count}} měsíce' // TODO
+    },
+
+    many: {
+      regular: 'přibližně {{count}} měsíců', // TODO
+      past: 'přibližně před {{count}} měsíci', // TODO
+      future: 'přibližně za {{count}} měsíců' // TODO
+    }
+  },
+
+  xWeeks: {
+    one: {
+      regular: 'měsíc', // TODO
+      past: 'před měsícem', // TODO
+      future: 'za měsíc' // TODO
+    },
+
+    few: {
+      regular: '{{count}} měsíce', // TODO
+      past: 'před {{count}} měsíci', // TODO
+      future: 'za {{count}} měsíce' // TODO
+    },
+
+    many: {
+      regular: '{{count}} měsíců', // TODO
+      past: 'před {{count}} měsíci', // TODO
+      future: 'za {{count}} měsíců' // TODO
+    }
+  },
+
   aboutXMonths: {
     one: {
       regular: 'přibližně měsíc',
       past: 'přibližně před měsícem',
       future: 'přibližně za měsíc'
     },
+
     few: {
       regular: 'přibližně {{count}} měsíce',
       past: 'přibližně před {{count}} měsíci',
       future: 'přibližně za {{count}} měsíce'
     },
+
     many: {
       regular: 'přibližně {{count}} měsíců',
       past: 'přibližně před {{count}} měsíci',
@@ -156,11 +199,13 @@ var formatDistanceLocale = {
       past: 'před měsícem',
       future: 'za měsíc'
     },
+
     few: {
       regular: '{{count}} měsíce',
       past: 'před {{count}} měsíci',
       future: 'za {{count}} měsíce'
     },
+
     many: {
       regular: '{{count}} měsíců',
       past: 'před {{count}} měsíci',

--- a/src/locale/cy/_lib/formatDistance/index.js
+++ b/src/locale/cy/_lib/formatDistance/index.js
@@ -39,17 +39,17 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'tua 1 mis', // TODO
-    two: 'tua 2 fis', // TODO
-    other: 'tua {{count}} mis' // TODO
+    one: 'tua 1 wythnos',
+    two: 'tua pythefnos',
+    other: 'tua {{count}} wythnos'
   },
 
   xWeeks: {
-    one: '1 mis', // TODO
-    two: '2 fis', // TODO
-    other: '{{count}} mis' // TODO
+    one: '1 wythnos',
+    two: 'pythefnos',
+    other: '{{count}} wythnos'
   },
-
+  
   aboutXMonths: {
     one: 'tua 1 mis',
     two: 'tua 2 fis',

--- a/src/locale/cy/_lib/formatDistance/index.js
+++ b/src/locale/cy/_lib/formatDistance/index.js
@@ -38,6 +38,18 @@ var formatDistanceLocale = {
     other: '{{count}} diwrnod'
   },
 
+  aboutXWeeks: {
+    one: 'tua 1 mis', // TODO
+    two: 'tua 2 fis', // TODO
+    other: 'tua {{count}} mis' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mis', // TODO
+    two: '2 fis', // TODO
+    other: '{{count}} mis' // TODO
+  },
+
   aboutXMonths: {
     one: 'tua 1 mis',
     two: 'tua 2 fis',

--- a/src/locale/da/_lib/formatDistance/index.js
+++ b/src/locale/da/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} dage'
   },
 
+  aboutXWeeks: {
+    one: 'cirka 1 måned', // TODO
+    other: 'cirka {{count}} måneder' // TODO
+  },
+
+  xWeeks: {
+    one: '1 måned', // TODO
+    other: '{{count}} måneder' // TODO
+  },
+
   aboutXMonths: {
     one: 'cirka 1 måned',
     other: 'cirka {{count}} måneder'

--- a/src/locale/da/_lib/formatDistance/index.js
+++ b/src/locale/da/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'cirka 1 måned', // TODO
-    other: 'cirka {{count}} måneder' // TODO
+    one: 'cirka 1 uge',
+    other: 'cirka {{count}} uger'
   },
 
   xWeeks: {
-    one: '1 måned', // TODO
-    other: '{{count}} måneder' // TODO
+    one: '1 uge',
+    other: '{{count}} uger'
   },
 
   aboutXMonths: {

--- a/src/locale/de/_lib/formatDistance/index.js
+++ b/src/locale/de/_lib/formatDistance/index.js
@@ -79,7 +79,28 @@ var formatDistanceLocale = {
       one: 'einem Tag',
       other: '{{count}} Tagen'
     }
+  },
 
+  aboutXWeeks: {
+    standalone: {
+      one: 'etwa ein Monat', // TODO
+      other: 'etwa {{count}} Monate' // TODO
+    },
+    withPreposition: {
+      one: 'etwa einem Monat', // TODO
+      other: 'etwa {{count}} Monaten' // TODO
+    }
+  },
+
+  xWeeks: {
+    standalone: {
+      one: 'ein Monat', // TODO
+      other: '{{count}} Monate' // TODO
+    },
+    withPreposition: {
+      one: 'einem Monat', // TODO
+      other: '{{count}} Monaten' // TODO
+    }
   },
 
   aboutXMonths: {
@@ -149,7 +170,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var usageGroup = options.addSuffix

--- a/src/locale/de/_lib/formatDistance/index.js
+++ b/src/locale/de/_lib/formatDistance/index.js
@@ -83,23 +83,23 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     standalone: {
-      one: 'etwa ein Monat', // TODO
-      other: 'etwa {{count}} Monate' // TODO
+      one: 'etwa ein Woche',
+      other: 'etwa {{count}} Wochen'
     },
     withPreposition: {
-      one: 'etwa einem Monat', // TODO
-      other: 'etwa {{count}} Monaten' // TODO
+      one: 'etwa einem Woche',
+      other: 'etwa {{count}} Wochen'
     }
   },
 
   xWeeks: {
     standalone: {
-      one: 'ein Monat', // TODO
-      other: '{{count}} Monate' // TODO
+      one: 'ein Woche',
+      other: '{{count}} Wochen'
     },
     withPreposition: {
-      one: 'einem Monat', // TODO
-      other: '{{count}} Monaten' // TODO
+      one: 'einem Woche',
+      other: '{{count}} Wochen'
     }
   },
 

--- a/src/locale/el/_lib/formatDistance/index.js
+++ b/src/locale/el/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'περίπου 1 μήνας', // TODO
-    other: 'περίπου {{count}} μήνες' // TODO
+    one: 'περίπου 1 εβδομάδα',
+    other: 'περίπου {{count}} εβδομάδες'
   },
 
   xWeeks: {
-    one: '1 μήνας', // TODO
-    other: '{{count}} μήνες' // TODO
+    one: '1 εβδομάδα',
+    other: '{{count}} εβδομάδες'
   },
 
   aboutXMonths: {

--- a/src/locale/el/_lib/formatDistance/index.js
+++ b/src/locale/el/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} ημέρες'
   },
 
+  aboutXWeeks: {
+    one: 'περίπου 1 μήνας', // TODO
+    other: 'περίπου {{count}} μήνες' // TODO
+  },
+
+  xWeeks: {
+    one: '1 μήνας', // TODO
+    other: '{{count}} μήνες' // TODO
+  },
+
   aboutXMonths: {
     one: 'περίπου 1 μήνας',
     other: 'περίπου {{count}} μήνες'

--- a/src/locale/en-CA/_lib/formatDistance/index.js
+++ b/src/locale/en-CA/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} days'
   },
 
+  aboutXWeeks: {
+    one: 'about a week',
+    other: 'about {{count}} weeks'
+  },
+
+  xWeeks: {
+    one: 'a week',
+    other: '{{count}} weeks'
+  },
+
   aboutXMonths: {
     one: 'about a month',
     other: 'about {{count}} months'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/eo/_lib/formatDistance/index.js
+++ b/src/locale/eo/_lib/formatDistance/index.js
@@ -42,13 +42,13 @@ var formatDistanceLocale = {
   },
 
   xWeeks: {
-    one: '1 monato', // TODO
-    other: '{{count}} monatoj' // TODO
+    one: '1 semajno',
+    other: '{{count}} semajnoj'
   },
 
   aboutXWeeks: {
-    one: 'proksimume 1 jaro', // TODO
-    other: 'proksimume {{count}} jaroj' // TODO
+    one: 'proksimume 1 semajno',
+    other: 'proksimume {{count}} semajnoj'
   },
 
   xMonths: {

--- a/src/locale/eo/_lib/formatDistance/index.js
+++ b/src/locale/eo/_lib/formatDistance/index.js
@@ -41,6 +41,16 @@ var formatDistanceLocale = {
     other: 'proksimume {{count}} monatoj'
   },
 
+  xWeeks: {
+    one: '1 monato', // TODO
+    other: '{{count}} monatoj' // TODO
+  },
+
+  aboutXWeeks: {
+    one: 'proksimume 1 jaro', // TODO
+    other: 'proksimume {{count}} jaroj' // TODO
+  },
+
   xMonths: {
     one: '1 monato',
     other: '{{count}} monatoj'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/es/_lib/formatDistance/index.js
+++ b/src/locale/es/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} días'
   },
 
+  aboutXWeeks: {
+    one: 'alrededor de 1 mes', // TODO
+    other: 'alrededor de {{count}} meses' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mes', // TODO
+    other: '{{count}} meses' // TODO
+  },
+
   aboutXMonths: {
     one: 'alrededor de 1 mes',
     other: 'alrededor de {{count}} meses'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/es/_lib/formatDistance/index.js
+++ b/src/locale/es/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'alrededor de 1 mes', // TODO
-    other: 'alrededor de {{count}} meses' // TODO
+    one: 'alrededor de 1 semana',
+    other: 'alrededor de {{count}} semanas'
   },
 
   xWeeks: {
-    one: '1 mes', // TODO
-    other: '{{count}} meses' // TODO
+    one: '1 semana',
+    other: '{{count}} semanas'
   },
 
   aboutXMonths: {

--- a/src/locale/et/_lib/formatDistance/index.js
+++ b/src/locale/et/_lib/formatDistance/index.js
@@ -83,23 +83,23 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     standalone: {
-      one: 'umbes üks kuu', // TODO
-      other: 'umbes {{count}} kuud' // TODO
+      one: 'umbes üks nädal',
+      other: 'umbes {{count}} nädalat'
     },
     withPreposition: {
-      one: 'umbes ühe kuu', // TODO
-      other: 'umbes {{count}} kuu' // TODO
+      one: 'umbes ühe nädala',
+      other: 'umbes {{count}} nädala'
     }
   },
 
   xWeeks: {
     standalone: {
-      one: 'üks kuu', // TODO
-      other: '{{count}} kuud' // TODO
+      one: 'üks nädal',
+      other: '{{count}} nädalat'
     },
     withPreposition: {
-      one: 'ühe kuu', // TODO
-      other: '{{count}} kuu' // TODO
+      one: 'ühe nädala',
+      other: '{{count}} nädala'
     }
   },
 

--- a/src/locale/et/_lib/formatDistance/index.js
+++ b/src/locale/et/_lib/formatDistance/index.js
@@ -79,7 +79,28 @@ var formatDistanceLocale = {
       one: 'ühe päeva',
       other: '{{count}} päeva'
     }
+  },
 
+  aboutXWeeks: {
+    standalone: {
+      one: 'umbes üks kuu', // TODO
+      other: 'umbes {{count}} kuud' // TODO
+    },
+    withPreposition: {
+      one: 'umbes ühe kuu', // TODO
+      other: 'umbes {{count}} kuu' // TODO
+    }
+  },
+
+  xWeeks: {
+    standalone: {
+      one: 'üks kuu', // TODO
+      other: '{{count}} kuud' // TODO
+    },
+    withPreposition: {
+      one: 'ühe kuu', // TODO
+      other: '{{count}} kuu' // TODO
+    }
   },
 
   aboutXMonths: {
@@ -149,7 +170,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var usageGroup = options.addSuffix

--- a/src/locale/fa-IR/_lib/formatDistance/index.js
+++ b/src/locale/fa-IR/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'حدود 1 ماه', // TODO
-    other: 'حدود {{count}} ماه' // TODO
+    one: 'حدود 1 هفته',
+    other: 'حدود {{count}} هفته'
   },
 
   xWeeks: {
-    one: '1 ماه', // TODO
-    other: '{{count}} ماه' // TODO
+    one: '1 هفته',
+    other: '{{count}} هفته'
   },
 
   aboutXMonths: {

--- a/src/locale/fa-IR/_lib/formatDistance/index.js
+++ b/src/locale/fa-IR/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} روز'
   },
 
+  aboutXWeeks: {
+    one: 'حدود 1 ماه', // TODO
+    other: 'حدود {{count}} ماه' // TODO
+  },
+
+  xWeeks: {
+    one: '1 ماه', // TODO
+    other: '{{count}} ماه' // TODO
+  },
+
   aboutXMonths: {
     one: 'حدود 1 ماه',
     other: 'حدود {{count}} ماه'

--- a/src/locale/fi/_lib/formatDistance/index.js
+++ b/src/locale/fi/_lib/formatDistance/index.js
@@ -15,7 +15,7 @@ function futureDays(text) {
 }
 
 function futureWeeks(text) {
-  return text.replace(/(kuukausi|kuukautta)/, 'kuukauden') // TODO
+  return text.replace(/(viikko|viikkoa)/, 'viikon')
 }
 
 function futureMonths(text) {
@@ -78,15 +78,15 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'noin kuukausi', // TODO
-    other: 'noin {{count}} kuukautta', // TODO
+    one: 'noin viikko',
+    other: 'noin {{count}} viikkoa',
     futureTense: futureWeeks
   },
 
   xWeeks: {
-    one: 'kuukausi', // TODO
-    other: '{{count}} kuukautta', // TODO
-    futureTense: futureWeeks // TODO
+    one: 'viikko',
+    other: '{{count}} viikkoa',
+    futureTense: futureWeeks
   },
 
   aboutXMonths: {

--- a/src/locale/fi/_lib/formatDistance/index.js
+++ b/src/locale/fi/_lib/formatDistance/index.js
@@ -14,6 +14,10 @@ function futureDays(text) {
   return text.replace(/päivää?/, 'päivän')
 }
 
+function futureWeeks(text) {
+  return text.replace(/(kuukausi|kuukautta)/, 'kuukauden') // TODO
+}
+
 function futureMonths(text) {
   return text.replace(/(kuukausi|kuukautta)/, 'kuukauden')
 }
@@ -71,6 +75,18 @@ var formatDistanceLocale = {
     one: 'päivä',
     other: '{{count}} päivää',
     futureTense: futureDays
+  },
+
+  aboutXWeeks: {
+    one: 'noin kuukausi', // TODO
+    other: 'noin {{count}} kuukautta', // TODO
+    futureTense: futureWeeks
+  },
+
+  xWeeks: {
+    one: 'kuukausi', // TODO
+    other: '{{count}} kuukautta', // TODO
+    futureTense: futureWeeks // TODO
   },
 
   aboutXMonths: {

--- a/src/locale/fil/_lib/formatDistance/index.js
+++ b/src/locale/fil/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} araw'
   },
 
+  aboutXWeeks: {
+    one: 'mga 1 buwan', // TODO
+    other: 'mga {{count}} buwan' // TODO
+  },
+
+  xWeeks: {
+    one: '1 buwan', // TODO
+    other: '{{count}} buwan' // TODO
+  },
+
   aboutXMonths: {
     one: 'mga 1 buwan',
     other: 'mga {{count}} buwan'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/fr-CH/_lib/formatDistance/index.js
+++ b/src/locale/fr-CH/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} jours'
   },
 
+  aboutXWeeks: {
+    one: 'environ 1 mois', // TODO
+    other: 'environ {{count}} mois' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mois', // TODO
+    other: '{{count}} mois' // TODO
+  },
+
   aboutXMonths: {
     one: 'environ 1 mois',
     other: 'environ {{count}} mois'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/fr-CH/_lib/formatDistance/index.js
+++ b/src/locale/fr-CH/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'environ 1 mois', // TODO
-    other: 'environ {{count}} mois' // TODO
+    one: 'environ 1 semaine',
+    other: 'environ {{count}} semaines'
   },
 
   xWeeks: {
-    one: '1 mois', // TODO
-    other: '{{count}} mois' // TODO
+    one: '1 semaine',
+    other: '{{count}} semaines'
   },
 
   aboutXMonths: {

--- a/src/locale/fr/_lib/formatDistance/index.js
+++ b/src/locale/fr/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} jours'
   },
 
+  aboutXWeeks: {
+    one: 'environ 1 mois', // TODO
+    other: 'environ {{count}} mois' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mois', // TODO
+    other: '{{count}} mois' // TODO
+  },
+
   aboutXMonths: {
     one: 'environ 1 mois',
     other: 'environ {{count}} mois'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/fr/_lib/formatDistance/index.js
+++ b/src/locale/fr/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'environ 1 mois', // TODO
-    other: 'environ {{count}} mois' // TODO
+    one: 'environ 1 semaine',
+    other: 'environ {{count}} semaines'
   },
 
   xWeeks: {
-    one: '1 mois', // TODO
-    other: '{{count}} mois' // TODO
+    one: '1 semaine',
+    other: '{{count}} semaines'
   },
 
   aboutXMonths: {

--- a/src/locale/gl/_lib/formatDistance/index.js
+++ b/src/locale/gl/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} días'
   },
 
+  aboutXWeeks: {
+    one: 'arredor de 1 mes', // TODO
+    other: 'arredor de {{count}} meses' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mes', // TODO
+    other: '{{count}} meses' // TODO
+  },
+
   aboutXMonths: {
     one: 'arredor de 1 mes',
     other: 'arredor de {{count}} meses'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/gl/_lib/formatDistance/index.js
+++ b/src/locale/gl/_lib/formatDistance/index.js
@@ -22,7 +22,7 @@ var formatDistanceLocale = {
   },
 
   aboutXHours: {
-    one: 'arredor de 1 hora',
+    one: 'arredor dunha hora',
     other: 'arredor de {{count}} horas'
   },
 
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'arredor de 1 mes', // TODO
-    other: 'arredor de {{count}} meses' // TODO
+    one: 'arredor dunha semana',
+    other: 'arredor de {{count}} semanas'
   },
 
   xWeeks: {
-    one: '1 mes', // TODO
-    other: '{{count}} meses' // TODO
+    one: '1 semana',
+    other: '{{count}} semanas'
   },
 
   aboutXMonths: {
@@ -57,7 +57,7 @@ var formatDistanceLocale = {
   },
 
   aboutXYears: {
-    one: 'arredor de 1 ano',
+    one: 'arredor dun ano',
     other: 'arredor de {{count}} anos'
   },
 
@@ -67,13 +67,13 @@ var formatDistanceLocale = {
   },
 
   overXYears: {
-    one: 'mais de 1 ano',
-    other: 'mais de {{count}} anos'
+    one: 'máis dun ano',
+    other: 'máis de {{count}} anos'
   },
 
   almostXYears: {
-    one: 'casi 1 ano',
-    other: 'casi {{count}} anos'
+    one: 'case un ano',
+    other: 'case {{count}} anos'
   }
 }
 

--- a/src/locale/gl/snapshot.md
+++ b/src/locale/gl/snapshot.md
@@ -196,17 +196,17 @@ If now is January 1st, 2000, 00:00.
 | 2004-01-01T00:00:00.000Z | arredor de 4 anos  | arredor de 4 anos      | en arredor de 4 anos   |
 | 2003-01-01T00:00:00.000Z | arredor de 3 anos  | arredor de 3 anos      | en arredor de 3 anos   |
 | 2002-01-01T00:00:00.000Z | arredor de 2 anos  | arredor de 2 anos      | en arredor de 2 anos   |
-| 2001-06-01T00:00:00.000Z | mais de 1 ano      | mais de 1 ano          | en mais de 1 ano       |
-| 2001-02-01T00:00:00.000Z | arredor de 1 ano   | arredor de 1 ano       | en arredor de 1 ano    |
-| 2001-01-01T00:00:00.000Z | arredor de 1 ano   | arredor de 1 ano       | en arredor de 1 ano    |
+| 2001-06-01T00:00:00.000Z | máis dun ano       | máis dun ano           | en máis dun ano        |
+| 2001-02-01T00:00:00.000Z | arredor dun ano    | arredor dun ano        | en arredor dun ano     |
+| 2001-01-01T00:00:00.000Z | arredor dun ano    | arredor dun ano        | en arredor dun ano     |
 | 2000-06-01T00:00:00.000Z | 5 meses            | 5 meses                | en 5 meses             |
 | 2000-03-01T00:00:00.000Z | 2 meses            | 2 meses                | en 2 meses             |
 | 2000-02-01T00:00:00.000Z | arredor de 1 mes   | arredor de 1 mes       | en arredor de 1 mes    |
 | 2000-01-15T00:00:00.000Z | 14 días            | 14 días                | en 14 días             |
 | 2000-01-02T00:00:00.000Z | 1 día              | 1 día                  | en 1 día               |
 | 2000-01-01T06:00:00.000Z | arredor de 6 horas | arredor de 6 horas     | en arredor de 6 horas  |
-| 2000-01-01T01:00:00.000Z | arredor de 1 hora  | arredor de 1 hora      | en arredor de 1 hora   |
-| 2000-01-01T00:45:00.000Z | arredor de 1 hora  | arredor de 1 hora      | en arredor de 1 hora   |
+| 2000-01-01T01:00:00.000Z | arredor dunha hora | arredor dunha hora     | en arredor dunha hora  |
+| 2000-01-01T00:45:00.000Z | arredor dunha hora | arredor dunha hora     | en arredor dunha hora  |
 | 2000-01-01T00:30:00.000Z | 30 minutos         | 30 minutos             | en 30 minutos          |
 | 2000-01-01T00:15:00.000Z | 15 minutos         | 15 minutos             | en 15 minutos          |
 | 2000-01-01T00:01:00.000Z | 1 minuto           | 1 minuto               | en 1 minuto            |
@@ -220,17 +220,17 @@ If now is January 1st, 2000, 00:00.
 | 1999-12-31T23:59:00.000Z | 1 minuto           | 1 minuto               | hai 1 minuto           |
 | 1999-12-31T23:45:00.000Z | 15 minutos         | 15 minutos             | hai 15 minutos         |
 | 1999-12-31T23:30:00.000Z | 30 minutos         | 30 minutos             | hai 30 minutos         |
-| 1999-12-31T23:15:00.000Z | arredor de 1 hora  | arredor de 1 hora      | hai arredor de 1 hora  |
-| 1999-12-31T23:00:00.000Z | arredor de 1 hora  | arredor de 1 hora      | hai arredor de 1 hora  |
+| 1999-12-31T23:15:00.000Z | arredor dunha hora | arredor dunha hora     | hai arredor dunha hora |
+| 1999-12-31T23:00:00.000Z | arredor dunha hora | arredor dunha hora     | hai arredor dunha hora |
 | 1999-12-31T18:00:00.000Z | arredor de 6 horas | arredor de 6 horas     | hai arredor de 6 horas |
 | 1999-12-30T00:00:00.000Z | 2 días             | 2 días                 | hai 2 días             |
 | 1999-12-15T00:00:00.000Z | 17 días            | 17 días                | hai 17 días            |
 | 1999-12-01T00:00:00.000Z | arredor de 1 mes   | arredor de 1 mes       | hai arredor de 1 mes   |
 | 1999-11-01T00:00:00.000Z | 2 meses            | 2 meses                | hai 2 meses            |
 | 1999-06-01T00:00:00.000Z | 7 meses            | 7 meses                | hai 7 meses            |
-| 1999-01-01T00:00:00.000Z | arredor de 1 ano   | arredor de 1 ano       | hai arredor de 1 ano   |
-| 1998-12-01T00:00:00.000Z | arredor de 1 ano   | arredor de 1 ano       | hai arredor de 1 ano   |
-| 1998-06-01T00:00:00.000Z | mais de 1 ano      | mais de 1 ano          | hai mais de 1 ano      |
+| 1999-01-01T00:00:00.000Z | arredor dun ano    | arredor dun ano        | hai arredor dun ano    |
+| 1998-12-01T00:00:00.000Z | arredor dun ano    | arredor dun ano        | hai arredor dun ano    |
+| 1998-06-01T00:00:00.000Z | máis dun ano       | máis dun ano           | hai máis dun ano       |
 | 1998-01-01T00:00:00.000Z | arredor de 2 anos  | arredor de 2 anos      | hai arredor de 2 anos  |
 | 1997-01-01T00:00:00.000Z | arredor de 3 anos  | arredor de 3 anos      | hai arredor de 3 anos  |
 | 1996-01-01T00:00:00.000Z | arredor de 4 anos  | arredor de 4 anos      | hai arredor de 4 anos  |

--- a/src/locale/gu/_lib/formatDistance/index.js
+++ b/src/locale/gu/_lib/formatDistance/index.js
@@ -37,6 +37,16 @@ var formatDistanceLocale = {
     other: '{{count}} દિવસ'
   },
 
+  aboutXWeeks: {
+    one: 'આશરે 1 મહિનો', // TODO
+    other: 'આશરે {{count}} મહિના' // TODO
+  },
+
+  xWeeks: {
+    one: '1 મહિનો', // TODO
+    other: '{{count}} મહિના' // TODO
+  },
+
   aboutXMonths: {
     one: 'આશરે 1 મહિનો',
     other: 'આશરે {{count}} મહિના'

--- a/src/locale/gu/_lib/formatDistance/index.js
+++ b/src/locale/gu/_lib/formatDistance/index.js
@@ -38,13 +38,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'આશરે 1 મહિનો', // TODO
-    other: 'આશરે {{count}} મહિના' // TODO
+    one: 'આશરે 1 અઠવાડિયું',
+    other: 'આશરે {{count}} અઠવાડિયા'
   },
 
   xWeeks: {
-    one: '1 મહિનો', // TODO
-    other: '{{count}} મહિના' // TODO
+    one: '1 અઠવાડિયું',
+    other: '{{count}} અઠવાડિયા'
   },
 
   aboutXMonths: {

--- a/src/locale/he/_lib/formatDistance/index.js
+++ b/src/locale/he/_lib/formatDistance/index.js
@@ -43,6 +43,18 @@ var formatDistanceLocale = {
     other: '{{count}} ימים'
   },
 
+  aboutXWeeks: {
+    one: 'בערך חודש', // TODO
+    two: 'בערך חודשיים', // TODO
+    other: 'בערך {{count}} חודשים' // TODO
+  },
+
+  xWeeks: {
+    one: 'חודש', // TODO
+    two: 'חודשיים', // TODO
+    other: '{{count}} חודשים' // TODO
+  },
+
   aboutXMonths: {
     one: 'בערך חודש',
     two: 'בערך חודשיים',
@@ -80,7 +92,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   // Return word instead of `in one day` or `one day ago`

--- a/src/locale/he/_lib/formatDistance/index.js
+++ b/src/locale/he/_lib/formatDistance/index.js
@@ -44,15 +44,15 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'בערך חודש', // TODO
-    two: 'בערך חודשיים', // TODO
-    other: 'בערך {{count}} חודשים' // TODO
+    one: 'בערך שבוע',
+    two: 'בערך שבועיים',
+    other: 'בערך {{count}} שבועות'
   },
 
   xWeeks: {
-    one: 'חודש', // TODO
-    two: 'חודשיים', // TODO
-    other: '{{count}} חודשים' // TODO
+    one: 'שבוע',
+    two: 'שבועיים',
+    other: '{{count}} שבועות'
   },
 
   aboutXMonths: {

--- a/src/locale/hi/_lib/formatDistance/index.js
+++ b/src/locale/hi/_lib/formatDistance/index.js
@@ -39,13 +39,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'लगभग १ महीना', // TODO
-    other: 'लगभग {{count}} महीने' // TODO
+    one: 'लगभग १ सप्ताह',
+    other: 'लगभग {{count}} सप्ताह'
   },
 
   xWeeks: {
-    one: '१ महीना', // TODO
-    other: '{{count}} महीने' // TODO
+    one: '१ सप्ताह',
+    other: '{{count}} सप्ताह'
   },
 
   aboutXMonths: {

--- a/src/locale/hi/_lib/formatDistance/index.js
+++ b/src/locale/hi/_lib/formatDistance/index.js
@@ -38,6 +38,16 @@ var formatDistanceLocale = {
     other: '{{count}} दिन'
   },
 
+  aboutXWeeks: {
+    one: 'लगभग १ महीना', // TODO
+    other: 'लगभग {{count}} महीने' // TODO
+  },
+
+  xWeeks: {
+    one: '१ महीना', // TODO
+    other: '{{count}} महीने' // TODO
+  },
+
   aboutXMonths: {
     one: 'लगभग १ महीना',
     other: 'लगभग {{count}} महीने'

--- a/src/locale/hr/_lib/formatDistance/index.js
+++ b/src/locale/hr/_lib/formatDistance/index.js
@@ -71,6 +71,26 @@ var formatDistanceLocale = {
     other: '{{count}} dana'
   },
 
+  aboutXWeeks: {
+    one: {
+      standalone: 'oko 1 mjesec', // TODO
+      withPrepositionAgo: 'oko 1 mjesec', // TODO
+      withPrepositionIn: 'oko 1 mjesec' // TODO
+    },
+    dual: 'oko {{count}} mjeseca', // TODO
+    other: 'oko {{count}} mjeseci' // TODO
+  },
+
+  xWeeks: {
+    one: {
+      standalone: '1 mjesec', // TODO
+      withPrepositionAgo: '1 mjesec', // TODO
+      withPrepositionIn: '1 mjesec' // TODO
+    },
+    dual: '{{count}} mjeseca', // TODO
+    other: '{{count}} mjeseci' // TODO
+  },
+
   aboutXMonths: {
     one: {
       standalone: 'oko 1 mjesec',
@@ -132,7 +152,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result
@@ -150,7 +170,8 @@ export default function formatDistance (token, count, options) {
       result = formatDistanceLocale[token].one.standalone
     }
   } else if (
-    count % 10 > 1 && count % 10 < 5 && // if last digit is between 2 and 4
+    count % 10 > 1 &&
+    count % 10 < 5 && // if last digit is between 2 and 4
     String(count).substr(-2, 1) !== '1' // unless the 2nd to last digit is "1"
   ) {
     result = formatDistanceLocale[token].dual.replace('{{count}}', count)

--- a/src/locale/hr/_lib/formatDistance/index.js
+++ b/src/locale/hr/_lib/formatDistance/index.js
@@ -73,22 +73,22 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     one: {
-      standalone: 'oko 1 mjesec', // TODO
-      withPrepositionAgo: 'oko 1 mjesec', // TODO
-      withPrepositionIn: 'oko 1 mjesec' // TODO
+      standalone: 'oko 1 tjedan',
+      withPrepositionAgo: 'oko 1 tjedan',
+      withPrepositionIn: 'oko 1 tjedan'
     },
-    dual: 'oko {{count}} mjeseca', // TODO
-    other: 'oko {{count}} mjeseci' // TODO
+    dual: 'oko {{count}} tjedna',
+    other: 'oko {{count}} tjedana'
   },
 
   xWeeks: {
     one: {
-      standalone: '1 mjesec', // TODO
-      withPrepositionAgo: '1 mjesec', // TODO
-      withPrepositionIn: '1 mjesec' // TODO
+      standalone: '1 tjedan',
+      withPrepositionAgo: '1 tjedan',
+      withPrepositionIn: '1 tjedan'
     },
-    dual: '{{count}} mjeseca', // TODO
-    other: '{{count}} mjeseci' // TODO
+    dual: '{{count}} tjedna',
+    other: '{{count}} tjedana'
   },
 
   aboutXMonths: {

--- a/src/locale/hu/_lib/formatDistance/index.js
+++ b/src/locale/hu/_lib/formatDistance/index.js
@@ -38,6 +38,12 @@ function translate(number, addSuffix, key, comparison) {
       if (comparison === 1) return num + ' nap múlva'
       return num + ' nap'
 
+    case 'xweeks':
+      if (comparison === -1 && addSuffix) return num + ' hónappal ezelőtt' // TODO
+      if (comparison === -1 && !addSuffix) return num + ' hónapja' // TODO
+      if (comparison === 1) return num + ' hónap múlva' // TODO
+      return num + ' hónap' // TODO
+
     case 'xmonths':
       if (comparison === -1 && addSuffix) return num + ' hónappal ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' hónapja'

--- a/src/locale/hu/_lib/formatDistance/index.js
+++ b/src/locale/hu/_lib/formatDistance/index.js
@@ -39,10 +39,10 @@ function translate(number, addSuffix, key, comparison) {
       return num + ' nap'
 
     case 'xweeks':
-      if (comparison === -1 && addSuffix) return num + ' hónappal ezelőtt' // TODO
-      if (comparison === -1 && !addSuffix) return num + ' hónapja' // TODO
-      if (comparison === 1) return num + ' hónap múlva' // TODO
-      return num + ' hónap' // TODO
+      if (comparison === -1 && addSuffix) return num + ' héttel ezelőtt'
+      if (comparison === -1 && !addSuffix) return num + ' hete'
+      if (comparison === 1) return num + ' hét múlva'
+      return num + ' hét'
 
     case 'xmonths':
       if (comparison === -1 && addSuffix) return num + ' hónappal ezelőtt'

--- a/src/locale/hy/_lib/formatDistance/index.js
+++ b/src/locale/hy/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'մոտ 1 ամիս', // TODO
-    other: 'մոտ {{count}} ամիս' // TODO
+    one: 'մոտ 1 շաբաթ',
+    other: 'մոտ {{count}} շաբաթ'
   },
 
   xWeeks: {
-    one: '1 ամիս', // TODO
-    other: '{{count}} ամիս' // TODO
+    one: '1 շաբաթ',
+    other: '{{count}} շաբաթ'
   },
 
   aboutXMonths: {

--- a/src/locale/hy/_lib/formatDistance/index.js
+++ b/src/locale/hy/_lib/formatDistance/index.js
@@ -3,51 +3,74 @@ var formatDistanceLocale = {
     one: 'ավելի քիչ քան 1 վայրկյան',
     other: 'ավելի քիչ քան {{count}} վայրկյան'
   },
+
   xSeconds: {
     one: '1 վայրկյան',
     other: '{{count}} վայրկյան'
   },
+
   halfAMinute: 'կես րոպե',
+
   lessThanXMinutes: {
     one: 'ավելի քիչ քան 1 րոպե',
     other: 'ավելի քիչ քան {{count}} րոպե'
   },
+
   xMinutes: {
     one: '1 րոպե',
     other: '{{count}} րոպե'
   },
+
   aboutXHours: {
     one: 'մոտ 1 ժամ',
     other: 'մոտ {{count}} ժամ'
   },
+
   xHours: {
     one: '1 ժամ',
     other: '{{count}} ժամ'
   },
+
   xDays: {
     one: '1 օր',
     other: '{{count}} օր'
   },
+
+  aboutXWeeks: {
+    one: 'մոտ 1 ամիս', // TODO
+    other: 'մոտ {{count}} ամիս' // TODO
+  },
+
+  xWeeks: {
+    one: '1 ամիս', // TODO
+    other: '{{count}} ամիս' // TODO
+  },
+
   aboutXMonths: {
     one: 'մոտ 1 ամիս',
     other: 'մոտ {{count}} ամիս'
   },
+
   xMonths: {
     one: '1 ամիս',
     other: '{{count}} ամիս'
   },
+
   aboutXYears: {
     one: 'մոտ 1 տարի',
     other: 'մոտ {{count}} տարի'
   },
+
   xYears: {
     one: '1 տարի',
     other: '{{count}} տարի'
   },
+
   overXYears: {
     one: 'ավելի քան 1 տարի',
     other: 'ավելի քան {{count}} տարի'
   },
+
   almostXYears: {
     one: 'համարյա 1 տարի',
     other: 'համարյա {{count}} տարի'

--- a/src/locale/id/_lib/formatDistance/index.js
+++ b/src/locale/id/_lib/formatDistance/index.js
@@ -42,8 +42,8 @@ var formatDistanceLocale = {
   },
 
   xWeeks: {
-    one: '1 bulan', // TODO
-    other: '{{count}} bulan' // TODO
+    one: '1 minggu',
+    other: '{{count}} minggu'
   },
 
   aboutXMonths: {

--- a/src/locale/id/_lib/formatDistance/index.js
+++ b/src/locale/id/_lib/formatDistance/index.js
@@ -37,8 +37,8 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'sekitar 1 bulan', // TODO
-    other: 'sekitar {{count}} bulan' // TODO
+    one: 'sekitar 1 minggu',
+    other: 'sekitar {{count}} minggu'
   },
 
   xWeeks: {

--- a/src/locale/id/_lib/formatDistance/index.js
+++ b/src/locale/id/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} hari'
   },
 
+  aboutXWeeks: {
+    one: 'sekitar 1 bulan', // TODO
+    other: 'sekitar {{count}} bulan' // TODO
+  },
+
+  xWeeks: {
+    one: '1 bulan', // TODO
+    other: '{{count}} bulan' // TODO
+  },
+
   aboutXMonths: {
     one: 'sekitar 1 bulan',
     other: 'sekitar {{count}} bulan'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/is/_lib/formatDistance/index.js
+++ b/src/locale/is/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} dagar'
   },
 
+  aboutXWeeks: {
+    one: 'u.þ.b. 1 mánuður', // TODO
+    other: 'u.þ.b. {{count}} mánuðir' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mánuður', // TODO
+    other: '{{count}} mánuðir' // TODO
+  },
+
   aboutXMonths: {
     one: 'u.þ.b. 1 mánuður',
     other: 'u.þ.b. {{count}} mánuðir'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/is/_lib/formatDistance/index.js
+++ b/src/locale/is/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'u.þ.b. 1 mánuður', // TODO
-    other: 'u.þ.b. {{count}} mánuðir' // TODO
+    one: 'um viku',
+    other: 'um {{count}} vikur'
   },
 
   xWeeks: {
-    one: '1 mánuður', // TODO
-    other: '{{count}} mánuðir' // TODO
+    one: '1 viku',
+    other: '{{count}} vikur'
   },
 
   aboutXMonths: {

--- a/src/locale/it/_lib/formatDistance/index.js
+++ b/src/locale/it/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'circa un mese', // TODO
-    other: 'circa {{count}} mesi' // TODO
+    one: 'circa una settimana',
+    other: 'circa {{count}} settimane'
   },
 
   xWeeks: {
-    one: 'un mese', // TODO
-    other: '{{count}} mesi' // TODO
+    one: 'una settimana',
+    other: '{{count}} settimane'
   },
 
   aboutXMonths: {

--- a/src/locale/it/_lib/formatDistance/index.js
+++ b/src/locale/it/_lib/formatDistance/index.js
@@ -22,18 +22,28 @@ var formatDistanceLocale = {
   },
 
   aboutXHours: {
-    one: 'circa un\'ora',
+    one: "circa un'ora",
     other: 'circa {{count}} ore'
   },
 
   xHours: {
-    one: 'un\'ora',
+    one: "un'ora",
     other: '{{count}} ore'
   },
 
   xDays: {
     one: 'un giorno',
     other: '{{count}} giorni'
+  },
+
+  aboutXWeeks: {
+    one: 'circa un mese', // TODO
+    other: 'circa {{count}} mesi' // TODO
+  },
+
+  xWeeks: {
+    one: 'un mese', // TODO
+    other: '{{count}} mesi' // TODO
   },
 
   aboutXMonths: {
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/ja/_lib/formatDistance/index.js
+++ b/src/locale/ja/_lib/formatDistance/index.js
@@ -41,13 +41,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: '約1か月', // TODO
-    other: '約{{count}}か月' // TODO
+    one: '約1週間',
+    other: '約{{count}}週間'
   },
 
   xWeeks: {
-    one: '1か月', // TODO
-    other: '{{count}}か月' // TODO
+    one: '1週間',
+    other: '{{count}}週間'
   },
 
   aboutXMonths: {

--- a/src/locale/ja/_lib/formatDistance/index.js
+++ b/src/locale/ja/_lib/formatDistance/index.js
@@ -40,6 +40,16 @@ var formatDistanceLocale = {
     other: '{{count}}日'
   },
 
+  aboutXWeeks: {
+    one: '約1か月', // TODO
+    other: '約{{count}}か月' // TODO
+  },
+
+  xWeeks: {
+    one: '1か月', // TODO
+    other: '{{count}}か月' // TODO
+  },
+
   aboutXMonths: {
     one: '約1か月',
     other: '約{{count}}か月'

--- a/src/locale/ka/_lib/formatDistance/index.js
+++ b/src/locale/ka/_lib/formatDistance/index.js
@@ -48,15 +48,15 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    past: 'დაახლოებით {{count}} თვის წინ', // TODO
-    present: 'დაახლოებით {{count}} თვე', // TODO
-    future: 'დაახლოებით {{count}} თვეში' // TODO
+    past: 'დაახლოებით {{count}} კვირას წინ',
+    present: 'დაახლოებით {{count}} კვირა',
+    future: 'დაახლოებით {{count}} კვირაში'
   },
 
   xWeeks: {
-    past: '{{count}} თვის წინ', // TODO
-    present: '{{count}} თვე', // TODO
-    future: '{{count}} თვეში' // TODO
+    past: '{{count}} კვირას კვირა',
+    present: '{{count}} კვირა',
+    future: '{{count}} კვირაში'
   },
 
   aboutXMonths: {

--- a/src/locale/ka/_lib/formatDistance/index.js
+++ b/src/locale/ka/_lib/formatDistance/index.js
@@ -47,6 +47,18 @@ var formatDistanceLocale = {
     future: '{{count}} დღეში'
   },
 
+  aboutXWeeks: {
+    past: 'დაახლოებით {{count}} თვის წინ', // TODO
+    present: 'დაახლოებით {{count}} თვე', // TODO
+    future: 'დაახლოებით {{count}} თვეში' // TODO
+  },
+
+  xWeeks: {
+    past: '{{count}} თვის წინ', // TODO
+    present: '{{count}} თვე', // TODO
+    future: '{{count}} თვეში' // TODO
+  },
+
   aboutXMonths: {
     past: 'დაახლოებით {{count}} თვის წინ',
     present: 'დაახლოებით {{count}} თვე',
@@ -84,7 +96,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/kk/_lib/formatDistance/index.js
+++ b/src/locale/kk/_lib/formatDistance/index.js
@@ -156,6 +156,27 @@ var formatDistanceLocale = {
     }
   }),
 
+  aboutXWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: 'шамамен {{count}} ай', // TODO
+      singularGenitive: 'шамамен {{count}} ай', // TODO
+      pluralGenitive: 'шамамен {{count}} ай' // TODO
+    },
+    future: {
+      singularNominative: 'шамамен {{count}} айдан кейін', // TODO
+      singularGenitive: 'шамамен {{count}} айдан кейін', // TODO
+      pluralGenitive: 'шамамен {{count}} айдан кейін' // TODO
+    }
+  }),
+
+  xWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: '{{count}} ай', // TODO
+      singularGenitive: '{{count}} ай', // TODO
+      pluralGenitive: '{{count}} ай' // TODO
+    }
+  }),
+
   aboutXMonths: buildLocalizeTokenFn({
     regular: {
       singularNominative: 'шамамен {{count}} ай',

--- a/src/locale/kk/_lib/formatDistance/index.js
+++ b/src/locale/kk/_lib/formatDistance/index.js
@@ -156,26 +156,15 @@ var formatDistanceLocale = {
     }
   }),
 
-  aboutXWeeks: buildLocalizeTokenFn({
-    regular: {
-      singularNominative: 'шамамен {{count}} ай', // TODO
-      singularGenitive: 'шамамен {{count}} ай', // TODO
-      pluralGenitive: 'шамамен {{count}} ай' // TODO
-    },
-    future: {
-      singularNominative: 'шамамен {{count}} айдан кейін', // TODO
-      singularGenitive: 'шамамен {{count}} айдан кейін', // TODO
-      pluralGenitive: 'шамамен {{count}} айдан кейін' // TODO
-    }
-  }),
+  aboutXWeeks: {
+    one: 'шамамен 1 апта',
+    other: 'шамамен {{count}} апта'
+  },
 
-  xWeeks: buildLocalizeTokenFn({
-    regular: {
-      singularNominative: '{{count}} ай', // TODO
-      singularGenitive: '{{count}} ай', // TODO
-      pluralGenitive: '{{count}} ай' // TODO
-    }
-  }),
+  xWeeks: {
+    one: '1 апта',
+    other: '{{count}} апта'
+  },
 
   aboutXMonths: buildLocalizeTokenFn({
     regular: {

--- a/src/locale/ko/_lib/formatDistance/index.js
+++ b/src/locale/ko/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: '약 1개월', // TODO
-    other: '약 {{count}}개월' // TODO
+    one: '약 1주',
+    other: '약 {{count}}주'
   },
 
   xWeeks: {
-    one: '1개월', // TODO
-    other: '{{count}}개월' // TODO
+    one: '1주',
+    other: '{{count}}주'
   },
 
   aboutXMonths: {

--- a/src/locale/ko/_lib/formatDistance/index.js
+++ b/src/locale/ko/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}}일'
   },
 
+  aboutXWeeks: {
+    one: '약 1개월', // TODO
+    other: '약 {{count}}개월' // TODO
+  },
+
+  xWeeks: {
+    one: '1개월', // TODO
+    other: '{{count}}개월' // TODO
+  },
+
   aboutXMonths: {
     one: '약 1개월',
     other: '약 {{count}}개월'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/lt/_lib/formatDistance/index.js
+++ b/src/locale/lt/_lib/formatDistance/index.js
@@ -85,8 +85,8 @@ var translations = {
   xhours_other: 'valandos_valandų_valandas',
   xdays_one: 'diena_dienos_dieną',
   xdays_other: 'dienos_dienų_dienas',
-  xweeks_one: 'mėnuo_mėnesio_mėnesį', // TODO
-  xweeks_other: 'mėnesiai_mėnesių_mėnesius', // TODO
+  xweeks_one: 'savaitė_savaitės_savaitę',
+  xweeks_other: 'savaitės_savaičių_savaites',
   xmonths_one: 'mėnuo_mėnesio_mėnesį',
   xmonths_other: 'mėnesiai_mėnesių_mėnesius',
   xyears_one: 'metai_metų_metus',

--- a/src/locale/lt/_lib/formatDistance/index.js
+++ b/src/locale/lt/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: translate
   },
 
+  aboutWeeks: {
+    one: translateSingular,
+    other: translate
+  },
+
+  xWeeks: {
+    one: translateSingular,
+    other: translate
+  },
+
   aboutXMonths: {
     one: translateSingular,
     other: translate
@@ -68,39 +78,41 @@ var formatDistanceLocale = {
 }
 
 var translations = {
-  'xseconds_other': 'sekundė_sekundžių_sekundes',
-  'xminutes_one': 'minutė_minutės_minutę',
-  'xminutes_other': 'minutės_minučių_minutes',
-  'xhours_one': 'valanda_valandos_valandą',
-  'xhours_other': 'valandos_valandų_valandas',
-  'xdays_one': 'diena_dienos_dieną',
-  'xdays_other': 'dienos_dienų_dienas',
-  'xmonths_one': 'mėnuo_mėnesio_mėnesį',
-  'xmonths_other': 'mėnesiai_mėnesių_mėnesius',
-  'xyears_one': 'metai_metų_metus',
-  'xyears_other': 'metai_metų_metus',
-  'about': 'apie',
-  'over': 'daugiau nei',
-  'almost': 'beveik',
-  'lessthan': 'mažiau nei'
+  xseconds_other: 'sekundė_sekundžių_sekundes',
+  xminutes_one: 'minutė_minutės_minutę',
+  xminutes_other: 'minutės_minučių_minutes',
+  xhours_one: 'valanda_valandos_valandą',
+  xhours_other: 'valandos_valandų_valandas',
+  xdays_one: 'diena_dienos_dieną',
+  xdays_other: 'dienos_dienų_dienas',
+  xweeks_one: 'mėnuo_mėnesio_mėnesį', // TODO
+  xweeks_other: 'mėnesiai_mėnesių_mėnesius', // TODO
+  xmonths_one: 'mėnuo_mėnesio_mėnesį',
+  xmonths_other: 'mėnesiai_mėnesių_mėnesius',
+  xyears_one: 'metai_metų_metus',
+  xyears_other: 'metai_metų_metus',
+  about: 'apie',
+  over: 'daugiau nei',
+  almost: 'beveik',
+  lessthan: 'mažiau nei'
 }
-function translateSeconds (number, addSuffix, key, isFuture) {
+function translateSeconds(number, addSuffix, key, isFuture) {
   if (!addSuffix) {
     return 'kelios sekundės'
   } else {
     return isFuture ? 'kelių sekundžių' : 'kelias sekundes'
   }
 }
-function translateSingular (number, addSuffix, key, isFuture) {
-  return !addSuffix ? forms(key)[0] : (isFuture ? forms(key)[1] : forms(key)[2])
+function translateSingular(number, addSuffix, key, isFuture) {
+  return !addSuffix ? forms(key)[0] : isFuture ? forms(key)[1] : forms(key)[2]
 }
-function special (number) {
+function special(number) {
   return number % 10 === 0 || (number > 10 && number < 20)
 }
-function forms (key) {
+function forms(key) {
   return translations[key].split('_')
 }
-function translate (number, addSuffix, key, isFuture) {
+function translate(number, addSuffix, key, isFuture) {
   var result = number + ' '
   if (number === 1) {
     return result + translateSingular(number, addSuffix, key[0], isFuture)
@@ -115,7 +127,7 @@ function translate (number, addSuffix, key, isFuture) {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
   var adverb = token.match(/about|over|almost|lessthan/i)
   var unit = token.replace(adverb, '')
@@ -124,9 +136,17 @@ export default function formatDistance (token, count, options) {
   if (typeof formatDistanceLocale[token] === 'string') {
     result = formatDistanceLocale[token]
   } else if (count === 1) {
-    result = formatDistanceLocale[token].one(count, options.addSuffix, unit.toLowerCase() + '_one')
+    result = formatDistanceLocale[token].one(
+      count,
+      options.addSuffix,
+      unit.toLowerCase() + '_one'
+    )
   } else {
-    result = formatDistanceLocale[token].other(count, options.addSuffix, unit.toLowerCase() + '_other')
+    result = formatDistanceLocale[token].other(
+      count,
+      options.addSuffix,
+      unit.toLowerCase() + '_other'
+    )
   }
 
   if (adverb) {

--- a/src/locale/lv/_lib/formatDistance/index.js
+++ b/src/locale/lv/_lib/formatDistance/index.js
@@ -83,6 +83,22 @@ var formatDistanceLocale = {
     other: ['{{count}} {{time}}', 'diena', 'dienas', 'dienas', 'dienām']
   }),
 
+  aboutXWeeks: buildLocalizeTokenFn({
+    one: ['apmēram 1 {{time}}', 'mēnesis', 'mēneša'], // TODO
+    other: [
+      'apmēram {{count}} {{time}}', // TODO
+      'mēnesis',
+      'mēneši',
+      'mēneša',
+      'mēnešiem'
+    ] // TODO
+  }),
+
+  xWeeks: buildLocalizeTokenFn({
+    one: ['1 {{time}}', 'mēnesis', 'mēneša'], // TODO
+    other: ['{{count}} {{time}}', 'mēnesis', 'mēneši', 'mēneša', 'mēnešiem'] // TODO
+  }),
+
   aboutXMonths: buildLocalizeTokenFn({
     one: ['apmēram 1 {{time}}', 'mēnesis', 'mēneša'],
     other: [

--- a/src/locale/lv/_lib/formatDistance/index.js
+++ b/src/locale/lv/_lib/formatDistance/index.js
@@ -84,19 +84,25 @@ var formatDistanceLocale = {
   }),
 
   aboutXWeeks: buildLocalizeTokenFn({
-    one: ['apmēram 1 {{time}}', 'mēnesis', 'mēneša'], // TODO
+    one: ['apmēram 1 {{time}}', 'nedēļa', 'nedēļas'],
     other: [
-      'apmēram {{count}} {{time}}', // TODO
-      'mēnesis',
-      'mēneši',
-      'mēneša',
-      'mēnešiem'
-    ] // TODO
+      'apmēram {{count}} {{time}}',
+      'nedēļa',
+      'nedēļu',
+      'nedēļas',
+      'nedēļām'
+    ]
   }),
 
   xWeeks: buildLocalizeTokenFn({
-    one: ['1 {{time}}', 'mēnesis', 'mēneša'], // TODO
-    other: ['{{count}} {{time}}', 'mēnesis', 'mēneši', 'mēneša', 'mēnešiem'] // TODO
+    one: ['1 {{time}}', 'nedēļa', 'nedēļas'],
+    other: [
+      '{{count}} {{time}}', // TODO
+      'nedēļa',
+      'nedēļu',
+      'nedēļas',
+      'nedēļām'
+    ]
   }),
 
   aboutXMonths: buildLocalizeTokenFn({

--- a/src/locale/mk/_lib/formatDistance/index.js
+++ b/src/locale/mk/_lib/formatDistance/index.js
@@ -37,18 +37,18 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'околу 1 месец', // TODO
-    other: 'околу {{count}} месеци' // TODO
+    one: 'околу 1 недела',
+    other: 'околу {{count}} месеци'
   },
 
   xWeeks: {
-    one: '1 месец', // TODO
-    other: '{{count}} месеци' // TODO
+    one: '1 недела',
+    other: '{{count}} недели'
   },
 
   aboutXMonths: {
     one: 'околу 1 месец',
-    other: 'околу {{count}} месеци'
+    other: 'околу {{count}} недели'
   },
 
   xMonths: {

--- a/src/locale/mk/_lib/formatDistance/index.js
+++ b/src/locale/mk/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} дена'
   },
 
+  aboutXWeeks: {
+    one: 'околу 1 месец', // TODO
+    other: 'околу {{count}} месеци' // TODO
+  },
+
+  xWeeks: {
+    one: '1 месец', // TODO
+    other: '{{count}} месеци' // TODO
+  },
+
   aboutXMonths: {
     one: 'околу 1 месец',
     other: 'околу {{count}} месеци'

--- a/src/locale/ms/_lib/formatDistance/index.js
+++ b/src/locale/ms/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'sekitar 1 bulan', // TODO
-    other: 'sekitar {{count}} bulan' // TODO
+    one: 'sekitar 1 minggu',
+    other: 'sekitar {{count}} minggu'
   },
 
   xWeeks: {
-    one: '1 bulan', // TODO
-    other: '{{count}} bulan' // TODO
+    one: '1 minggu',
+    other: '{{count}} minggu'
   },
 
   aboutXMonths: {

--- a/src/locale/ms/_lib/formatDistance/index.js
+++ b/src/locale/ms/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} hari'
   },
 
+  aboutXWeeks: {
+    one: 'sekitar 1 bulan', // TODO
+    other: 'sekitar {{count}} bulan' // TODO
+  },
+
+  xWeeks: {
+    one: '1 bulan', // TODO
+    other: '{{count}} bulan' // TODO
+  },
+
   aboutXMonths: {
     one: 'sekitar 1 bulan',
     other: 'sekitar {{count}} bulan'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/mt/_lib/formatDistance/index.js
+++ b/src/locale/mt/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'madwar xahar', // TODO
-    other: 'madwar {{count}} xhur' // TODO
+    one: 'madwar ġimgħa',
+    other: 'madwar {{count}} ġimgħat'
   },
 
   xWeeks: {
-    one: 'xahar', // TODO
-    other: '{{count}} xhur' // TODO
+    one: 'ġimgħa',
+    other: '{{count}} ġimgħat'
   },
 
   aboutXMonths: {

--- a/src/locale/mt/_lib/formatDistance/index.js
+++ b/src/locale/mt/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} ġranet'
   },
 
+  aboutXWeeks: {
+    one: 'madwar xahar', // TODO
+    other: 'madwar {{count}} xhur' // TODO
+  },
+
+  xWeeks: {
+    one: 'xahar', // TODO
+    other: '{{count}} xhur' // TODO
+  },
+
   aboutXMonths: {
     one: 'madwar xahar',
     other: 'madwar {{count}} xhur'

--- a/src/locale/nb/_lib/formatDistance/index.js
+++ b/src/locale/nb/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    singular: 'omtrent en måned', // TODO
-    plural: 'omtrent {{count}} måneder' // TODO
+    singular: 'omtrent en uke',
+    plural: 'omtrent {{count}} uker'
   },
 
   xWeeks: {
-    singular: 'en måned', // TODO
-    plural: '{{count}} måneder' // TODO
+    singular: 'en uke',
+    plural: '{{count}} uker'
   },
 
   aboutXMonths: {

--- a/src/locale/nb/_lib/formatDistance/index.js
+++ b/src/locale/nb/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     plural: '{{count}} dager'
   },
 
+  aboutXWeeks: {
+    singular: 'omtrent en måned', // TODO
+    plural: 'omtrent {{count}} måneder' // TODO
+  },
+
+  xWeeks: {
+    singular: 'en måned', // TODO
+    plural: '{{count}} måneder' // TODO
+  },
+
   aboutXMonths: {
     singular: 'omtrent en måned',
     plural: 'omtrent {{count}} måneder'
@@ -83,7 +93,7 @@ var wordMapping = [
   'tolv'
 ]
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {
     onlyNumeric: false
   }
@@ -96,7 +106,10 @@ export default function formatDistance (token, count, options) {
     if (options.onlyNumeric) {
       result = translation.plural.replace('{{count}}', count)
     } else {
-      result = translation.plural.replace('{{count}}', count < 13 ? wordMapping[count] : count)
+      result = translation.plural.replace(
+        '{{count}}',
+        count < 13 ? wordMapping[count] : count
+      )
     }
   } else {
     result = translation.singular

--- a/src/locale/nl/_lib/formatDistance/index.js
+++ b/src/locale/nl/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'ongeveer 1 maand', // TODO
-    other: 'ongeveer {{count}} maanden' // TODO
+    one: 'ongeveer 1 week',
+    other: 'ongeveer {{count}} weken'
   },
 
   xWeeks: {
-    one: '1 maand', // TODO
-    other: '{{count}} maanden' // TODO
+    one: '1 week',
+    other: '{{count}} weken'
   },
 
   aboutXMonths: {

--- a/src/locale/nl/_lib/formatDistance/index.js
+++ b/src/locale/nl/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} dagen'
   },
 
+  aboutXWeeks: {
+    one: 'ongeveer 1 maand', // TODO
+    other: 'ongeveer {{count}} maanden' // TODO
+  },
+
+  xWeeks: {
+    one: '1 maand', // TODO
+    other: '{{count}} maanden' // TODO
+  },
+
   aboutXMonths: {
     one: 'ongeveer 1 maand',
     other: 'ongeveer {{count}} maanden'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/nn/_lib/formatDistance/index.js
+++ b/src/locale/nn/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    singular: 'omtrent ein månad', // TODO
-    plural: 'omtrent {{count}} månader' // TODO
+    singular: 'omtrent ei veke',
+    plural: 'omtrent {{count}} veker'
   },
 
   xWeeks: {
-    singular: 'ein månad', // TODO
-    plural: '{{count}} månader' // TODO
+    singular: 'ei veke',
+    plural: '{{count}} veker'
   },
 
   aboutXMonths: {

--- a/src/locale/nn/_lib/formatDistance/index.js
+++ b/src/locale/nn/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     plural: '{{count}} dagar'
   },
 
+  aboutXWeeks: {
+    singular: 'omtrent ein månad', // TODO
+    plural: 'omtrent {{count}} månader' // TODO
+  },
+
+  xWeeks: {
+    singular: 'ein månad', // TODO
+    plural: '{{count}} månader' // TODO
+  },
+
   aboutXMonths: {
     singular: 'omtrent ein månad',
     plural: 'omtrent {{count}} månader'

--- a/src/locale/pl/_lib/formatDistance/index.js
+++ b/src/locale/pl/_lib/formatDistance/index.js
@@ -111,8 +111,8 @@ var formatDistanceLocale = {
   },
 
   xWeeks: {
-    one: 'tydzień'
-    twoFour: '{{count}} tygodnie'
+    one: 'tydzień',
+    twoFour: '{{count}} tygodnie',
     other: '{{count}} tygodni'
   },
 

--- a/src/locale/pl/_lib/formatDistance/index.js
+++ b/src/locale/pl/_lib/formatDistance/index.js
@@ -105,15 +105,15 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'około miesiąc', // TODO
-    twoFour: 'około {{count}} miesiące', // TODO
-    other: 'około {{count}} miesięcy' // TODO
+    one: 'około tygodnia',
+    twoFour: 'około {{count}} tygodni',
+    other: 'około {{count}} tygodni'
   },
 
   xWeeks: {
-    one: 'miesiąc', // TODO
-    twoFour: '{{count}} miesiące', // TODO
-    other: '{{count}} miesięcy' // TODO
+    one: 'tydzień'
+    twoFour: '{{count}} tygodnie'
+    other: '{{count}} tygodni'
   },
 
   aboutXMonths: {

--- a/src/locale/pl/_lib/formatDistance/index.js
+++ b/src/locale/pl/_lib/formatDistance/index.js
@@ -104,6 +104,18 @@ var formatDistanceLocale = {
     other: '{{count}} dni'
   },
 
+  aboutXWeeks: {
+    one: 'około miesiąc', // TODO
+    twoFour: 'około {{count}} miesiące', // TODO
+    other: 'około {{count}} miesięcy' // TODO
+  },
+
+  xWeeks: {
+    one: 'miesiąc', // TODO
+    twoFour: '{{count}} miesiące', // TODO
+    other: '{{count}} miesięcy' // TODO
+  },
+
   aboutXMonths: {
     one: 'około miesiąc',
     twoFour: 'około {{count}} miesiące',

--- a/src/locale/pt-BR/_lib/formatDistance/index.js
+++ b/src/locale/pt-BR/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} dias'
   },
 
+  aboutXWeeks: {
+    one: 'cerca de 1 mês', // TODO
+    other: 'cerca de {{count}} meses' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mês', // TODO
+    other: '{{count}} meses' // TODO
+  },
+
   aboutXMonths: {
     one: 'cerca de 1 mês',
     other: 'cerca de {{count}} meses'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/pt-BR/_lib/formatDistance/index.js
+++ b/src/locale/pt-BR/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'cerca de 1 mês', // TODO
-    other: 'cerca de {{count}} meses' // TODO
+    one: 'cerca de 1 mês',
+    other: 'cerca de {{count}} meses'
   },
 
   xWeeks: {
-    one: '1 mês', // TODO
-    other: '{{count}} meses' // TODO
+    one: '1 mês',
+    other: '{{count}} meses'
   },
 
   aboutXMonths: {

--- a/src/locale/pt/_lib/formatDistance/index.js
+++ b/src/locale/pt/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} dias'
   },
 
+  aboutXWeeks: {
+    one: 'aproximadamente 1 mês', // TODO
+    other: 'aproximadamente {{count}} meses' // TODO
+  },
+
+  xWeeks: {
+    one: '1 mês', // TODO
+    other: '{{count}} meses' // TODO
+  },
+
   aboutXMonths: {
     one: 'aproximadamente 1 mês',
     other: 'aproximadamente {{count}} meses'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/ro/_lib/formatDistance/index.js
+++ b/src/locale/ro/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'circa 1 lună', // TODO
-    other: 'circa {{count}} luni' // TODO
+    one: 'circa o săptămână',
+    other: 'circa {{count}} săptămâni'
   },
 
   xWeeks: {
-    one: '1 lună', // TODO
-    other: '{{count}} luni' // TODO
+    one: '1 săptămână',
+    other: '{{count}} săptămâni'
   },
 
   aboutXMonths: {

--- a/src/locale/ro/_lib/formatDistance/index.js
+++ b/src/locale/ro/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} zile'
   },
 
+  aboutXWeeks: {
+    one: 'circa 1 lună', // TODO
+    other: 'circa {{count}} luni' // TODO
+  },
+
+  xWeeks: {
+    one: '1 lună', // TODO
+    other: '{{count}} luni' // TODO
+  },
+
   aboutXMonths: {
     one: 'circa 1 lună',
     other: 'circa {{count}} luni'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/ru/_lib/formatDistance/index.js
+++ b/src/locale/ru/_lib/formatDistance/index.js
@@ -153,22 +153,22 @@ var formatDistanceLocale = {
 
   aboutXWeeks: buildLocalizeTokenFn({
     regular: {
-      singularNominative: 'около {{count}} недели', // TODO
-      singularGenitive: 'около {{count}} недели', // TODO
-      pluralGenitive: 'около {{count}} недель' // TODO
+      singularNominative: 'около {{count}} недели',
+      singularGenitive: 'около {{count}} недель',
+      pluralGenitive: 'около {{count}} недель'
     },
     future: {
-      singularNominative: 'приблизительно через {{count}} неделю', // TODO
-      singularGenitive: 'приблизительно через {{count}} недели', // TODO
-      pluralGenitive: 'приблизительно через {{count}} недель' // TODO
+      singularNominative: 'приблизительно через {{count}} неделю',
+      singularGenitive: 'приблизительно через {{count}} недели',
+      pluralGenitive: 'приблизительно через {{count}} недель'
     }
   }),
 
   xWeeks: buildLocalizeTokenFn({
     regular: {
-      singularNominative: '{{count}} неделя', // TODO
-      singularGenitive: '{{count}} недели', // TODO
-      pluralGenitive: '{{count}} недель' // TODO
+      singularNominative: '{{count}} неделя',
+      singularGenitive: '{{count}} недели',
+      pluralGenitive: '{{count}} недель'
     }
   }),
 

--- a/src/locale/ru/_lib/formatDistance/index.js
+++ b/src/locale/ru/_lib/formatDistance/index.js
@@ -1,4 +1,4 @@
-function declension (scheme, count) {
+function declension(scheme, count) {
   // scheme for count=1 exists
   if (scheme.one !== undefined && count === 1) {
     return scheme.one
@@ -11,18 +11,18 @@ function declension (scheme, count) {
   if (rem10 === 1 && rem100 !== 11) {
     return scheme.singularNominative.replace('{{count}}', count)
 
-  // 2, 3, 4, 22, 23, 24, 32 ...
-  } else if ((rem10 >= 2 && rem10 <= 4) && (rem100 < 10 || rem100 > 20)) {
+    // 2, 3, 4, 22, 23, 24, 32 ...
+  } else if (rem10 >= 2 && rem10 <= 4 && (rem100 < 10 || rem100 > 20)) {
     return scheme.singularGenitive.replace('{{count}}', count)
 
-  // 5, 6, 7, 8, 9, 10, 11, ...
+    // 5, 6, 7, 8, 9, 10, 11, ...
   } else {
     return scheme.pluralGenitive.replace('{{count}}', count)
   }
 }
 
-function buildLocalizeTokenFn (scheme) {
-  return function (count, options) {
+function buildLocalizeTokenFn(scheme) {
+  return function(count, options) {
     if (options.addSuffix) {
       if (options.comparison > 0) {
         if (scheme.future) {
@@ -77,7 +77,7 @@ var formatDistanceLocale = {
     }
   }),
 
-  halfAMinute: function (_, options) {
+  halfAMinute: function(_, options) {
     if (options.addSuffix) {
       if (options.comparison > 0) {
         return 'через полминуты'
@@ -151,6 +151,27 @@ var formatDistanceLocale = {
     }
   }),
 
+  aboutXWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: 'около {{count}} недели', // TODO
+      singularGenitive: 'около {{count}} недели', // TODO
+      pluralGenitive: 'около {{count}} недель' // TODO
+    },
+    future: {
+      singularNominative: 'приблизительно через {{count}} неделю', // TODO
+      singularGenitive: 'приблизительно через {{count}} недели', // TODO
+      pluralGenitive: 'приблизительно через {{count}} недель' // TODO
+    }
+  }),
+
+  xWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: '{{count}} неделя', // TODO
+      singularGenitive: '{{count}} недели', // TODO
+      pluralGenitive: '{{count}} недель' // TODO
+    }
+  }),
+
   aboutXMonths: buildLocalizeTokenFn({
     regular: {
       singularNominative: 'около {{count}} месяца',
@@ -220,7 +241,7 @@ var formatDistanceLocale = {
   })
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
   return formatDistanceLocale[token](count, options)
 }

--- a/src/locale/sk/_lib/formatDistance/index.js
+++ b/src/locale/sk/_lib/formatDistance/index.js
@@ -143,6 +143,24 @@ var formatDistanceLocale = {
     }
   },
 
+  xWeeks: {
+    one: {
+      regular: 'mesiac', // TODO
+      past: 'mesiacom', // TODO
+      future: 'mesiac' // TODO
+    },
+    twoFour: {
+      regular: '{{count}} mesiace', // TODO
+      past: '{{count}} mesiacmi', // TODO
+      future: '{{count}} mesiace' // TODO
+    },
+    other: {
+      regular: '{{count}} mesiacov', // TODO
+      past: '{{count}} mesiacmi', // TODO
+      future: '{{count}} mesiacov' // TODO
+    }
+  },
+
   xMonths: {
     one: {
       regular: 'mesiac',

--- a/src/locale/sl/_lib/formatDistance/index.js
+++ b/src/locale/sl/_lib/formatDistance/index.js
@@ -51,17 +51,17 @@ var distanceInWordsLocale = {
   },
 
   aboutXWeeks: {
-    one: 'približno {{count}} mesec', // TODO
-    two: 'približno {{count}} meseca', // TODO
-    few: 'približno {{count}} mesece', // TODO
-    other: 'približno {{count}} mesecev' // TODO
+    one: 'približno {{count}} teden',
+    two: 'približno {{count}} tedna',
+    few: 'približno {{count}} tedne',
+    other: 'približno {{count}} tednov'
   },
 
   xWeeks: {
-    one: '{{count}} mesec', // TODO
-    two: '{{count}} meseca', // TODO
-    few: '{{count}} meseci', // TODO
-    other: '{{count}} mesecev' // TODO
+    one: '{{count}} teden',
+    two: '{{count}} tedna',
+    few: '{{count}} tedne',
+    other: '{{count}} tednov'
   },
 
   aboutXMonths: {

--- a/src/locale/sl/_lib/formatDistance/index.js
+++ b/src/locale/sl/_lib/formatDistance/index.js
@@ -50,6 +50,20 @@ var distanceInWordsLocale = {
     other: '{{count}} dni'
   },
 
+  aboutXWeeks: {
+    one: 'približno {{count}} mesec', // TODO
+    two: 'približno {{count}} meseca', // TODO
+    few: 'približno {{count}} mesece', // TODO
+    other: 'približno {{count}} mesecev' // TODO
+  },
+
+  xWeeks: {
+    one: '{{count}} mesec', // TODO
+    two: '{{count}} meseca', // TODO
+    few: '{{count}} meseci', // TODO
+    other: '{{count}} mesecev' // TODO
+  },
+
   aboutXMonths: {
     one: 'približno {{count}} mesec',
     two: 'približno {{count}} meseca',

--- a/src/locale/sr-Latn/_lib/formatDistance/index.js
+++ b/src/locale/sr-Latn/_lib/formatDistance/index.js
@@ -73,22 +73,22 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     one: {
-      standalone: 'oko 1 mesec', // TODO
-      withPrepositionAgo: 'oko 1 mesec', // TODO
-      withPrepositionIn: 'oko 1 mesec' // TODO
+      standalone: 'oko 1 nedjelju',
+      withPrepositionAgo: 'oko 1 nedjelju',
+      withPrepositionIn: 'oko 1 nedjelju'
     },
-    dual: 'oko {{count}} meseca', // TODO
-    other: 'oko {{count}} meseci' // TODO
+    dual: 'oko {{count}} nedjelje',
+    other: 'oko {{count}} nedjelje'
   },
 
   xWeeks: {
     one: {
-      standalone: '1 mesec', // TODO
-      withPrepositionAgo: '1 mesec', // TODO
-      withPrepositionIn: '1 mesec' // TODO
+      standalone: '1 nedjelju',
+      withPrepositionAgo: '1 nedjelju',
+      withPrepositionIn: '1 nedjelju'
     },
-    dual: '{{count}} meseca', // TODO
-    other: '{{count}} meseci' // TODO
+    dual: '{{count}} nedjelje',
+    other: '{{count}} nedjelje'
   },
 
   aboutXMonths: {

--- a/src/locale/sr-Latn/_lib/formatDistance/index.js
+++ b/src/locale/sr-Latn/_lib/formatDistance/index.js
@@ -71,6 +71,26 @@ var formatDistanceLocale = {
     other: '{{count}} dana'
   },
 
+  aboutXWeeks: {
+    one: {
+      standalone: 'oko 1 mesec', // TODO
+      withPrepositionAgo: 'oko 1 mesec', // TODO
+      withPrepositionIn: 'oko 1 mesec' // TODO
+    },
+    dual: 'oko {{count}} meseca', // TODO
+    other: 'oko {{count}} meseci' // TODO
+  },
+
+  xWeeks: {
+    one: {
+      standalone: '1 mesec', // TODO
+      withPrepositionAgo: '1 mesec', // TODO
+      withPrepositionIn: '1 mesec' // TODO
+    },
+    dual: '{{count}} meseca', // TODO
+    other: '{{count}} meseci' // TODO
+  },
+
   aboutXMonths: {
     one: {
       standalone: 'oko 1 mesec',

--- a/src/locale/sr/_lib/formatDistance/index.js
+++ b/src/locale/sr/_lib/formatDistance/index.js
@@ -73,22 +73,22 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     one: {
-      standalone: 'око 1 месец', // TODO
-      withPrepositionAgo: 'око 1 месец', // TODO
-      withPrepositionIn: 'око 1 месец' // TODO
+      standalone: 'око 1 недељу',
+      withPrepositionAgo: 'око 1 недељу',
+      withPrepositionIn: 'око 1 недељу'
     },
-    dual: 'око {{count}} месеца', // TODO
-    other: 'око {{count}} месеци' // TODO
+    dual: 'око {{count}} недеље',
+    other: 'око {{count}} недеље'
   },
 
   xWeeks: {
     one: {
-      standalone: '1 месец', // TODO
-      withPrepositionAgo: '1 месец', // TODO
-      withPrepositionIn: '1 месец' // TODO
+      standalone: '1 недељу',
+      withPrepositionAgo: '1 недељу',
+      withPrepositionIn: '1 недељу'
     },
-    dual: '{{count}} месеца', // TODO
-    other: '{{count}} месеци' // TODO
+    dual: '{{count}} недеље',
+    other: '{{count}} недеље'
   },
 
   aboutXMonths: {

--- a/src/locale/sr/_lib/formatDistance/index.js
+++ b/src/locale/sr/_lib/formatDistance/index.js
@@ -71,6 +71,26 @@ var formatDistanceLocale = {
     other: '{{count}} дана'
   },
 
+  aboutXWeeks: {
+    one: {
+      standalone: 'око 1 месец', // TODO
+      withPrepositionAgo: 'око 1 месец', // TODO
+      withPrepositionIn: 'око 1 месец' // TODO
+    },
+    dual: 'око {{count}} месеца', // TODO
+    other: 'око {{count}} месеци' // TODO
+  },
+
+  xWeeks: {
+    one: {
+      standalone: '1 месец', // TODO
+      withPrepositionAgo: '1 месец', // TODO
+      withPrepositionIn: '1 месец' // TODO
+    },
+    dual: '{{count}} месеца', // TODO
+    other: '{{count}} месеци' // TODO
+  },
+
   aboutXMonths: {
     one: {
       standalone: 'око 1 месец',

--- a/src/locale/sv/_lib/formatDistance/index.js
+++ b/src/locale/sv/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    singular: 'ungefär en månad', // TODO
-    plural: 'ungefär {{count}} månader' // TODO
+    singular: 'ungefär en vecka',
+    plural: 'ungefär {{count}} vecka'
   },
 
   xWeeks: {
-    singular: 'en månad', // TODO
-    plural: '{{count}} månader' // TODO
+    singular: 'en vecka',
+    plural: '{{count}} vecka'
   },
 
   aboutXMonths: {

--- a/src/locale/sv/_lib/formatDistance/index.js
+++ b/src/locale/sv/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     plural: '{{count}} dagar'
   },
 
+  aboutXWeeks: {
+    singular: 'ungefär en månad', // TODO
+    plural: 'ungefär {{count}} månader' // TODO
+  },
+
+  xWeeks: {
+    singular: 'en månad', // TODO
+    plural: '{{count}} månader' // TODO
+  },
+
   aboutXMonths: {
     singular: 'ungefär en månad',
     plural: 'ungefär {{count}} månader'
@@ -83,7 +93,7 @@ var wordMapping = [
   'tolv'
 ]
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {
     onlyNumeric: false
   }
@@ -96,7 +106,10 @@ export default function formatDistance (token, count, options) {
     if (options.onlyNumeric) {
       result = translation.plural.replace('{{count}}', count)
     } else {
-      result = translation.plural.replace('{{count}}', count < 13 ? wordMapping[count] : count)
+      result = translation.plural.replace(
+        '{{count}}',
+        count < 13 ? wordMapping[count] : count
+      )
     }
   } else {
     result = translation.singular

--- a/src/locale/ta/_lib/formatDistance/index.js
+++ b/src/locale/ta/_lib/formatDistance/index.js
@@ -96,6 +96,32 @@ var formatDistanceLocale = {
     }
   },
 
+  aboutXWeeks: {
+    one: {
+      default: 'சுமார் 1 மாதம்', // TODO
+      in: 'சுமார் 1 மாதத்தில்', // TODO
+      ago: 'சுமார் 1 மாதத்திற்கு முன்பு' // TODO
+    },
+    other: {
+      default: 'சுமார் {{count}} மாதங்கள்', // TODO
+      in: 'சுமார் {{count}} மாதங்களில்', // TODO
+      ago: 'சுமார் {{count}} மாதங்களுக்கு முன்பு' // TODO
+    }
+  },
+
+  xWeeks: {
+    one: {
+      default: '1 மாதம்', // TODO
+      in: '1 மாதத்தில்', // TODO
+      ago: '1 மாதம் முன்பு' // TODO
+    },
+    other: {
+      default: '{{count}} மாதங்கள்', // TODO
+      in: '{{count}} மாதங்களில்', // TODO
+      ago: '{{count}} மாதங்களுக்கு முன்பு' // TODO
+    }
+  },
+
   aboutXMonths: {
     one: {
       default: 'சுமார் 1 மாதம்',

--- a/src/locale/ta/_lib/formatDistance/index.js
+++ b/src/locale/ta/_lib/formatDistance/index.js
@@ -98,27 +98,27 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     one: {
-      default: 'சுமார் 1 மாதம்', // TODO
-      in: 'சுமார் 1 மாதத்தில்', // TODO
-      ago: 'சுமார் 1 மாதத்திற்கு முன்பு' // TODO
+      default: 'சுமார் 1 வாரம்',
+      in: 'சுமார் 1 வாரத்தில்',
+      ago: 'சுமார் 1 வாரம் முன்பு'
     },
     other: {
-      default: 'சுமார் {{count}} மாதங்கள்', // TODO
-      in: 'சுமார் {{count}} மாதங்களில்', // TODO
-      ago: 'சுமார் {{count}} மாதங்களுக்கு முன்பு' // TODO
+      default: 'சுமார் {{count}} வாரங்கள்',
+      in: 'சுமார் {{count}} வாரங்களில்',
+      ago: 'சுமார் {{count}} வாரங்களுக்கு முன்பு'
     }
   },
 
   xWeeks: {
     one: {
-      default: '1 மாதம்', // TODO
-      in: '1 மாதத்தில்', // TODO
-      ago: '1 மாதம் முன்பு' // TODO
+      default: '1 வாரம்',
+      in: '1 வாரத்தில்',
+      ago: '1 வாரம் முன்பு'
     },
     other: {
-      default: '{{count}} மாதங்கள்', // TODO
-      in: '{{count}} மாதங்களில்', // TODO
-      ago: '{{count}} மாதங்களுக்கு முன்பு' // TODO
+      default: '{{count}} வாரங்கள்',
+      in: '{{count}} வாரங்களில்',
+      ago: '{{count}} வாரங்களுக்கு முன்பு'
     }
   },
 

--- a/src/locale/te/_lib/formatDistance/index.js
+++ b/src/locale/te/_lib/formatDistance/index.js
@@ -84,23 +84,23 @@ var formatDistanceLocale = {
 
   aboutXWeeks: {
     standalone: {
-      one: 'సుమారు ఒక నెల', // TODO
-      other: 'సుమారు {{count}} నెలలు' // TODO
+      one: 'సుమారు ఒక వారం',
+      other: 'సుమారు {{count}} వారాలు'
     },
     withPreposition: {
-      one: 'సుమారు ఒక నెల', // TODO
-      other: 'సుమారు {{count}} నెలల' // TODO
+      one: 'సుమారు ఒక వారం',
+      other: 'సుమారు {{count}} వారాలల'
     }
   },
 
   xWeeks: {
     standalone: {
-      one: 'ఒక నెల', // TODO CLDR #1281
-      other: '{{count}} నెలలు' // TODO
+      one: 'ఒక వారం',
+      other: '{{count}} వారాలు'
     },
     withPreposition: {
-      one: 'ఒక నెల', // TODO
-      other: '{{count}} నెలల' // TODO
+      one: 'ఒక వారం',
+      other: '{{count}} వారాలల'
     }
   },
 

--- a/src/locale/te/_lib/formatDistance/index.js
+++ b/src/locale/te/_lib/formatDistance/index.js
@@ -82,6 +82,28 @@ var formatDistanceLocale = {
     }
   },
 
+  aboutXWeeks: {
+    standalone: {
+      one: 'సుమారు ఒక నెల', // TODO
+      other: 'సుమారు {{count}} నెలలు' // TODO
+    },
+    withPreposition: {
+      one: 'సుమారు ఒక నెల', // TODO
+      other: 'సుమారు {{count}} నెలల' // TODO
+    }
+  },
+
+  xWeeks: {
+    standalone: {
+      one: 'ఒక నెల', // TODO CLDR #1281
+      other: '{{count}} నెలలు' // TODO
+    },
+    withPreposition: {
+      one: 'ఒక నెల', // TODO
+      other: '{{count}} నెలల' // TODO
+    }
+  },
+
   aboutXMonths: {
     standalone: {
       one: 'సుమారు ఒక నెల',

--- a/src/locale/th/_lib/formatDistance/index.js
+++ b/src/locale/th/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} วัน'
   },
 
+  aboutXWeeks: {
+    one: 'ประมาณ 1 เดือน', // TODO
+    other: 'ประมาณ {{count}} เดือน' // TODO
+  },
+
+  xWeeks: {
+    one: '1 เดือน', // TODO
+    other: '{{count}} เดือน' // TODO
+  },
+
   aboutXMonths: {
     one: 'ประมาณ 1 เดือน',
     other: 'ประมาณ {{count}} เดือน'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/th/_lib/formatDistance/index.js
+++ b/src/locale/th/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'ประมาณ 1 เดือน', // TODO
-    other: 'ประมาณ {{count}} เดือน' // TODO
+    one: 'ประมาณ 1 สัปดาห์',
+    other: 'ประมาณ {{count}} สัปดาห์'
   },
 
   xWeeks: {
-    one: '1 เดือน', // TODO
-    other: '{{count}} เดือน' // TODO
+    one: '1 สัปดาห์',
+    other: '{{count}} สัปดาห์'
   },
 
   aboutXMonths: {

--- a/src/locale/tr/_lib/formatDistance/index.js
+++ b/src/locale/tr/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'yaklaşık 1 ay', // TODO
-    other: 'yaklaşık {{count}} ay' // TODO
+    one: 'yaklaşık 1 hafta',
+    other: 'yaklaşık {{count}} hafta'
   },
 
   xWeeks: {
-    one: '1 ay', // TODO
-    other: '{{count}} ay' // TODO
+    one: '1 hafta',
+    other: '{{count}} hafta'
   },
 
   aboutXMonths: {

--- a/src/locale/tr/_lib/formatDistance/index.js
+++ b/src/locale/tr/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} gün'
   },
 
+  aboutXWeeks: {
+    one: 'yaklaşık 1 ay', // TODO
+    other: 'yaklaşık {{count}} ay' // TODO
+  },
+
+  xWeeks: {
+    one: '1 ay', // TODO
+    other: '{{count}} ay' // TODO
+  },
+
   aboutXMonths: {
     one: 'yaklaşık 1 ay',
     other: 'yaklaşık {{count}} ay'

--- a/src/locale/ug/_lib/formatDistance/index.js
+++ b/src/locale/ug/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'تەخمىنەن بىر ئاي', // TODO
-    other: 'ئاي {{count}} تەخمىنەن' // TODO
+    one: 'تەخمىنەن بىرھەپتە',
+    other: 'ھەپتە {{count}} تەخمىنەن'
   },
 
   xWeeks: {
-    one: 'بىر ئاي', // TODO
-    other: 'ئاي {{count}}' // TODO
+    one: 'بىرھەپتە',
+    other: 'ھەپتە {{count}}'
   },
 
   aboutXMonths: {

--- a/src/locale/ug/_lib/formatDistance/index.js
+++ b/src/locale/ug/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: 'كۈن {{count}}'
   },
 
+  aboutXWeeks: {
+    one: 'تەخمىنەن بىر ئاي', // TODO
+    other: 'ئاي {{count}} تەخمىنەن' // TODO
+  },
+
+  xWeeks: {
+    one: 'بىر ئاي', // TODO
+    other: 'ئاي {{count}}' // TODO
+  },
+
   aboutXMonths: {
     one: 'تەخمىنەن بىر ئاي',
     other: 'ئاي {{count}} تەخمىنەن'

--- a/src/locale/uk/_lib/formatDistance/index.js
+++ b/src/locale/uk/_lib/formatDistance/index.js
@@ -153,22 +153,22 @@ var formatDistanceLocale = {
 
   aboutXWeeks: buildLocalizeTokenFn({
     regular: {
-      singularNominative: 'близько {{count}} місяця', // TODO
-      singularGenitive: 'близько {{count}} місяців', // TODO
-      pluralGenitive: 'близько {{count}} місяців' // TODO
+      singularNominative: 'близько {{count}} тижня', // TODO
+      singularGenitive: 'близько {{count}} тижнів', // TODO
+      pluralGenitive: 'близько {{count}} тижнів' // TODO
     },
     future: {
-      singularNominative: 'приблизно за {{count}} місяць', // TODO
-      singularGenitive: 'приблизно за {{count}} місяця', // TODO
-      pluralGenitive: 'приблизно за {{count}} місяців' // TODO
+      singularNominative: 'приблизно за {{count}} тиждень', // TODO
+      singularGenitive: 'приблизно за {{count}} тижні', // TODO
+      pluralGenitive: 'приблизно за {{count}} тижні' // TODO
     }
   }),
 
   xWeeks: buildLocalizeTokenFn({
     regular: {
-      singularNominative: '{{count}} місяць', // TODO
-      singularGenitive: '{{count}} місяця', // TODO
-      pluralGenitive: '{{count}} місяців' // TODO
+      singularNominative: '{{count}} тиждень', // TODO
+      singularGenitive: '{{count}} тижня', // TODO
+      pluralGenitive: '{{count}} тижні' // TODO
     }
   }),
 

--- a/src/locale/uk/_lib/formatDistance/index.js
+++ b/src/locale/uk/_lib/formatDistance/index.js
@@ -153,22 +153,22 @@ var formatDistanceLocale = {
 
   aboutXWeeks: buildLocalizeTokenFn({
     regular: {
-      singularNominative: 'близько {{count}} тижня', // TODO
-      singularGenitive: 'близько {{count}} тижнів', // TODO
-      pluralGenitive: 'близько {{count}} тижнів' // TODO
+      singularNominative: 'близько {{count}} тижня',
+      singularGenitive: 'близько {{count}} тижнів',
+      pluralGenitive: 'близько {{count}} тижнів'
     },
     future: {
-      singularNominative: 'приблизно за {{count}} тиждень', // TODO
-      singularGenitive: 'приблизно за {{count}} тижні', // TODO
-      pluralGenitive: 'приблизно за {{count}} тижні' // TODO
+      singularNominative: 'приблизно за {{count}} тиждень',
+      singularGenitive: 'приблизно за {{count}} тижні',
+      pluralGenitive: 'приблизно за {{count}} тижні'
     }
   }),
 
   xWeeks: buildLocalizeTokenFn({
     regular: {
-      singularNominative: '{{count}} тиждень', // TODO
-      singularGenitive: '{{count}} тижня', // TODO
-      pluralGenitive: '{{count}} тижні' // TODO
+      singularNominative: '{{count}} тиждень',
+      singularGenitive: '{{count}} тижня',
+      pluralGenitive: '{{count}} тижні'
     }
   }),
 

--- a/src/locale/uk/_lib/formatDistance/index.js
+++ b/src/locale/uk/_lib/formatDistance/index.js
@@ -1,4 +1,4 @@
-function declension (scheme, count) {
+function declension(scheme, count) {
   // scheme for count=1 exists
   if (scheme.one !== undefined && count === 1) {
     return scheme.one
@@ -11,18 +11,18 @@ function declension (scheme, count) {
   if (rem10 === 1 && rem100 !== 11) {
     return scheme.singularNominative.replace('{{count}}', count)
 
-  // 2, 3, 4, 22, 23, 24, 32 ...
-  } else if ((rem10 >= 2 && rem10 <= 4) && (rem100 < 10 || rem100 > 20)) {
+    // 2, 3, 4, 22, 23, 24, 32 ...
+  } else if (rem10 >= 2 && rem10 <= 4 && (rem100 < 10 || rem100 > 20)) {
     return scheme.singularGenitive.replace('{{count}}', count)
 
-  // 5, 6, 7, 8, 9, 10, 11, ...
+    // 5, 6, 7, 8, 9, 10, 11, ...
   } else {
     return scheme.pluralGenitive.replace('{{count}}', count)
   }
 }
 
-function buildLocalizeTokenFn (scheme) {
-  return function (count, options) {
+function buildLocalizeTokenFn(scheme) {
+  return function(count, options) {
     if (options.addSuffix) {
       if (options.comparison > 0) {
         if (scheme.future) {
@@ -77,7 +77,7 @@ var formatDistanceLocale = {
     }
   }),
 
-  halfAMinute: function (_, options) {
+  halfAMinute: function(_, options) {
     if (options.addSuffix) {
       if (options.comparison > 0) {
         return 'за півхвилини'
@@ -151,6 +151,27 @@ var formatDistanceLocale = {
     }
   }),
 
+  aboutXWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: 'близько {{count}} місяця', // TODO
+      singularGenitive: 'близько {{count}} місяців', // TODO
+      pluralGenitive: 'близько {{count}} місяців' // TODO
+    },
+    future: {
+      singularNominative: 'приблизно за {{count}} місяць', // TODO
+      singularGenitive: 'приблизно за {{count}} місяця', // TODO
+      pluralGenitive: 'приблизно за {{count}} місяців' // TODO
+    }
+  }),
+
+  xWeeks: buildLocalizeTokenFn({
+    regular: {
+      singularNominative: '{{count}} місяць', // TODO
+      singularGenitive: '{{count}} місяця', // TODO
+      pluralGenitive: '{{count}} місяців' // TODO
+    }
+  }),
+
   aboutXMonths: buildLocalizeTokenFn({
     regular: {
       singularNominative: 'близько {{count}} місяця',
@@ -220,7 +241,7 @@ var formatDistanceLocale = {
   })
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
   return formatDistanceLocale[token](count, options)
 }

--- a/src/locale/uz/_lib/formatDistance/index.js
+++ b/src/locale/uz/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} kun'
   },
 
+  aboutXWeeks: {
+    one: 'tahminan 1 oy', // TODO
+    other: 'tahminan {{count}} oy' // TODO
+  },
+
+  xWeeks: {
+    one: '1 oy', // TODO
+    other: '{{count}} oy' // TODO
+  },
+
   aboutXMonths: {
     one: 'tahminan 1 oy',
     other: 'tahminan {{count}} oy'

--- a/src/locale/uz/_lib/formatDistance/index.js
+++ b/src/locale/uz/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'tahminan 1 oy', // TODO
-    other: 'tahminan {{count}} oy' // TODO
+    one: 'tahminan 1 hafta',
+    other: 'tahminan {{count}} hafta'
   },
 
   xWeeks: {
-    one: '1 oy', // TODO
-    other: '{{count}} oy' // TODO
+    one: '1 hafta',
+    other: '{{count}} hafta'
   },
 
   aboutXMonths: {

--- a/src/locale/vi/_lib/formatDistance/index.js
+++ b/src/locale/vi/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'khoảng 1 tháng', // TODO
-    other: 'khoảng {{count}} tháng' // TODO
+    one: 'khoảng 1 tuần',
+    other: 'khoảng {{count}} tuần'
   },
 
   xWeeks: {
-    one: '1 tháng', // TODO
-    other: '{{count}} tháng' // TODO
+    one: '1 tuần',
+    other: '{{count}} tuần'
   },
 
   aboutXMonths: {

--- a/src/locale/vi/_lib/formatDistance/index.js
+++ b/src/locale/vi/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} ngày'
   },
 
+  aboutXWeeks: {
+    one: 'khoảng 1 tháng', // TODO
+    other: 'khoảng {{count}} tháng' // TODO
+  },
+
+  xWeeks: {
+    one: '1 tháng', // TODO
+    other: '{{count}} tháng' // TODO
+  },
+
   aboutXMonths: {
     one: 'khoảng 1 tháng',
     other: 'khoảng {{count}} tháng'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/zh-CN/_lib/formatDistance/index.js
+++ b/src/locale/zh-CN/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} 天'
   },
 
+  aboutXWeeks: {
+    one: '大约 1 个月', // TODO
+    other: '大约 {{count}} 个月' // TODO
+  },
+
+  xWeeks: {
+    one: '1 个月', // TODO
+    other: '{{count}} 个月' // TODO
+  },
+
   aboutXMonths: {
     one: '大约 1 个月',
     other: '大约 {{count}} 个月'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/zh-CN/_lib/formatDistance/index.js
+++ b/src/locale/zh-CN/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: '大约 1 个星期', // TODO
-    other: '大约 {{count}} 个星期' // TODO
+    one: '大约 1 个星期',
+    other: '大约 {{count}} 个星期'
   },
 
   xWeeks: {
-    one: '1 个星期', // TODO
-    other: '{{count}} 个星期' // TODO
+    one: '1 个星期',
+    other: '{{count}} 个星期'
   },
 
   aboutXMonths: {

--- a/src/locale/zh-CN/_lib/formatDistance/index.js
+++ b/src/locale/zh-CN/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: '大约 1 个月', // TODO
-    other: '大约 {{count}} 个月' // TODO
+    one: '大约 1 个星期', // TODO
+    other: '大约 {{count}} 个星期' // TODO
   },
 
   xWeeks: {
-    one: '1 个月', // TODO
-    other: '{{count}} 个月' // TODO
+    one: '1 个星期', // TODO
+    other: '{{count}} 个星期' // TODO
   },
 
   aboutXMonths: {

--- a/src/locale/zh-TW/_lib/formatDistance/index.js
+++ b/src/locale/zh-TW/_lib/formatDistance/index.js
@@ -36,6 +36,16 @@ var formatDistanceLocale = {
     other: '{{count}} 天'
   },
 
+  aboutXWeeks: {
+    one: '大約 1 個月', // TODO
+    other: '大約 {{count}} 個月' // TODO
+  },
+
+  xWeeks: {
+    one: '1 個月', // TODO
+    other: '{{count}} 個月' // TODO
+  },
+
   aboutXMonths: {
     one: '大約 1 個月',
     other: '大約 {{count}} 個月'
@@ -67,7 +77,7 @@ var formatDistanceLocale = {
   }
 }
 
-export default function formatDistance (token, count, options) {
+export default function formatDistance(token, count, options) {
   options = options || {}
 
   var result

--- a/src/locale/zh-TW/_lib/formatDistance/index.js
+++ b/src/locale/zh-TW/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: '大約 1 個月', // TODO
-    other: '大約 {{count}} 個月' // TODO
+    one: '大約 1 个星期',
+    other: '大約 {{count}} 个星期'
   },
 
   xWeeks: {
-    one: '1 個月', // TODO
-    other: '{{count}} 個月' // TODO
+    one: '1 个星期',
+    other: '{{count}} 个星期'
   },
 
   aboutXMonths: {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -408,6 +408,16 @@ declare module 'date-fns' {
   ): string
   namespace formatDistanceToNowStrict {}
 
+  function formatDuration(
+    duration: Duration,
+    options?: {
+      format?: string[]
+      zero?: boolean
+      delimiter?: string
+    }
+  ): string
+  namespace formatDuration {}
+
   function formatISO(
     date: Date | number,
     options?: {
@@ -1278,6 +1288,11 @@ declare module 'date-fns/formatDistanceToNow' {
 declare module 'date-fns/formatDistanceToNowStrict' {
   import { formatDistanceToNowStrict } from 'date-fns'
   export default formatDistanceToNowStrict
+}
+
+declare module 'date-fns/formatDuration' {
+  import { formatDuration } from 'date-fns'
+  export default formatDuration
 }
 
 declare module 'date-fns/formatISO' {
@@ -2240,6 +2255,11 @@ declare module 'date-fns/formatDistanceToNowStrict/index' {
   export default formatDistanceToNowStrict
 }
 
+declare module 'date-fns/formatDuration/index' {
+  import { formatDuration } from 'date-fns'
+  export default formatDuration
+}
+
 declare module 'date-fns/formatISO/index' {
   import { formatISO } from 'date-fns'
   export default formatISO
@@ -3200,6 +3220,11 @@ declare module 'date-fns/formatDistanceToNowStrict/index.js' {
   export default formatDistanceToNowStrict
 }
 
+declare module 'date-fns/formatDuration/index.js' {
+  import { formatDuration } from 'date-fns'
+  export default formatDuration
+}
+
 declare module 'date-fns/formatISO/index.js' {
   import { formatISO } from 'date-fns'
   export default formatISO
@@ -4150,6 +4175,20 @@ declare module 'date-fns/fp' {
   >
   namespace formatDistanceWithOptions {}
 
+  const formatDuration: CurriedFn1<Duration, string>
+  namespace formatDuration {}
+
+  const formatDurationWithOptions: CurriedFn2<
+    {
+      delimiter?: string
+      zero?: boolean
+      format?: string[]
+    },
+    Duration,
+    string
+  >
+  namespace formatDurationWithOptions {}
+
   const formatISO: CurriedFn1<Date | number, string>
   namespace formatISO {}
 
@@ -5045,6 +5084,16 @@ declare module 'date-fns/fp/formatDistanceStrictWithOptions' {
 declare module 'date-fns/fp/formatDistanceWithOptions' {
   import { formatDistanceWithOptions } from 'date-fns/fp'
   export default formatDistanceWithOptions
+}
+
+declare module 'date-fns/fp/formatDuration' {
+  import { formatDuration } from 'date-fns/fp'
+  export default formatDuration
+}
+
+declare module 'date-fns/fp/formatDurationWithOptions' {
+  import { formatDurationWithOptions } from 'date-fns/fp'
+  export default formatDurationWithOptions
 }
 
 declare module 'date-fns/fp/formatISO' {
@@ -6042,6 +6091,16 @@ declare module 'date-fns/fp/formatDistanceWithOptions/index' {
   export default formatDistanceWithOptions
 }
 
+declare module 'date-fns/fp/formatDuration/index' {
+  import { formatDuration } from 'date-fns/fp'
+  export default formatDuration
+}
+
+declare module 'date-fns/fp/formatDurationWithOptions/index' {
+  import { formatDurationWithOptions } from 'date-fns/fp'
+  export default formatDurationWithOptions
+}
+
 declare module 'date-fns/fp/formatISO/index' {
   import { formatISO } from 'date-fns/fp'
   export default formatISO
@@ -7035,6 +7094,16 @@ declare module 'date-fns/fp/formatDistanceStrictWithOptions/index.js' {
 declare module 'date-fns/fp/formatDistanceWithOptions/index.js' {
   import { formatDistanceWithOptions } from 'date-fns/fp'
   export default formatDistanceWithOptions
+}
+
+declare module 'date-fns/fp/formatDuration/index.js' {
+  import { formatDuration } from 'date-fns/fp'
+  export default formatDuration
+}
+
+declare module 'date-fns/fp/formatDurationWithOptions/index.js' {
+  import { formatDurationWithOptions } from 'date-fns/fp'
+  export default formatDurationWithOptions
 }
 
 declare module 'date-fns/fp/formatISO/index.js' {
@@ -8035,6 +8104,16 @@ declare module 'date-fns/esm' {
   ): string
   namespace formatDistanceToNowStrict {}
 
+  function formatDuration(
+    duration: Duration,
+    options?: {
+      format?: string[]
+      zero?: boolean
+      delimiter?: string
+    }
+  ): string
+  namespace formatDuration {}
+
   function formatISO(
     date: Date | number,
     options?: {
@@ -8905,6 +8984,11 @@ declare module 'date-fns/esm/formatDistanceToNow' {
 declare module 'date-fns/esm/formatDistanceToNowStrict' {
   import { formatDistanceToNowStrict } from 'date-fns/esm'
   export default formatDistanceToNowStrict
+}
+
+declare module 'date-fns/esm/formatDuration' {
+  import { formatDuration } from 'date-fns/esm'
+  export default formatDuration
 }
 
 declare module 'date-fns/esm/formatISO' {
@@ -9867,6 +9951,11 @@ declare module 'date-fns/esm/formatDistanceToNowStrict/index' {
   export default formatDistanceToNowStrict
 }
 
+declare module 'date-fns/esm/formatDuration/index' {
+  import { formatDuration } from 'date-fns/esm'
+  export default formatDuration
+}
+
 declare module 'date-fns/esm/formatISO/index' {
   import { formatISO } from 'date-fns/esm'
   export default formatISO
@@ -10827,6 +10916,11 @@ declare module 'date-fns/esm/formatDistanceToNowStrict/index.js' {
   export default formatDistanceToNowStrict
 }
 
+declare module 'date-fns/esm/formatDuration/index.js' {
+  import { formatDuration } from 'date-fns/esm'
+  export default formatDuration
+}
+
 declare module 'date-fns/esm/formatISO/index.js' {
   import { formatISO } from 'date-fns/esm'
   export default formatISO
@@ -11777,6 +11871,20 @@ declare module 'date-fns/esm/fp' {
   >
   namespace formatDistanceWithOptions {}
 
+  const formatDuration: CurriedFn1<Duration, string>
+  namespace formatDuration {}
+
+  const formatDurationWithOptions: CurriedFn2<
+    {
+      delimiter?: string
+      zero?: boolean
+      format?: string[]
+    },
+    Duration,
+    string
+  >
+  namespace formatDurationWithOptions {}
+
   const formatISO: CurriedFn1<Date | number, string>
   namespace formatISO {}
 
@@ -12672,6 +12780,16 @@ declare module 'date-fns/esm/fp/formatDistanceStrictWithOptions' {
 declare module 'date-fns/esm/fp/formatDistanceWithOptions' {
   import { formatDistanceWithOptions } from 'date-fns/esm/fp'
   export default formatDistanceWithOptions
+}
+
+declare module 'date-fns/esm/fp/formatDuration' {
+  import { formatDuration } from 'date-fns/esm/fp'
+  export default formatDuration
+}
+
+declare module 'date-fns/esm/fp/formatDurationWithOptions' {
+  import { formatDurationWithOptions } from 'date-fns/esm/fp'
+  export default formatDurationWithOptions
 }
 
 declare module 'date-fns/esm/fp/formatISO' {
@@ -13669,6 +13787,16 @@ declare module 'date-fns/esm/fp/formatDistanceWithOptions/index' {
   export default formatDistanceWithOptions
 }
 
+declare module 'date-fns/esm/fp/formatDuration/index' {
+  import { formatDuration } from 'date-fns/esm/fp'
+  export default formatDuration
+}
+
+declare module 'date-fns/esm/fp/formatDurationWithOptions/index' {
+  import { formatDurationWithOptions } from 'date-fns/esm/fp'
+  export default formatDurationWithOptions
+}
+
 declare module 'date-fns/esm/fp/formatISO/index' {
   import { formatISO } from 'date-fns/esm/fp'
   export default formatISO
@@ -14662,6 +14790,16 @@ declare module 'date-fns/esm/fp/formatDistanceStrictWithOptions/index.js' {
 declare module 'date-fns/esm/fp/formatDistanceWithOptions/index.js' {
   import { formatDistanceWithOptions } from 'date-fns/esm/fp'
   export default formatDistanceWithOptions
+}
+
+declare module 'date-fns/esm/fp/formatDuration/index.js' {
+  import { formatDuration } from 'date-fns/esm/fp'
+  export default formatDuration
+}
+
+declare module 'date-fns/esm/fp/formatDurationWithOptions/index.js' {
+  import { formatDurationWithOptions } from 'date-fns/esm/fp'
+  export default formatDurationWithOptions
 }
 
 declare module 'date-fns/esm/fp/formatISO/index.js' {
@@ -18171,6 +18309,15 @@ interface dateFns {
       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
       roundingMethod?: 'floor' | 'ceil' | 'round'
       locale?: Locale
+    }
+  ): string
+
+  formatDuration(
+    duration: Duration,
+    options?: {
+      format?: string[]
+      zero?: boolean
+      delimiter?: string
     }
   ): string
 


### PR DESCRIPTION
Add `formatDuration` function that allows formatting [`Duration`](https://date-fns.org/docs/Duration) object as a human-readable string, i.e.:

```js
formatDuration({ years: 0, months: 9 })
//=> '9 months'

formatDuration({ years: 0, months: 9 }, null, { zero: true })
//=> '0 years 9 months'

formatDuration({ years: 2, months: 9, weeks: 3 }, { delimiter: ', ' })
//=> '2 years, 9 months, 3 weeks'
```

A big part of this pull-request is adding weeks to locale's `formatDistance`. Meaning we have to update every locale before we can ship this PR 😱

## 🚧 Locales to update

- [x] Afrikaans `af` locale
- [x] Arabic `ar-DZ` locale (Algeria)
- [x] Arabic `ar-MA` locale (Moroccan)
- [x] Arabic `ar-SA` locale (Sauid Arabic)
- [x] Azerbaijani `az` locale
- [x] Bulgarian `bg` locale
- [x] Bengali `bn` locale
- [x] Catalan `ca` locale
- [x] Czech `cs` locale
- [x] Welsh `cy` locale
- [x] Danish `da` locale
- [x] German `de` locale
- [x] Greek `el` locale
- [x] English `en-AU` locale (Australia)
- [x] English `en-CA` locale (Canada)
- [x] English `en-GB` locale (UK)
- [x] English `en-US` locale (USA)
- [x] Esperanto `eo` locale
- [x] Spanish `es` locale
- [x] Estonian `et` locale
- [x] Persian/Farsi `fa-IR` locale (Iran)
- [x] Finnish `fi` locale
- [x] French `fr` locale
- [x] French `fr-CA` locale (Canada)
- [x] Galician `gl` locale
- [x] Gujarati `gu` locale
- [x] Hebrew `he` locale
- [x] Hindi `hi` locale
- [x] Croatian `hr` locale
- [x] Hungarian `hu` locale
- [x] Armenian `hy` locale
- [x] Indonesian `id` locale
- [x] Icelandic `is` locale
- [x] Italian `it` locale
- [x] Japanese `ja` locale
- [x] Georgian `ka` locale
- [x] Kazakh `kk` locale
- [x] Korean `ko` locale
- [x] Lithuanian `lt` locale
- [x] Latvian `lv` locale
- [x] Macedonian `mk` locale
- [x] Malay `ms` locale
- [x] Maltese `mt` locale
- [x] Norwegian Bokmål `nb` locale
- [x] Dutch `nl` locale
- [x] Norwegian Nynorsk `nn` locale
- [x] Polish `pl` locale
- [x] Portuguese `bt-BR` locale (Brazil)
- [x] Romanian `ro` locale
- [x] Russian `ru` locale
- [x] Slovak `sk` locale
- [x] Slovenian `sl` locale
- [x] Serbian cyrillic `sr` locale
- [x] Serbian latin `sr-Latn` locale
- [x] Swedish `sv` locale
- [x] Tamil `ta` locale (India)
- [x] Telugu `te` locale
- [x] Thai `th` locale
- [x] Turkish `tr` locale
- [x] Uighur `ug` locale
- [x] Ukrainian `uk` locale
- [x] Uzbek `uz` locale
- [x] Vietnamese `vi` locale
- [x] Chinese Simplified `zh-CN` locale
- [x] Chinese Traditional `zh-TW` locale