### PR TITLE
fix(formatDistance): gu locale for aboutXWeeks and xWeeks

### DIFF
--- a/src/locale/gu/_lib/formatDistance/index.js
+++ b/src/locale/gu/_lib/formatDistance/index.js
@@ -38,13 +38,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'આશરે 1 મહિનો', // TODO
-    other: 'આશરે {{count}} મહિના' // TODO
+    one: 'આશરે 1 અઠવાડિયું',
+    other: 'આશરે {{count}} અઠવાડિયા'
   },
 
   xWeeks: {
-    one: '1 મહિનો', // TODO
-    other: '{{count}} મહિના' // TODO
+    one: '1 અઠવાડિયું',
+    other: '{{count}} અઠવાડિયા'
   },
 
   aboutXMonths: {


### PR DESCRIPTION
This PR updates translation texts for `aboutXWeeks` and `xWeeks` tokens for the Gujarati (gu) language as requested. Please let me know if there's any correction required.