### PR TITLE
Fix formatting in parseJSON documentation

### DIFF
--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -14,19 +14,19 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * a `Date` instance which can be used with other functions in the `date-fns` library.
  * The following formats are supported:
  *
- *     - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`
- *     - `2000-03-15T05:20:10Z`: Without milliseconds
- *     - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
- *     - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
- *     - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
- *     - `2000-03-15T05:20:10.1234567`: Up to 7 digits in milliseconds field. Only first 3 are taken into account since JS does not allow fractional milliseconds
- *     - `2000-03-15 05:20:10`: With a space instead of a 'T' separator for APIs returning a SQL date without reformatting
+ * - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`
+ * - `2000-03-15T05:20:10Z`: Without milliseconds
+ * - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
+ * - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
+ * - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
+ * - `2000-03-15T05:20:10.1234567`: Up to 7 digits in milliseconds field. Only first 3 are taken into account since JS does not allow fractional milliseconds
+ * - `2000-03-15 05:20:10`: With a space instead of a 'T' separator for APIs returning a SQL date without reformatting
  *
  * For convenience and ease of use these other input types are also supported
  * via [toDate]{@link https://date-fns.org/docs/toDate}:
  *
- *     - A `Date` instance will be cloned
- *     - A `number` will be treated as a timestamp
+ * - A `Date` instance will be cloned
+ * - A `number` will be treated as a timestamp
  *
  * Any other input type or invalid date strings will return an `Invalid Date`.
  *


### PR DESCRIPTION
The current documentation (https://date-fns.org/v2.11.1/docs/parseJSON) shows all the bullet points as a single line

![image](https://user-images.githubusercontent.com/318668/83388183-ae504580-a3f6-11ea-956a-2c0b4d0e624b.png)
