### PR TITLE
Makes parse optional params optional

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -743,8 +743,8 @@ declare module 'date-fns' {
 
   function parse(
     dateString: string,
-    formatString: string,
-    referenceDate: Date | number,
+    formatString?: string,
+    referenceDate?: Date | number,
     options?: {
       locale?: Locale
       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6


### PR DESCRIPTION
As seen in the README, the parameters for parse are optional.
This is not reflected in the types.