### PR TITLE
Fix formatDistance strings in Hungarian locale

### DIFF
--- a/src/locale/hu/_lib/formatDistance/index.js
+++ b/src/locale/hu/_lib/formatDistance/index.js
@@ -5,58 +5,70 @@ var translations = {
   lessthan: 'kevesebb mint'
 }
 
-function translate(number, addSuffix, key, comparison) {
-  var num = number
-  switch (key) {
-    case 'xseconds':
-      if (comparison === -1 && addSuffix) return num + ' másodperccel ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' másodperce'
-      if (comparison === 1 && addSuffix) return num + ' másodperc múlva'
-      return num + ' másodperc'
+const withoutSuffixes = {
+  xseconds: ' másodperc',
+  halfaminute: 'fél perc',
+  xminutes: ' perc',
+  xhours: ' óra',
+  xdays: ' nap',
+  xweeks: ' hét',
+  xmonths: ' hónap',
+  xyears: ' év'
+}
 
-    case 'halfaminute':
-      if (comparison === -1 && addSuffix) return 'fél perccel ezelőtt'
-      if (comparison === -1 && !addSuffix) return 'fél perce'
-      if (comparison === 1 && addSuffix) return 'fél perc múlva'
-      return 'fél perc'
-
-    case 'xminutes':
-      if (comparison === -1 && addSuffix) return num + ' perccel ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' perce'
-      if (comparison === 1 && addSuffix) return num + ' perc múlva'
-      return num + ' perc'
-
-    case 'xhours':
-      if (comparison === -1 && addSuffix) return num + ' órával ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' órája'
-      if (comparison === 1 && addSuffix) return num + ' óra múlva'
-      return num + ' óra'
-
-    case 'xdays':
-      if (comparison === -1 && addSuffix) return num + ' nappal ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' napja'
-      if (comparison === 1 && addSuffix) return num + ' nap múlva'
-      return num + ' nap'
-
-    case 'xweeks':
-      if (comparison === -1 && addSuffix) return num + ' héttel ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' hete'
-      if (comparison === 1 && addSuffix) return num + ' hét múlva'
-      return num + ' hét'
-
-    case 'xmonths':
-      if (comparison === -1 && addSuffix) return num + ' hónappal ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' hónapja'
-      if (comparison === 1 && addSuffix) return num + ' hónap múlva'
-      return num + ' hónap'
-
-    case 'xyears':
-      if (comparison === -1 && addSuffix) return num + ' évvel ezelőtt'
-      if (comparison === -1 && !addSuffix) return num + ' éve'
-      if (comparison === 1 && addSuffix) return num + ' év múlva'
-      return num + ' év'
+const withSuffixes = {
+  xseconds: {
+    [-1]: ' másodperccel ezelőtt',
+    [1]: ' másodperc múlva',
+    [0]: ' másodperce'
+  },
+  halfaminute: {
+    [-1]: 'fél perccel ezelőtt',
+    [1]: 'fél perc múlva',
+    [0]: 'fél perce'
+  },
+  xminutes: {
+    [-1]: ' perccel ezelőtt',
+    [1]: ' perc múlva',
+    [0]: ' perce'
+  },
+  xhours: {
+    [-1]: ' órával ezelőtt',
+    [1]: ' óra múlva',
+    [0]: ' órája'
+  },
+  xdays: {
+    [-1]: ' nappal ezelőtt',
+    [1]: ' nap múlva',
+    [0]: ' napja'
+  },
+  xweeks: {
+    [-1]: ' héttel ezelőtt',
+    [1]: ' hét múlva',
+    [0]: ' hete'
+  },
+  xmonths: {
+    [-1]: ' hónappal ezelőtt',
+    [1]: ' hónap múlva',
+    [0]: ' hónapja'
+  },
+  xyears: {
+    [-1]: ' évvel ezelőtt',
+    [1]: ' év múlva',
+    [0]: ' éve'
   }
-  return ''
+}
+
+function translate(number, addSuffix, key, comparison) {
+  const translated = addSuffix
+    ? withSuffixes[key][comparison]
+    : withoutSuffixes[key]
+
+  if (key == 'halfaminute') {
+    return translated
+  }
+
+  return number + translated
 }
 
 export default function formatDistance(token, count, options) {

--- a/src/locale/hu/_lib/formatDistance/index.js
+++ b/src/locale/hu/_lib/formatDistance/index.js
@@ -64,7 +64,7 @@ function translate(number, addSuffix, key, comparison) {
     ? withSuffixes[key][comparison]
     : withoutSuffixes[key]
 
-  if (key == 'halfaminute') {
+  if (key === 'halfaminute') {
     return translated
   }
 

--- a/src/locale/hu/_lib/formatDistance/index.js
+++ b/src/locale/hu/_lib/formatDistance/index.js
@@ -11,49 +11,49 @@ function translate(number, addSuffix, key, comparison) {
     case 'xseconds':
       if (comparison === -1 && addSuffix) return num + ' másodperccel ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' másodperce'
-      if (comparison === 1) return num + ' másodperc múlva'
+      if (comparison === 1 && addSuffix) return num + ' másodperc múlva'
       return num + ' másodperc'
 
     case 'halfaminute':
       if (comparison === -1 && addSuffix) return 'fél perccel ezelőtt'
       if (comparison === -1 && !addSuffix) return 'fél perce'
-      if (comparison === 1) return 'fél perc múlva'
+      if (comparison === 1 && addSuffix) return 'fél perc múlva'
       return 'fél perc'
 
     case 'xminutes':
       if (comparison === -1 && addSuffix) return num + ' perccel ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' perce'
-      if (comparison === 1) return num + ' perc múlva'
+      if (comparison === 1 && addSuffix) return num + ' perc múlva'
       return num + ' perc'
 
     case 'xhours':
       if (comparison === -1 && addSuffix) return num + ' órával ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' órája'
-      if (comparison === 1) return num + ' óra múlva'
+      if (comparison === 1 && addSuffix) return num + ' óra múlva'
       return num + ' óra'
 
     case 'xdays':
       if (comparison === -1 && addSuffix) return num + ' nappal ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' napja'
-      if (comparison === 1) return num + ' nap múlva'
+      if (comparison === 1 && addSuffix) return num + ' nap múlva'
       return num + ' nap'
 
     case 'xweeks':
       if (comparison === -1 && addSuffix) return num + ' héttel ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' hete'
-      if (comparison === 1) return num + ' hét múlva'
+      if (comparison === 1 && addSuffix) return num + ' hét múlva'
       return num + ' hét'
 
     case 'xmonths':
       if (comparison === -1 && addSuffix) return num + ' hónappal ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' hónapja'
-      if (comparison === 1) return num + ' hónap múlva'
+      if (comparison === 1 && addSuffix) return num + ' hónap múlva'
       return num + ' hónap'
 
     case 'xyears':
       if (comparison === -1 && addSuffix) return num + ' évvel ezelőtt'
       if (comparison === -1 && !addSuffix) return num + ' éve'
-      if (comparison === 1) return num + ' év múlva'
+      if (comparison === 1 && addSuffix) return num + ' év múlva'
       return num + ' év'
   }
   return ''

--- a/src/locale/hu/snapshot.md
+++ b/src/locale/hu/snapshot.md
@@ -189,105 +189,105 @@
 
 If now is January 1st, 2000, 00:00.
 
-| Date                     | Result                     | `includeSeconds: true`           | `addSuffix: true`               |
-| ------------------------ | -------------------------- | -------------------------------- | ------------------------------- |
-| 2006-01-01T00:00:00.000Z | körülbelül 6 év múlva      | körülbelül 6 év múlva            | körülbelül 6 év múlva           |
-| 2005-01-01T00:00:00.000Z | körülbelül 5 év múlva      | körülbelül 5 év múlva            | körülbelül 5 év múlva           |
-| 2004-01-01T00:00:00.000Z | körülbelül 4 év múlva      | körülbelül 4 év múlva            | körülbelül 4 év múlva           |
-| 2003-01-01T00:00:00.000Z | körülbelül 3 év múlva      | körülbelül 3 év múlva            | körülbelül 3 év múlva           |
-| 2002-01-01T00:00:00.000Z | körülbelül 2 év múlva      | körülbelül 2 év múlva            | körülbelül 2 év múlva           |
-| 2001-06-01T00:00:00.000Z | több mint 1 év múlva       | több mint 1 év múlva             | több mint 1 év múlva            |
-| 2001-02-01T00:00:00.000Z | körülbelül 1 év múlva      | körülbelül 1 év múlva            | körülbelül 1 év múlva           |
-| 2001-01-01T00:00:00.000Z | körülbelül 1 év múlva      | körülbelül 1 év múlva            | körülbelül 1 év múlva           |
-| 2000-06-01T00:00:00.000Z | 5 hónap múlva              | 5 hónap múlva                    | 5 hónap múlva                   |
-| 2000-03-01T00:00:00.000Z | 2 hónap múlva              | 2 hónap múlva                    | 2 hónap múlva                   |
-| 2000-02-01T00:00:00.000Z | körülbelül 1 hónap múlva   | körülbelül 1 hónap múlva         | körülbelül 1 hónap múlva        |
-| 2000-01-15T00:00:00.000Z | 14 nap múlva               | 14 nap múlva                     | 14 nap múlva                    |
-| 2000-01-02T00:00:00.000Z | 1 nap múlva                | 1 nap múlva                      | 1 nap múlva                     |
-| 2000-01-01T06:00:00.000Z | körülbelül 6 óra múlva     | körülbelül 6 óra múlva           | körülbelül 6 óra múlva          |
-| 2000-01-01T01:00:00.000Z | körülbelül 1 óra múlva     | körülbelül 1 óra múlva           | körülbelül 1 óra múlva          |
-| 2000-01-01T00:45:00.000Z | körülbelül 1 óra múlva     | körülbelül 1 óra múlva           | körülbelül 1 óra múlva          |
-| 2000-01-01T00:30:00.000Z | 30 perc múlva              | 30 perc múlva                    | 30 perc múlva                   |
-| 2000-01-01T00:15:00.000Z | 15 perc múlva              | 15 perc múlva                    | 15 perc múlva                   |
-| 2000-01-01T00:01:00.000Z | 1 perc múlva               | 1 perc múlva                     | 1 perc múlva                    |
-| 2000-01-01T00:00:25.000Z | kevesebb mint 1 perc múlva | fél perc múlva                   | kevesebb mint 1 perc múlva      |
-| 2000-01-01T00:00:15.000Z | kevesebb mint 1 perc múlva | kevesebb mint 20 másodperc múlva | kevesebb mint 1 perc múlva      |
-| 2000-01-01T00:00:05.000Z | kevesebb mint 1 perc múlva | kevesebb mint 10 másodperc múlva | kevesebb mint 1 perc múlva      |
-| 2000-01-01T00:00:00.000Z | kevesebb mint 1 perc       | kevesebb mint 5 másodperc        | kevesebb mint 1 perc            |
-| 1999-12-31T23:59:55.000Z | kevesebb mint 1 perce      | kevesebb mint 10 másodperce      | kevesebb mint 1 perccel ezelőtt |
-| 1999-12-31T23:59:45.000Z | kevesebb mint 1 perce      | kevesebb mint 20 másodperce      | kevesebb mint 1 perccel ezelőtt |
-| 1999-12-31T23:59:35.000Z | kevesebb mint 1 perce      | fél perce                        | kevesebb mint 1 perccel ezelőtt |
-| 1999-12-31T23:59:00.000Z | 1 perce                    | 1 perce                          | 1 perccel ezelőtt               |
-| 1999-12-31T23:45:00.000Z | 15 perce                   | 15 perce                         | 15 perccel ezelőtt              |
-| 1999-12-31T23:30:00.000Z | 30 perce                   | 30 perce                         | 30 perccel ezelőtt              |
-| 1999-12-31T23:15:00.000Z | körülbelül 1 órája         | körülbelül 1 órája               | körülbelül 1 órával ezelőtt     |
-| 1999-12-31T23:00:00.000Z | körülbelül 1 órája         | körülbelül 1 órája               | körülbelül 1 órával ezelőtt     |
-| 1999-12-31T18:00:00.000Z | körülbelül 6 órája         | körülbelül 6 órája               | körülbelül 6 órával ezelőtt     |
-| 1999-12-30T00:00:00.000Z | 2 napja                    | 2 napja                          | 2 nappal ezelőtt                |
-| 1999-12-15T00:00:00.000Z | 17 napja                   | 17 napja                         | 17 nappal ezelőtt               |
-| 1999-12-01T00:00:00.000Z | körülbelül 1 hónapja       | körülbelül 1 hónapja             | körülbelül 1 hónappal ezelőtt   |
-| 1999-11-01T00:00:00.000Z | 2 hónapja                  | 2 hónapja                        | 2 hónappal ezelőtt              |
-| 1999-06-01T00:00:00.000Z | 7 hónapja                  | 7 hónapja                        | 7 hónappal ezelőtt              |
-| 1999-01-01T00:00:00.000Z | körülbelül 1 éve           | körülbelül 1 éve                 | körülbelül 1 évvel ezelőtt      |
-| 1998-12-01T00:00:00.000Z | körülbelül 1 éve           | körülbelül 1 éve                 | körülbelül 1 évvel ezelőtt      |
-| 1998-06-01T00:00:00.000Z | több mint 1 éve            | több mint 1 éve                  | több mint 1 évvel ezelőtt       |
-| 1998-01-01T00:00:00.000Z | körülbelül 2 éve           | körülbelül 2 éve                 | körülbelül 2 évvel ezelőtt      |
-| 1997-01-01T00:00:00.000Z | körülbelül 3 éve           | körülbelül 3 éve                 | körülbelül 3 évvel ezelőtt      |
-| 1996-01-01T00:00:00.000Z | körülbelül 4 éve           | körülbelül 4 éve                 | körülbelül 4 évvel ezelőtt      |
-| 1995-01-01T00:00:00.000Z | körülbelül 5 éve           | körülbelül 5 éve                 | körülbelül 5 évvel ezelőtt      |
-| 1994-01-01T00:00:00.000Z | körülbelül 6 éve           | körülbelül 6 éve                 | körülbelül 6 évvel ezelőtt      |
+| Date                     | Result               | `includeSeconds: true`     | `addSuffix: true`               |
+| ------------------------ | -------------------- | -------------------------- | ------------------------------- |
+| 2006-01-01T00:00:00.000Z | körülbelül 6 év      | körülbelül 6 év            | körülbelül 6 év múlva           |
+| 2005-01-01T00:00:00.000Z | körülbelül 5 év      | körülbelül 5 év            | körülbelül 5 év múlva           |
+| 2004-01-01T00:00:00.000Z | körülbelül 4 év      | körülbelül 4 év            | körülbelül 4 év múlva           |
+| 2003-01-01T00:00:00.000Z | körülbelül 3 év      | körülbelül 3 év            | körülbelül 3 év múlva           |
+| 2002-01-01T00:00:00.000Z | körülbelül 2 év      | körülbelül 2 év            | körülbelül 2 év múlva           |
+| 2001-06-01T00:00:00.000Z | több mint 1 év       | több mint 1 év             | több mint 1 év múlva            |
+| 2001-02-01T00:00:00.000Z | körülbelül 1 év      | körülbelül 1 év            | körülbelül 1 év múlva           |
+| 2001-01-01T00:00:00.000Z | körülbelül 1 év      | körülbelül 1 év            | körülbelül 1 év múlva           |
+| 2000-06-01T00:00:00.000Z | 5 hónap              | 5 hónap                    | 5 hónap múlva                   |
+| 2000-03-01T00:00:00.000Z | 2 hónap              | 2 hónap                    | 2 hónap múlva                   |
+| 2000-02-01T00:00:00.000Z | körülbelül 1 hónap   | körülbelül 1 hónap         | körülbelül 1 hónap múlva        |
+| 2000-01-15T00:00:00.000Z | 14 nap               | 14 nap                     | 14 nap múlva                    |
+| 2000-01-02T00:00:00.000Z | 1 nap                | 1 nap                      | 1 nap múlva                     |
+| 2000-01-01T06:00:00.000Z | körülbelül 6 óra     | körülbelül 6 óra           | körülbelül 6 óra múlva          |
+| 2000-01-01T01:00:00.000Z | körülbelül 1 óra     | körülbelül 1 óra           | körülbelül 1 óra múlva          |
+| 2000-01-01T00:45:00.000Z | körülbelül 1 óra     | körülbelül 1 óra           | körülbelül 1 óra múlva          |
+| 2000-01-01T00:30:00.000Z | 30 perc              | 30 perc                    | 30 perc múlva                   |
+| 2000-01-01T00:15:00.000Z | 15 perc              | 15 perc                    | 15 perc múlva                   |
+| 2000-01-01T00:01:00.000Z | 1 perc               | 1 perc                     | 1 perc múlva                    |
+| 2000-01-01T00:00:25.000Z | kevesebb mint 1 perc | fél perc                   | kevesebb mint 1 perc múlva      |
+| 2000-01-01T00:00:15.000Z | kevesebb mint 1 perc | kevesebb mint 20 másodperc | kevesebb mint 1 perc múlva      |
+| 2000-01-01T00:00:05.000Z | kevesebb mint 1 perc | kevesebb mint 10 másodperc | kevesebb mint 1 perc múlva      |
+| 2000-01-01T00:00:00.000Z | kevesebb mint 1 perc | kevesebb mint 5 másodperc  | kevesebb mint 1 perce           |
+| 1999-12-31T23:59:55.000Z | kevesebb mint 1 perc | kevesebb mint 10 másodperc | kevesebb mint 1 perccel ezelőtt |
+| 1999-12-31T23:59:45.000Z | kevesebb mint 1 perc | kevesebb mint 20 másodperc | kevesebb mint 1 perccel ezelőtt |
+| 1999-12-31T23:59:35.000Z | kevesebb mint 1 perc | fél perc                   | kevesebb mint 1 perccel ezelőtt |
+| 1999-12-31T23:59:00.000Z | 1 perc               | 1 perc                     | 1 perccel ezelőtt               |
+| 1999-12-31T23:45:00.000Z | 15 perc              | 15 perc                    | 15 perccel ezelőtt              |
+| 1999-12-31T23:30:00.000Z | 30 perc              | 30 perc                    | 30 perccel ezelőtt              |
+| 1999-12-31T23:15:00.000Z | körülbelül 1 óra     | körülbelül 1 óra           | körülbelül 1 órával ezelőtt     |
+| 1999-12-31T23:00:00.000Z | körülbelül 1 óra     | körülbelül 1 óra           | körülbelül 1 órával ezelőtt     |
+| 1999-12-31T18:00:00.000Z | körülbelül 6 óra     | körülbelül 6 óra           | körülbelül 6 órával ezelőtt     |
+| 1999-12-30T00:00:00.000Z | 2 nap                | 2 nap                      | 2 nappal ezelőtt                |
+| 1999-12-15T00:00:00.000Z | 17 nap               | 17 nap                     | 17 nappal ezelőtt               |
+| 1999-12-01T00:00:00.000Z | körülbelül 1 hónap   | körülbelül 1 hónap         | körülbelül 1 hónappal ezelőtt   |
+| 1999-11-01T00:00:00.000Z | 2 hónap              | 2 hónap                    | 2 hónappal ezelőtt              |
+| 1999-06-01T00:00:00.000Z | 7 hónap              | 7 hónap                    | 7 hónappal ezelőtt              |
+| 1999-01-01T00:00:00.000Z | körülbelül 1 év      | körülbelül 1 év            | körülbelül 1 évvel ezelőtt      |
+| 1998-12-01T00:00:00.000Z | körülbelül 1 év      | körülbelül 1 év            | körülbelül 1 évvel ezelőtt      |
+| 1998-06-01T00:00:00.000Z | több mint 1 év       | több mint 1 év             | több mint 1 évvel ezelőtt       |
+| 1998-01-01T00:00:00.000Z | körülbelül 2 év      | körülbelül 2 év            | körülbelül 2 évvel ezelőtt      |
+| 1997-01-01T00:00:00.000Z | körülbelül 3 év      | körülbelül 3 év            | körülbelül 3 évvel ezelőtt      |
+| 1996-01-01T00:00:00.000Z | körülbelül 4 év      | körülbelül 4 év            | körülbelül 4 évvel ezelőtt      |
+| 1995-01-01T00:00:00.000Z | körülbelül 5 év      | körülbelül 5 év            | körülbelül 5 évvel ezelőtt      |
+| 1994-01-01T00:00:00.000Z | körülbelül 6 év      | körülbelül 6 év            | körülbelül 6 évvel ezelőtt      |
 
 ## `formatDistanceStrict`
 
 If now is January 1st, 2000, 00:00.
 
-| Date                     | Result             | `addSuffix: true`       | With forced unit (i.e. `hour`) |
-| ------------------------ | ------------------ | ----------------------- | ------------------------------ |
-| 2006-01-01T00:00:00.000Z | 6 év múlva         | 6 év múlva              | 52608 óra múlva                |
-| 2005-01-01T00:00:00.000Z | 5 év múlva         | 5 év múlva              | 43848 óra múlva                |
-| 2004-01-01T00:00:00.000Z | 4 év múlva         | 4 év múlva              | 35064 óra múlva                |
-| 2003-01-01T00:00:00.000Z | 3 év múlva         | 3 év múlva              | 26304 óra múlva                |
-| 2002-01-01T00:00:00.000Z | 2 év múlva         | 2 év múlva              | 17544 óra múlva                |
-| 2001-06-01T00:00:00.000Z | 1 év múlva         | 1 év múlva              | 12408 óra múlva                |
-| 2001-02-01T00:00:00.000Z | 1 év múlva         | 1 év múlva              | 9528 óra múlva                 |
-| 2001-01-01T00:00:00.000Z | 1 év múlva         | 1 év múlva              | 8784 óra múlva                 |
-| 2000-06-01T00:00:00.000Z | 5 hónap múlva      | 5 hónap múlva           | 3648 óra múlva                 |
-| 2000-03-01T00:00:00.000Z | 2 hónap múlva      | 2 hónap múlva           | 1440 óra múlva                 |
-| 2000-02-01T00:00:00.000Z | 1 hónap múlva      | 1 hónap múlva           | 744 óra múlva                  |
-| 2000-01-15T00:00:00.000Z | 14 nap múlva       | 14 nap múlva            | 336 óra múlva                  |
-| 2000-01-02T00:00:00.000Z | 1 nap múlva        | 1 nap múlva             | 24 óra múlva                   |
-| 2000-01-01T06:00:00.000Z | 6 óra múlva        | 6 óra múlva             | 6 óra múlva                    |
-| 2000-01-01T01:00:00.000Z | 1 óra múlva        | 1 óra múlva             | 1 óra múlva                    |
-| 2000-01-01T00:45:00.000Z | 45 perc múlva      | 45 perc múlva           | 1 óra múlva                    |
-| 2000-01-01T00:30:00.000Z | 30 perc múlva      | 30 perc múlva           | 1 óra múlva                    |
-| 2000-01-01T00:15:00.000Z | 15 perc múlva      | 15 perc múlva           | 0 óra múlva                    |
-| 2000-01-01T00:01:00.000Z | 1 perc múlva       | 1 perc múlva            | 0 óra múlva                    |
-| 2000-01-01T00:00:25.000Z | 25 másodperc múlva | 25 másodperc múlva      | 0 óra múlva                    |
-| 2000-01-01T00:00:15.000Z | 15 másodperc múlva | 15 másodperc múlva      | 0 óra múlva                    |
-| 2000-01-01T00:00:05.000Z | 5 másodperc múlva  | 5 másodperc múlva       | 0 óra múlva                    |
-| 2000-01-01T00:00:00.000Z | 0 másodperc        | 0 másodperc             | 0 óra                          |
-| 1999-12-31T23:59:55.000Z | 5 másodperce       | 5 másodperccel ezelőtt  | 0 órája                        |
-| 1999-12-31T23:59:45.000Z | 15 másodperce      | 15 másodperccel ezelőtt | 0 órája                        |
-| 1999-12-31T23:59:35.000Z | 25 másodperce      | 25 másodperccel ezelőtt | 0 órája                        |
-| 1999-12-31T23:59:00.000Z | 1 perce            | 1 perccel ezelőtt       | 0 órája                        |
-| 1999-12-31T23:45:00.000Z | 15 perce           | 15 perccel ezelőtt      | 0 órája                        |
-| 1999-12-31T23:30:00.000Z | 30 perce           | 30 perccel ezelőtt      | 1 órája                        |
-| 1999-12-31T23:15:00.000Z | 45 perce           | 45 perccel ezelőtt      | 1 órája                        |
-| 1999-12-31T23:00:00.000Z | 1 órája            | 1 órával ezelőtt        | 1 órája                        |
-| 1999-12-31T18:00:00.000Z | 6 órája            | 6 órával ezelőtt        | 6 órája                        |
-| 1999-12-30T00:00:00.000Z | 2 napja            | 2 nappal ezelőtt        | 48 órája                       |
-| 1999-12-15T00:00:00.000Z | 17 napja           | 17 nappal ezelőtt       | 408 órája                      |
-| 1999-12-01T00:00:00.000Z | 1 hónapja          | 1 hónappal ezelőtt      | 744 órája                      |
-| 1999-11-01T00:00:00.000Z | 2 hónapja          | 2 hónappal ezelőtt      | 1464 órája                     |
-| 1999-06-01T00:00:00.000Z | 7 hónapja          | 7 hónappal ezelőtt      | 5136 órája                     |
-| 1999-01-01T00:00:00.000Z | 1 éve              | 1 évvel ezelőtt         | 8760 órája                     |
-| 1998-12-01T00:00:00.000Z | 1 éve              | 1 évvel ezelőtt         | 9504 órája                     |
-| 1998-06-01T00:00:00.000Z | 2 éve              | 2 évvel ezelőtt         | 13896 órája                    |
-| 1998-01-01T00:00:00.000Z | 2 éve              | 2 évvel ezelőtt         | 17520 órája                    |
-| 1997-01-01T00:00:00.000Z | 3 éve              | 3 évvel ezelőtt         | 26280 órája                    |
-| 1996-01-01T00:00:00.000Z | 4 éve              | 4 évvel ezelőtt         | 35064 órája                    |
-| 1995-01-01T00:00:00.000Z | 5 éve              | 5 évvel ezelőtt         | 43824 órája                    |
-| 1994-01-01T00:00:00.000Z | 6 éve              | 6 évvel ezelőtt         | 52584 órája                    |
+| Date                     | Result       | `addSuffix: true`       | With forced unit (i.e. `hour`) |
+| ------------------------ | ------------ | ----------------------- | ------------------------------ |
+| 2006-01-01T00:00:00.000Z | 6 év         | 6 év múlva              | 52608 óra                      |
+| 2005-01-01T00:00:00.000Z | 5 év         | 5 év múlva              | 43848 óra                      |
+| 2004-01-01T00:00:00.000Z | 4 év         | 4 év múlva              | 35064 óra                      |
+| 2003-01-01T00:00:00.000Z | 3 év         | 3 év múlva              | 26304 óra                      |
+| 2002-01-01T00:00:00.000Z | 2 év         | 2 év múlva              | 17544 óra                      |
+| 2001-06-01T00:00:00.000Z | 1 év         | 1 év múlva              | 12408 óra                      |
+| 2001-02-01T00:00:00.000Z | 1 év         | 1 év múlva              | 9528 óra                       |
+| 2001-01-01T00:00:00.000Z | 1 év         | 1 év múlva              | 8784 óra                       |
+| 2000-06-01T00:00:00.000Z | 5 hónap      | 5 hónap múlva           | 3648 óra                       |
+| 2000-03-01T00:00:00.000Z | 2 hónap      | 2 hónap múlva           | 1440 óra                       |
+| 2000-02-01T00:00:00.000Z | 1 hónap      | 1 hónap múlva           | 744 óra                        |
+| 2000-01-15T00:00:00.000Z | 14 nap       | 14 nap múlva            | 336 óra                        |
+| 2000-01-02T00:00:00.000Z | 1 nap        | 1 nap múlva             | 24 óra                         |
+| 2000-01-01T06:00:00.000Z | 6 óra        | 6 óra múlva             | 6 óra                          |
+| 2000-01-01T01:00:00.000Z | 1 óra        | 1 óra múlva             | 1 óra                          |
+| 2000-01-01T00:45:00.000Z | 45 perc      | 45 perc múlva           | 1 óra                          |
+| 2000-01-01T00:30:00.000Z | 30 perc      | 30 perc múlva           | 1 óra                          |
+| 2000-01-01T00:15:00.000Z | 15 perc      | 15 perc múlva           | 0 óra                          |
+| 2000-01-01T00:01:00.000Z | 1 perc       | 1 perc múlva            | 0 óra                          |
+| 2000-01-01T00:00:25.000Z | 25 másodperc | 25 másodperc múlva      | 0 óra                          |
+| 2000-01-01T00:00:15.000Z | 15 másodperc | 15 másodperc múlva      | 0 óra                          |
+| 2000-01-01T00:00:05.000Z | 5 másodperc  | 5 másodperc múlva       | 0 óra                          |
+| 2000-01-01T00:00:00.000Z | 0 másodperc  | 0 másodperce            | 0 óra                          |
+| 1999-12-31T23:59:55.000Z | 5 másodperc  | 5 másodperccel ezelőtt  | 0 óra                          |
+| 1999-12-31T23:59:45.000Z | 15 másodperc | 15 másodperccel ezelőtt | 0 óra                          |
+| 1999-12-31T23:59:35.000Z | 25 másodperc | 25 másodperccel ezelőtt | 0 óra                          |
+| 1999-12-31T23:59:00.000Z | 1 perc       | 1 perccel ezelőtt       | 0 óra                          |
+| 1999-12-31T23:45:00.000Z | 15 perc      | 15 perccel ezelőtt      | 0 óra                          |
+| 1999-12-31T23:30:00.000Z | 30 perc      | 30 perccel ezelőtt      | 1 óra                          |
+| 1999-12-31T23:15:00.000Z | 45 perc      | 45 perccel ezelőtt      | 1 óra                          |
+| 1999-12-31T23:00:00.000Z | 1 óra        | 1 órával ezelőtt        | 1 óra                          |
+| 1999-12-31T18:00:00.000Z | 6 óra        | 6 órával ezelőtt        | 6 óra                          |
+| 1999-12-30T00:00:00.000Z | 2 nap        | 2 nappal ezelőtt        | 48 óra                         |
+| 1999-12-15T00:00:00.000Z | 17 nap       | 17 nappal ezelőtt       | 408 óra                        |
+| 1999-12-01T00:00:00.000Z | 1 hónap      | 1 hónappal ezelőtt      | 744 óra                        |
+| 1999-11-01T00:00:00.000Z | 2 hónap      | 2 hónappal ezelőtt      | 1464 óra                       |
+| 1999-06-01T00:00:00.000Z | 7 hónap      | 7 hónappal ezelőtt      | 5136 óra                       |
+| 1999-01-01T00:00:00.000Z | 1 év         | 1 évvel ezelőtt         | 8760 óra                       |
+| 1998-12-01T00:00:00.000Z | 1 év         | 1 évvel ezelőtt         | 9504 óra                       |
+| 1998-06-01T00:00:00.000Z | 2 év         | 2 évvel ezelőtt         | 13896 óra                      |
+| 1998-01-01T00:00:00.000Z | 2 év         | 2 évvel ezelőtt         | 17520 óra                      |
+| 1997-01-01T00:00:00.000Z | 3 év         | 3 évvel ezelőtt         | 26280 óra                      |
+| 1996-01-01T00:00:00.000Z | 4 év         | 4 évvel ezelőtt         | 35064 óra                      |
+| 1995-01-01T00:00:00.000Z | 5 év         | 5 évvel ezelőtt         | 43824 óra                      |
+| 1994-01-01T00:00:00.000Z | 6 év         | 6 évvel ezelőtt         | 52584 óra                      |
 
 ## `formatRelative`
 


### PR DESCRIPTION
All of the modified lines are containing suffixes (múlva), which breaks localized duration strings.