### PR TITLE
Fix 2.11->2.12 DST issues with differenceInDays (fix #1750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ This change log follows the format documented in [Keep a CHANGELOG].
 
 ## Unreleased
 
-Thanks to [@JorenVos](https://github.com/JorenVos), [@developergouli](https://github.com/developergouli), [@rhlowe](https://github.com/rhlowe) for working on the release!
+Thanks to [@JorenVos](https://github.com/JorenVos), [@developergouli](https://github.com/developergouli), [@rhlowe](https://github.com/rhlowe), [@justingrant](http://github.com/justingrant) for working on the release!
 
 ### Fixed
 
 - [Fixed mei abbreviation in the Dutch locale](https://github.com/date-fns/date-fns/pull/1752).
+- [Fix differenceInDays DST behavior broken in 2.12.0](https://github.com/date-fns/date-fns/pull/1754).
 
 ### Added
 

--- a/src/differenceInCalendarDays/test.js
+++ b/src/differenceInCalendarDays/test.js
@@ -3,6 +3,7 @@
 
 import assert from 'power-assert'
 import differenceInCalendarDays from '.'
+import { getDstTransitions } from '../../test/dst/tzOffsetTransitions'
 
 describe('differenceInCalendarDays', function() {
   it('returns the number of calendar days between the given dates', function() {
@@ -102,4 +103,102 @@ describe('differenceInCalendarDays', function() {
     assert.throws(differenceInCalendarDays.bind(null), TypeError)
     assert.throws(differenceInCalendarDays.bind(null, 1), TypeError)
   })
+
+  // These tests were copy-pasted almost unchagned from DST tests for
+  // `differenceInDays`
+  const dstTransitions = getDstTransitions(2017)
+  const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz
+  dstOnly(
+    `works across DST start & end in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      const { start, end } = dstTransitions
+      const HOUR = 1000 * 60 * 60
+      function sameTime(t1, t2) {
+        return (
+          t1.getHours() === t2.getHours() &&
+          t1.getMinutes() === t2.getMinutes() &&
+          t1.getSeconds() === t2.getSeconds() &&
+          t1.getMilliseconds() === t2.getMilliseconds()
+        )
+      }
+
+      // TEST DST START (SPRING)
+
+      // anchor to one hour before the boundary
+      {
+        const a = new Date(start.getTime() - HOUR) // 1 hour before DST
+        const b = new Date(a.getTime() + 23 * HOUR) // 1 day later, same local time
+        const c = new Date(a.getTime() + 47 * HOUR) // 2 days later, same local time
+
+        assert(sameTime(a, b))
+        assert(sameTime(a, c))
+        assert(sameTime(b, c))
+        assert(differenceInCalendarDays(c, b) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(b, a) === 1) // 23 hours -> 1 day
+        assert(differenceInCalendarDays(c, a) === 2) // 47 hours -> 2 days
+      }
+      // anchor exactly at the boundary
+      {
+        const a = start // exactly when DST starts
+        const b = new Date(a.getTime() + 24 * HOUR) // 1 day later, same local time
+        const c = new Date(a.getTime() + 48 * HOUR) // 2 days later, same local time
+
+        assert(sameTime(a, b))
+        assert(sameTime(a, c))
+        assert(sameTime(b, c))
+        assert(differenceInCalendarDays(c, b) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(b, a) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(c, a) === 2) // 2 normal 24-hour days
+      }
+
+      // TEST DST END (FALL)
+
+      // make sure that diffs across a "fall back" DST boundary won't report a full day
+      // until 25 hours have elapsed.
+      {
+        const a = new Date(end.getTime() - HOUR / 2) // 1 hour before Standard Time starts
+        const b = new Date(a.getTime() + 24.75 * HOUR) // 1 day later, 15 mins earlier local time
+        const c = new Date(a.getTime() + 48.75 * HOUR) // 2 days later, 15 mins earlier local time
+
+        assert(differenceInCalendarDays(c, b) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(b, a) === 1) // 24.75 hours but 1 calendar days
+        assert(differenceInCalendarDays(c, a) === 2) // 49.75 hours but 2 calendar days
+      }
+      // anchor to one hour before the boundary
+      {
+        const a = new Date(end.getTime() - HOUR) // 1 hour before Standard Time starts
+        const b = new Date(a.getTime() + 25 * HOUR) // 1 day later, same local time
+        const c = new Date(a.getTime() + 49 * HOUR) // 2 days later, same local time
+
+        assert(sameTime(a, b))
+        assert(sameTime(a, c))
+        assert(sameTime(b, c))
+        assert(differenceInCalendarDays(c, b) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(b, a) === 1) // 25 hours -> 1 day
+        assert(differenceInCalendarDays(c, a) === 2) // 49 hours -> 2 days
+      }
+      // anchor to one hour after the boundary
+      {
+        const a = new Date(end.getTime() + HOUR) // 1 hour after Standard Time starts
+        const b = new Date(a.getTime() + 24 * HOUR) // 1 day later, same local time
+        const c = new Date(a.getTime() + 48 * HOUR) // 2 days later, same local time
+
+        assert(sameTime(a, b))
+        assert(sameTime(a, c))
+        assert(sameTime(b, c))
+        assert(differenceInCalendarDays(c, b) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(b, a) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(c, a) === 2) // 2 normal 24-hour days
+      }
+      // anchor exactly at the boundary
+      {
+        const a = end // exactly when Standard Time starts
+        const b = new Date(a.getTime() + 24 * HOUR) // 1 day later, same local time
+        const c = new Date(a.getTime() + 48 * HOUR) // 2 days later, same local time
+        assert(differenceInCalendarDays(b, a) === 1) // normal 24-hour day
+        assert(differenceInCalendarDays(c, a) === 2) // 2 normal 24-hour days
+      }
+    }
+  )
 })

--- a/src/differenceInDays/index.js
+++ b/src/differenceInDays/index.js
@@ -1,5 +1,30 @@
 import toDate from '../toDate/index.js'
+import differenceInCalendarDays from '../differenceInCalendarDays/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.js'
+
+// Like `compareAsc` but uses local time not UTC, which is needed
+// for accurate equality comparisons of UTC timestamps that end up
+// having the same representation in local time, e.g. one hour before
+// DST ends vs. the instant that DST ends.
+function compareLocalAsc(dateLeft, dateRight) {
+  var diff =
+    dateLeft.getFullYear() - dateRight.getFullYear() ||
+    dateLeft.getMonth() - dateRight.getMonth() ||
+    dateLeft.getDate() - dateRight.getDate() ||
+    dateLeft.getHours() - dateRight.getHours() ||
+    dateLeft.getMinutes() - dateRight.getMinutes() ||
+    dateLeft.getSeconds() - dateRight.getSeconds() ||
+    dateLeft.getMilliseconds() - dateRight.getMilliseconds()
+
+  if (diff < 0) {
+    return -1
+  } else if (diff > 0) {
+    return 1
+    // Return 0 if diff is 0; return NaN if diff is NaN
+  } else {
+    return diff
+  }
+}
 
 /**
  * @name differenceInDays
@@ -7,8 +32,15 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * @summary Get the number of full days between the given dates.
  *
  * @description
- * Get the number of full day periods between the given dates.
- * This function returns the difference in days as an integer whole number of 24 hour periods between two timestamps,  and thereby ignores DST changes.
+ * Get the number of full day periods between two dates. Fractional days are
+ * truncated towards zero.
+ *
+ * One "full day" is the distance between a local time in one day to the same
+ * local time on the next or previous day. A full day can sometimes be less than
+ * or more than 24 hours if a daylight savings change happens between two dates.
+ *
+ * To ignore DST and only measure exact 24-hour periods, use this instead:
+ * `Math.floor(differenceInHours(dateLeft, dateRight)/24)|0`.
  *
  *
  * ### v2.0.0 breaking changes:
@@ -17,7 +49,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *
  * @param {Date|Number} dateLeft - the later date
  * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of full days
+ * @returns {Number} the number of full days according to the local timezone
  * @throws {TypeError} 2 arguments required
  *
  * @example
@@ -28,25 +60,40 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *   new Date(2011, 6, 2, 23, 0)
  * )
  * //=> 365
- * // How many days are between
+ * // How many full days are between
  * // 2 July 2011 23:59:00 and 3 July 2011 00:01:00?
  * var result = differenceInDays(
  *   new Date(2011, 6, 3, 0, 1),
  *   new Date(2011, 6, 2, 23, 59)
  * )
  * //=> 0
+ * // How many full days are between
+ * // 1 March 2020 0:00 and 1 June 2020 0:00 ?
+ * // Note: because local time is used, the
+ * // result will always be 51 days, even in
+ * // time zones where DST starts and the
+ * // period has only 51*24-1 hours.
+ * var result = differenceInDays(
+ *   new Date(2020, 5, 1),
+ *   new Date(2020, 2, 1)
+ * )
+//=> 51
  */
-var MILLISECONDS_IN_DAY = 86400000
-
 export default function differenceInDays(dirtyDateLeft, dirtyDateRight) {
   requiredArgs(2, arguments)
 
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)
 
-  var result = (dateLeft - dateRight) / MILLISECONDS_IN_DAY
+  var sign = compareLocalAsc(dateLeft, dateRight)
+  var difference = Math.abs(differenceInCalendarDays(dateLeft, dateRight))
 
-  // round towards zero
-  if (result > 0) return Math.floor(result)
-  return Math.ceil(result)
+  dateLeft.setDate(dateLeft.getDate() - sign * difference)
+
+  // Math.abs(diff in full days - diff in calendar days) === 1 if last calendar day is not full
+  // If so, result must be decreased by 1 in absolute value
+  var isLastDayNotFull = compareLocalAsc(dateLeft, dateRight) === -sign
+  var result = sign * (difference - isLastDayNotFull)
+  // Prevent negative zero
+  return result === 0 ? 0 : result
 }

--- a/src/differenceInWeeks/index.js
+++ b/src/differenceInWeeks/index.js
@@ -7,7 +7,16 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * @summary Get the number of full weeks between the given dates.
  *
  * @description
- * Get the number of full weeks between the given dates.
+ * Get the number of full weeks between two dates. Fractional weeks are
+ * truncated towards zero.
+ *
+ * One "full week" is the distance between a local time in one day to the same
+ * local time 7 days earlier or later. A full week can sometimes be less than
+ * or more than 7*24 hours if a daylight savings change happens between two dates.
+ *
+ * To ignore DST and only measure exact 7*24-hour periods, use this instead:
+ * `Math.floor(differenceInHours(dateLeft, dateRight)/(7*24))|0`.
+ *
  *
  * ### v2.0.0 breaking changes:
  *
@@ -22,6 +31,18 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * // How many full weeks are between 5 July 2014 and 20 July 2014?
  * var result = differenceInWeeks(new Date(2014, 6, 20), new Date(2014, 6, 5))
  * //=> 2
+ *
+ * // How many full weeks are between
+ * // 1 March 2020 0:00 and 6 June 2020 0:00 ?
+ * // Note: because local time is used, the
+ * // result will always be 8 weeks (54 days),
+ * // even if DST starts and the period has
+ * // only 54*24-1 hours.
+ * var result = differenceInWeeks(
+ *   new Date(2020, 5, 1),
+ *   new Date(2020, 2, 6)
+ * )
+ * //=> 8
  */
 export default function differenceInWeeks(dirtyDateLeft, dirtyDateRight) {
   requiredArgs(2, arguments)

--- a/test/dst/tzOffsetTransitions.js
+++ b/test/dst/tzOffsetTransitions.js
@@ -1,0 +1,136 @@
+/**
+ * Fetch the start and end of DST for the local time
+ * zone in a given year.
+ * We'll assume that DST start & end are the first
+ * forward and the last back transitions in the year,
+ * except transitions in Jan or Dec which are likely
+ * to be permanent TZ changes rather than DST changes.
+ * @param {number} year
+ * @returns object with two Date-valued properties:
+ * - `start` is the first instant of DST in the Spring,
+ *   or undefined if there's no DST in this year.
+ * - `end` is the first instant of standard time
+ *   in the Fall, or undefined if there's no DST in
+ *   this year.
+ */
+export function getDstTransitions(year) {
+  var result = {
+    start: undefined,
+    end: undefined
+  }
+  var transitions = getTzOffsetTransitions(year)
+  for (var i = 0; i < transitions.length; i++) {
+    var t = transitions[i]
+    var month = t.date.getMonth()
+    if (month > 0 && month < 11) {
+      if (t.type === 'forward') result.start = t.date
+      if (t.type === 'back' && !result.end) result.end = t.date
+    }
+  }
+  return result
+}
+
+function isValidDate(d) {
+  return d instanceof Date && !isNaN(d)
+}
+
+var MINUTE = 1000 * 60
+
+function firstTickInLocalDay(date) {
+  var dateNumber = date.getDate()
+  var prev = date
+  var d = date
+  do {
+    prev = d
+    d = new Date(d.getTime() - MINUTE)
+  } while (dateNumber === d.getDate())
+  return prev
+}
+
+function fiveMinutesLater(date) {
+  return new Date(date.getTime() + 5 * MINUTE)
+}
+function oneDayLater(date) {
+  var d = new Date(date)
+  d.setDate(d.getDate() + 1)
+  return firstTickInLocalDay(d)
+}
+function previousTickTimezoneOffset(date) {
+  var d = new Date(date.getTime() - 1)
+  return d.getTimezoneOffset()
+}
+
+/**
+ * Fetch all timezone-offset transitions in a given
+ * year.  These are almost always DST transitions,
+ * but sometimes there are non-DST changes, e.g.
+ * when a country changes its time zone
+ * @param {number} year
+ * @returns array of objects, each  with the following 
+ * propeerties:
+ * - `date` - a `Date` representing the first instant
+ *   when the new timezone offset is effective.
+ * - `type` - either `forward` for skippnig time like
+ *   the Spring transition to DST.
+ * - `before` - the timezone offset before the tranition.
+ *   For example, the UTC-0400 offset will return -240.
+ *   To match how times are displayed in ISO 8601 format,
+ *   the sign of this value is reversed from the return
+ *   value of `Date.getTimezoneOffset`.
+ * - `after` - the timezone offset after the tranition.
+ *   Examples and caveats are the same as `before`.
+
+ */
+export function getTzOffsetTransitions(year) {
+  // start at the end of the previous day
+  var date = firstTickInLocalDay(new Date(year, 0, 1))
+  if (!isValidDate(date)) {
+    throw new Error('Invalid Date')
+  }
+  var baseTzOffset = previousTickTimezoneOffset(date)
+  var transitions = []
+  do {
+    var tzOffset = date.getTimezoneOffset()
+    if (baseTzOffset !== tzOffset) {
+      if (tzOffset !== previousTickTimezoneOffset(date)) {
+        // Transition is the first tick of a local day.
+        transitions.push({
+          date: date,
+          type: tzOffset < baseTzOffset ? 'forward' : 'back',
+          before: -baseTzOffset,
+          after: -tzOffset
+        })
+        baseTzOffset = tzOffset
+      } else {
+        // transition was not at the start of the day, so it must have happened
+        // yesterday. Back up one day and find the minute where it happened.
+        var transitionDate = new Date(date.getTime())
+        transitionDate.setDate(transitionDate.getDate() - 1)
+
+        // Iterate through each 5 mins of the day until we find a transition.
+        // TODO: this could be optimized to search hours then minutes or by or
+        // by using a binary search.
+        var dayNumber = transitionDate.getDate()
+        while (
+          isValidDate(transitionDate) &&
+          transitionDate.getDate() === dayNumber
+        ) {
+          tzOffset = transitionDate.getTimezoneOffset()
+          if (baseTzOffset !== tzOffset) {
+            transitions.push({
+              date: transitionDate,
+              type: tzOffset < baseTzOffset ? 'forward' : 'back',
+              before: -baseTzOffset,
+              after: -tzOffset
+            })
+            baseTzOffset = tzOffset
+            break // assuming only 1 transition per day
+          }
+          transitionDate = fiveMinutesLater(transitionDate)
+        }
+      }
+    }
+    date = oneDayLater(date)
+  } while (date.getFullYear() === year)
+  return transitions
+}


### PR DESCRIPTION
As documented in #1750, date-fns 2.12 (specifically #1630) contained a breaking change that made `differenceInDays` stop matching `addDays` across a DST boundary.  This PR replaces #1630 with an implementation that fixes #533 (like #1630 did) without causing #1750 (like #1630 also did).

This PR: 
* Fixes #1750 by restoring the 2.11 implementation of `differenceInDays` (so should code-review against 2.11 implementation) but modifying it to fix #533 without triggering #1750. It does this by replacing the use in `differenceInDays` of `compareAsc` with a new local function (`compareLocalAsc`) that compares using local time not UTC timestamps. This change prevents errors when one of the times is on a DST boundary or contains an ambiguous local time due to DST.
* Adds new DST tests for `differenceInDays` to validate the work above. These tests will work in any timezone, thanks to new shared test code that detects DST start in the local timezone. All DST tests in this PR are relative to the DST start/end dates detected for the current timezone. These tests will be skipped in non-DST time zones. 
* Validates that all tests run OK in the America/Los_Angeles, America/Sao_Paulo, Australia/Sydney, and Europe/London timezones. This was done by temporarily adding a TZ env to the `yarn test` script command and then manually running tests under each TZ.
* Adds new JSDoc content and samples for `differenceInDays` to document DST behavior and to explain how to get non-DST behavior (full 24-hour periods only) using `Math.floor(differenceInHours(dateLeft, dateRight)/24)|0`.
* Adds analogous JSDoc content to `differenceInWeeks` which is implemented using `differenceInDays` and shares its DST behavior.
* Updates the changelog with a new empty release section as requested in CONTRIBUTING.md,

**Fix Details**

#533, like most JS bugs related to DST, happened because the pre-2.12 implementation of `differenceInDays` mixed UTC and local date calculations: `CompareAsc` uses UTC comparisons while `Date.setDate` (used in `differenceInDays`) uses local timezone math. The result: on or around DST boundaries `CompareAsc` returned results which suggested that the difference was not a full day when it really was, or vice versa. This led to off-by-one errors in results like #533.

The fix was to restore the 2.11 implementation of `differenceInDays` (effectively reverting #1630) and simply replace usage of `compareAsc` with a new local function `compareLocalAsc` that uses local date math instead.

If you really want to get into the weeds to understand how `setDate` works and why #533 happened, start here: 
* https://tc39.es/ecma262/#sec-date.prototype.setdate
* https://tc39.es/ecma262/#sec-local-time-zone-adjustment

**Discussion**

_"Full Days": 24-hour periods vs. matching local times_ 

Some contributors in #533 suggested that date diffs should be measured in 24-hour periods only and should ignore DST.  To see why this is problematic, imagine a user measures a 7-day period from (local) noon to (local) noon one week later.  If we only diff 24-hour periods, then that period would measure 7 days most of the year, but would return 6 days if DST started in the middle.  This intermittent variation is a certain cause of hard-to-diagnose bugs, and is also different from how date-fns has behaved for a long time.  That's why this PR goes back to the 2.11 behavior of taking DST into account.  BTW, if a developer wants to ignore DST and just count 24-hour periods, this PR documents one way (`Math.floor(differenceInHours(dateLeft, dateRight)/24)|0`) in user-visible JSDoc comments.

_API Consistency_

I admit that I couldn't fully understand the consistency discussion in #533. To me it seems like the pre-2.12 behavior was *more* consistent, because in 2.11 `differenceInDays` was consistent with `addDays`, and `differenceInDays` was also consistent with `differenceInMonths`.  And with JS Date APIs like `Date.setDate`.

_Guidelines_

In case it's helpful, here are three general rules of thumb that I use for safe date math:
* For adding/subtracting/comparing hours (and smaller) units, convert to UTC and do all math in UTC.
* For adding/subtracting/comparing days (and larger) units, only use local timezone math, not UTC (unless UTC is the local timezone!) because users expect that day and larger APIs return the same results whether or not a DST transition happened.  Here's a discussion about the same topic in moment.js: https://github.com/moment/moment/issues/78#issuecomment-2979637
* Know which APIs use local vs. UTC math, and don't mix them unless you really, really know what you're doing. When you mix UTC APIs like `Date.getDate` with local APIs like `date.setDate`, it's easy to end up with off-by-one-hour bugs like #533 or #1083 1510.

**Future Investigation Needed**

TODO: I suspect that `differenceInMonths`, `differenceInISOWeekYears`, and `differenceInYears` are vulnerable to the same bug but I didn't have the time yet to investigate but I wanted to get this breaking-change fix out ASAP.

