### PR TITLE
WIP: Double the speed of addMonths() while reducing its dependencies & code size

### DIFF
--- a/src/add/index.js
+++ b/src/add/index.js
@@ -57,10 +57,13 @@ export default function add(dirtyDate, duration) {
   const seconds = 'seconds' in duration ? toInteger(duration.seconds) : 0
 
   // Add years and months
-  const dateWithMonths = addMonths(toDate(dirtyDate), months + years * 12)
+  const date = toDate(dirtyDate)
+  const dateWithMonths =
+    months || years ? addMonths(date, months + years * 12) : date
 
   // Add weeks and days
-  const dateWithDays = addDays(dateWithMonths, days + weeks * 7)
+  const dateWithDays =
+    days || weeks ? addDays(dateWithMonths, days + weeks * 7) : dateWithMonths
 
   // Add days, hours, minutes and seconds
   const minutesToAdd = minutes + hours * 60

--- a/src/add/test.js
+++ b/src/add/test.js
@@ -3,6 +3,7 @@
 
 import assert from 'power-assert'
 import add from '.'
+import { getDstTransitions } from '../../test/dst/tzOffsetTransitions'
 
 describe('add', function() {
   it('adds the values from the given object', function() {
@@ -50,6 +51,20 @@ describe('add', function() {
     var result = add(date, { months: 9 })
     assert.deepEqual(result, new Date(2015, 8 /* Sep */, 30))
   })
+
+  const dstTransitions = getDstTransitions(2017)
+  const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz
+  const HOUR = 1000 * 60 * 60
+
+  dstOnly(
+    `works at DST-end boundary in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = dstTransitions.end
+      var result = add(date, { hours: 1 })
+      assert.deepEqual(result, new Date(date.getTime() + HOUR))
+    }
+  )
 
   it('handles dates before 100 AD', function() {
     var initialDate = new Date(0)

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -1,6 +1,5 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
-import getDaysInMonth from '../getDaysInMonth/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
@@ -30,13 +29,43 @@ export default function addMonths(dirtyDate, dirtyAmount) {
 
   var date = toDate(dirtyDate)
   var amount = toInteger(dirtyAmount)
-  var desiredMonth = date.getMonth() + amount
-  var dateWithDesiredMonth = new Date(0)
-  dateWithDesiredMonth.setFullYear(date.getFullYear(), desiredMonth, 1)
-  dateWithDesiredMonth.setHours(0, 0, 0, 0)
-  var daysInMonth = getDaysInMonth(dateWithDesiredMonth)
-  // Set the last day of the new month
-  // if the original date was the last day of the longer month
-  date.setMonth(desiredMonth, Math.min(daysInMonth, date.getDate()))
-  return date
+  if (isNaN(amount)) {
+    return new Date(NaN)
+  }
+  if (!amount) {
+    // If 0 months, no-op to avoid changing times in the hour before end of DST
+    return date
+  }
+  var dayOfMonth = date.getDate()
+
+  // The JS Date object supports date math by accepting out-of-bounds values for
+  // month, day, etc. For example, new Date(2020, 1, 0) returns 31 Dec 2019 and
+  // new Date(2020, 13, 1) returns 1 Feb 2021.  This is *almost* the behavior we
+  // want except that dates will wrap around the end of a month, meaning that
+  // new Date(2020, 13, 31) will return 3 Mar 2021 not 28 Feb 2021 as desired. So
+  // we'll default to the end of the desired month by adding 1 to the desired
+  // month and using a date of 0 to back up one day to the end of the desired
+  // month.
+  var endOfDesiredMonth = new Date(date.getTime())
+  endOfDesiredMonth.setMonth(date.getMonth() + amount + 1, 0)
+  var daysInMonth = endOfDesiredMonth.getDate()
+  if (dayOfMonth >= daysInMonth) {
+    // If we're already at the end of the month, then this is the correct date
+    // and we're done.
+    return endOfDesiredMonth
+  } else {
+    // Otherwise, we now know that setting the original day-of-month value won't
+    // cause an overflow, so set the desired day-of-month. Note that we can't
+    // just set the date of `dateCopy` because that object may have had its time
+    // changed in the unusual case where where a DST transition was on the last
+    // day of the month and its local time was in the hour skipped or repeated
+    // next to a DST transition.  So we use `date` instead which is guaranteed
+    // to still have the original time.
+    date.setFullYear(
+      endOfDesiredMonth.getFullYear(),
+      endOfDesiredMonth.getMonth(),
+      dayOfMonth
+    )
+    return date
+  }
 }


### PR DESCRIPTION
_EDIT: Oops, my optimization may have a flaw: if the last day of the new month is a DST transition, then the time on that day may be reset to avoid the "dead hour" or "ambiguous hour" caused by the DST transition. Then, when the date is set to the actual day-of-month, the time needs to be put back to what it was originally. Anyway, I'm marking this PR as a work-in-progress until I can add more tests to capture this case, and to fix it if tests fail. This might mean that this optimization isn't really helpful and I'll close the PR if so._

While investigating #1510 I spent some time optimizing `addMonths`. This PR: 

* Simplifies the code to make it more readable
* Removes the dependency on `getDaysInMonth`
* Removes several lines of code and multiple Date method calls.
* Removes creation of an extra `Date` object
* The changes above doubled the speed of this method (according to `yarn benchmark`) from 526410 ops/sec to 1048890 ops/sec on my 2015 MacBook Pro.

All tests continue to pass.  I also added two passing test cases to ensure that `addMonths` works properly across a DST-start and DST-end boundary.