### PR TITLE
fix parseISO not returning Invalid Date when there are space(s) in passed string

### DIFF
--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -155,7 +155,7 @@ function splitDateString(dateString) {
   var timeString
 
   // The regex match should only return at maximum two array.
-  // [date], [time], or [date, time].
+  // [date] or [date, time].
   if (array.length > 2) {
     return dateStrings
   }

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -155,7 +155,7 @@ function splitDateString(dateString) {
   var timeString
 
   // The regex match should only return at maximum two array.
-  // [date] or [date, time].
+  // [date], [time], or [date, time].
   if (array.length > 2) {
     return dateStrings
   }

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -154,7 +154,7 @@ function splitDateString(dateString) {
   var array = dateString.split(patterns.dateTimeDelimiter)
   var timeString
 
-  // The regex match should only return at maximum two array.
+  // The regex match should only return at maximum two array elements.
   // [date], [time], or [date, time].
   if (array.length > 2) {
     return dateStrings

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -154,6 +154,12 @@ function splitDateString(dateString) {
   var array = dateString.split(patterns.dateTimeDelimiter)
   var timeString
 
+  // The regex match should only return at maximum two array.
+  // [date], [time], or [date, time].
+  if (array.length > 2) {
+    return dateStrings
+  }
+
   if (/:/.test(array[0])) {
     dateStrings.date = null
     timeString = array[0]

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -321,6 +321,12 @@ describe('parseISO', () => {
         assert(result instanceof Date)
         assert(isNaN(result))
       })
+
+      it('returns `Invalid Date` when time contains space', () => {
+        const result = parseISO('2014-02-11T21 basketball')
+        assert(result instanceof Date)
+        assert(isNaN(result))
+      })
     })
 
     describe('timezones', () => {

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -331,7 +331,7 @@ describe('parseISO', () => {
       })
 
       it('returns `Invalid Date` when time contains spaces', () => {
-        const result = parseISO('21:59:00  basketball')
+        const result = parseISO('2014-02-11T21:59:00  basketball')
         assert(result instanceof Date)
         assert(isNaN(result))
       })

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -287,7 +287,7 @@ describe('parseISO', () => {
     })
 
     describe('date', () => {
-      it('returns `Invalid Date` when date contains spaces', () => {
+      it('returns `Invalid Date` when it contains spaces after the date', () => {
         const result = parseISO('2014-02-11  basketball')
         assert(result instanceof Date)
         assert(isNaN(result))
@@ -330,7 +330,7 @@ describe('parseISO', () => {
         assert(isNaN(result))
       })
 
-      it('returns `Invalid Date` when time contains spaces', () => {
+      it('returns `Invalid Date` when it contains spaces after the time', () => {
         const result = parseISO('2014-02-11T21:59:00  basketball')
         assert(result instanceof Date)
         assert(isNaN(result))

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -286,6 +286,14 @@ describe('parseISO', () => {
       })
     })
 
+    describe('date', () => {
+      it('returns `Invalid Date` when date contains spaces', () => {
+        const result = parseISO('2014-02-11  basketball')
+        assert(result instanceof Date)
+        assert(isNaN(result))
+      })
+    })
+
     describe('time', () => {
       it('parses 24:00 as midnight of the next day', () => {
         const result = parseISO('2014-02-11T24:00')
@@ -322,8 +330,8 @@ describe('parseISO', () => {
         assert(isNaN(result))
       })
 
-      it('returns `Invalid Date` when time contains space', () => {
-        const result = parseISO('2014-02-11T21 basketball')
+      it('returns `Invalid Date` when time contains spaces', () => {
+        const result = parseISO('21:59:00  basketball')
         assert(result instanceof Date)
         assert(isNaN(result))
       })


### PR DESCRIPTION
Fixes https://github.com/date-fns/date-fns/issues/1748. This PR adds additional validation when a datetime string is split using the existing RegEx in `splitDateString`, hence `parseISO` will return "Invalid Date" for strings with space(s).

## Current

```js
// Since we only check first 2 array elements, it won't resolve to "Invalid Date".
splitDateString('2014-02-11T07:00:00  basketball'); // ['2014-02-11', '07:00:00', 'basketball']
parseISO('2014-02-1107:00:00  basketball'); // 2014-02-11T00:00:00.000Z (I'm in GMT+7)

// This is also the same for date-only string.
splitDateString('2014-02-11  basketball'); // ['2014-02-11', '', 'basketball']
parseISO('2014-02-11  basketball'); // 2014-02-10T17:00:00.000Z (if time is not specified, we use 12am)
```

## This PR

With that, the solution of this PR is to always check the resulting array length from `splitDateString`. If the array length is more than 2, then it contains space(s) and it should resolve to "Invalid Date".

This is also considering the fact that ISO8601-formatted dates don't have spaces in it (source: https://www.w3.org/TR/NOTE-datetime).

```js
splitDateString('2014-02-11T07:00:00  basketball'); // ['2014-02-11', '07:00:00', 'basketball']
parseISO('2014-02-11T07:00:00  basketball'); // Invalid Date

splitDateString('2014-02-11  basketball'); // ['2014-02-11', '', 'basketball']
parseISO('2014-02-11  basketball'); // Invalid Date
```

Signed-off-by: Try Ajitiono <ballinst@gmail.com>