### PR TITLE
Change to September in addDays example

### DIFF
--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -21,7 +21,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *
  * @example
  * // Add 10 days to 1 September 2014:
- * var result = addDays(new Date(2014, 8, 1), 10)
+ * var result = addDays(new Date(2014, 9, 1), 10)
  * //=> Thu Sep 11 2014 00:00:00
  */
 export default function addDays(dirtyDate, dirtyAmount) {


### PR DESCRIPTION
Change from August to September in example for addDays so that the example reflects example information. 