### PR TITLE
Fix DST issues with add & addMonths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ This change log follows the format documented in [Keep a CHANGELOG].
 [semantic versioning]: http://semver.org/
 [keep a changelog]: http://keepachangelog.com/
 
+## Unreleased
+
+Thanks to [@justingrant](http://github.com/justingrant) for working on the release!
+
+### Fixed
+
+- [Fix DST issues with add & addMonths](https://github.com/date-fns/date-fns/pull/1760).
+
+### Added
+
+-
+
 ## [2.13.0] - 2020-05-06
 
 Thanks to [@JorenVos](https://github.com/JorenVos), [@developergouli](https://github.com/developergouli), [@rhlowe](https://github.com/rhlowe) and [@justingrant](http://github.com/justingrant) for working on the release!

--- a/src/add/index.js
+++ b/src/add/index.js
@@ -57,10 +57,13 @@ export default function add(dirtyDate, duration) {
   const seconds = 'seconds' in duration ? toInteger(duration.seconds) : 0
 
   // Add years and months
-  const dateWithMonths = addMonths(toDate(dirtyDate), months + years * 12)
+  const date = toDate(dirtyDate)
+  const dateWithMonths =
+    months || years ? addMonths(date, months + years * 12) : date
 
   // Add weeks and days
-  const dateWithDays = addDays(dateWithMonths, days + weeks * 7)
+  const dateWithDays =
+    days || weeks ? addDays(dateWithMonths, days + weeks * 7) : dateWithMonths
 
   // Add days, hours, minutes and seconds
   const minutesToAdd = minutes + hours * 60

--- a/src/add/test.js
+++ b/src/add/test.js
@@ -3,6 +3,7 @@
 
 import assert from 'power-assert'
 import add from '.'
+import { getDstTransitions } from '../../test/dst/tzOffsetTransitions'
 
 describe('add', function() {
   it('adds the values from the given object', function() {
@@ -50,6 +51,20 @@ describe('add', function() {
     var result = add(date, { months: 9 })
     assert.deepEqual(result, new Date(2015, 8 /* Sep */, 30))
   })
+
+  const dstTransitions = getDstTransitions(2017)
+  const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz
+  const HOUR = 1000 * 60 * 60
+
+  dstOnly(
+    `works at DST-end boundary in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = dstTransitions.end
+      var result = add(date, { hours: 1 })
+      assert.deepEqual(result, new Date(date.getTime() + HOUR))
+    }
+  )
 
   it('handles dates before 100 AD', function() {
     var initialDate = new Date(0)

--- a/src/addDays/index.js
+++ b/src/addDays/index.js
@@ -29,6 +29,13 @@ export default function addDays(dirtyDate, dirtyAmount) {
 
   var date = toDate(dirtyDate)
   var amount = toInteger(dirtyAmount)
+  if (isNaN(amount)) {
+    return new Date(NaN)
+  }
+  if (!amount) {
+    // If 0 days, no-op to avoid changing times in the hour before end of DST
+    return date
+  }
   date.setDate(date.getDate() + amount)
   return date
 }

--- a/src/addDays/test.js
+++ b/src/addDays/test.js
@@ -3,6 +3,7 @@
 
 import assert from 'power-assert'
 import addDays from '.'
+import { getDstTransitions } from '../../test/dst/tzOffsetTransitions'
 
 describe('addDays', function() {
   it('adds the given number of days', function() {
@@ -46,4 +47,78 @@ describe('addDays', function() {
     assert.throws(addDays.bind(null), TypeError)
     assert.throws(addDays.bind(null, 1), TypeError)
   })
+
+  const dstTransitions = getDstTransitions(2017)
+  const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz
+  const HOUR = 1000 * 60 * 60
+
+  dstOnly(
+    `works at DST-start boundary in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = dstTransitions.start
+      var result = addDays(date, 1)
+      assert.deepEqual(result, new Date(date.getTime() + 24 * HOUR))
+    }
+  )
+
+  dstOnly(
+    `works at DST-start - 30 mins in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = new Date(dstTransitions.start.getTime() - 0.5 * HOUR)
+      var result = addDays(date, 1)
+      // started before the transition so will only be 23 hours later in local time
+      assert.deepEqual(result, new Date(date.getTime() + 23 * HOUR))
+    }
+  )
+
+  dstOnly(
+    `works at DST-start - 60 mins in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = new Date(dstTransitions.start.getTime() - 1 * HOUR)
+      var result = addDays(date, 1)
+      // started before the transition so will only be 23 hours later in local time
+      assert.deepEqual(result, new Date(date.getTime() + 23 * HOUR))
+    }
+  )
+
+  dstOnly(
+    `works at DST-end boundary in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = dstTransitions.end
+      var result = addDays(date, 1)
+      assert.deepEqual(result, new Date(date.getTime() + 24 * HOUR))
+    }
+  )
+
+  dstOnly(
+    `works at DST-end - 30 mins in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = new Date(dstTransitions.end.getTime() - 0.5 * HOUR)
+      var result = addDays(date, 1)
+      // started before the transition so will be 25 hours later in local
+      // time because one hour repeats after DST ends.
+      assert.deepEqual(result, new Date(date.getTime() + 25 * HOUR))
+    }
+  )
+
+  dstOnly(
+    `works at DST-end - 60 mins in local timezone: ${tz || '(unknown)'}`,
+    function() {
+      var date = new Date(dstTransitions.end.getTime() - 1 * HOUR)
+      var result = addDays(date, 1)
+      // started before the transition so will be 25 hours later in local
+      // time because one hour repeats after DST ends.
+      assert.deepEqual(result, new Date(date.getTime() + 25 * HOUR))
+    }
+  )
+
+  dstOnly(
+    `doesn't mutate if zero increment is used: ${tz || '(unknown)'}`,
+    function() {
+      var date = new Date(dstTransitions.end)
+      var result = addDays(date, 0)
+      assert.deepEqual(result, date)
+    }
+  )
 })

--- a/src/addMonths/index.js
+++ b/src/addMonths/index.js
@@ -1,6 +1,5 @@
 import toInteger from '../_lib/toInteger/index.js'
 import toDate from '../toDate/index.js'
-import getDaysInMonth from '../getDaysInMonth/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.js'
 
 /**
@@ -30,13 +29,43 @@ export default function addMonths(dirtyDate, dirtyAmount) {
 
   var date = toDate(dirtyDate)
   var amount = toInteger(dirtyAmount)
-  var desiredMonth = date.getMonth() + amount
-  var dateWithDesiredMonth = new Date(0)
-  dateWithDesiredMonth.setFullYear(date.getFullYear(), desiredMonth, 1)
-  dateWithDesiredMonth.setHours(0, 0, 0, 0)
-  var daysInMonth = getDaysInMonth(dateWithDesiredMonth)
-  // Set the last day of the new month
-  // if the original date was the last day of the longer month
-  date.setMonth(desiredMonth, Math.min(daysInMonth, date.getDate()))
-  return date
+  if (isNaN(amount)) {
+    return new Date(NaN)
+  }
+  if (!amount) {
+    // If 0 months, no-op to avoid changing times in the hour before end of DST
+    return date
+  }
+  var dayOfMonth = date.getDate()
+
+  // The JS Date object supports date math by accepting out-of-bounds values for
+  // month, day, etc. For example, new Date(2020, 1, 0) returns 31 Dec 2019 and
+  // new Date(2020, 13, 1) returns 1 Feb 2021.  This is *almost* the behavior we
+  // want except that dates will wrap around the end of a month, meaning that
+  // new Date(2020, 13, 31) will return 3 Mar 2021 not 28 Feb 2021 as desired. So
+  // we'll default to the end of the desired month by adding 1 to the desired
+  // month and using a date of 0 to back up one day to the end of the desired
+  // month.
+  var endOfDesiredMonth = new Date(date.getTime())
+  endOfDesiredMonth.setMonth(date.getMonth() + amount + 1, 0)
+  var daysInMonth = endOfDesiredMonth.getDate()
+  if (dayOfMonth >= daysInMonth) {
+    // If we're already at the end of the month, then this is the correct date
+    // and we're done.
+    return endOfDesiredMonth
+  } else {
+    // Otherwise, we now know that setting the original day-of-month value won't
+    // cause an overflow, so set the desired day-of-month. Note that we can't
+    // just set the date of `endOfDesiredMonth` because that object may have had
+    // its time changed in the unusual case where where a DST transition was on
+    // the last day of the month and its local time was in the hour skipped or
+    // repeated next to a DST transition.  So we use `date` instead which is
+    // guaranteed to still have the original time.
+    date.setFullYear(
+      endOfDesiredMonth.getFullYear(),
+      endOfDesiredMonth.getMonth(),
+      dayOfMonth
+    )
+    return date
+  }
 }


### PR DESCRIPTION
This PR fixes #1682. Changes are fairly straightforward:
* `add` now only calls `addMonths` if `months` or `years` adding is requested, and it only calls `addDays` if `days` or `weeks` adding is requested. This fixes #1682 by preventing calls to `Date.setXXX` in cases where those calls aren't needed, which in turn prevents mutation of the time from DST end to one hour before DST end. See https://github.com/date-fns/date-fns/issues/1682#issuecomment-625062812
* `addMonths` and `addDays` now return early if `amount` of increment is zero. This prevents the same problem as #1682 but when calling `addMonths` or `addDays` directly. 
* Re-worked `addMonths` logic to avoid problems like #1758 which are caused by mixing UTC and local-time APIs.
* Added DST tests to `add`, `addMonths`, and `addDays` to verify the fixes above.
* Updated changelog