### PR TITLE
Unescaped single quotes in timeZones.md docs file

### DIFF
--- a/docs/timeZones.md
+++ b/docs/timeZones.md
@@ -48,7 +48,7 @@ const { zonedTimeToUtc, utcToZonedTime, format } = require('date-fns-tz')
 const utcDate = zonedTimeToUtc('2018-09-01 18:01:36.386', 'Europe/Berlin')
 
 // Obtain a Date instance that will render the equivalent Berlin time for the UTC date
-const date = new Date('2018-09-01Z16:01:36.386Z')
+const date = new Date('2018-09-01T16:01:36.386Z')
 const timeZone = 'Europe/Berlin'
 const zonedDate = utcToZonedTime(date, timeZone)
 // zonedDate could be used to initialize a date picker or display the formatted local date/time

--- a/docs/timeZones.md
+++ b/docs/timeZones.md
@@ -54,7 +54,7 @@ const zonedDate = utcToZonedTime(date, timeZone)
 // zonedDate could be used to initialize a date picker or display the formatted local date/time
 
 // Set the output to "1.9.2018 18:01:36.386 GMT+02:00 (CEST)"
-const pattern = 'd.m.yyyy HH:mm:ss.SSS \'GMT\' XXX (z)'
+const pattern = 'd.M.yyyy HH:mm:ss.SSS \'GMT\' XXX (z)'
 const output = format(zonedDate, pattern, { timeZone: 'Europe/Berlin' })
 ```
 

--- a/docs/timeZones.md
+++ b/docs/timeZones.md
@@ -54,7 +54,7 @@ const zonedDate = utcToZonedTime(date, timeZone)
 // zonedDate could be used to initialize a date picker or display the formatted local date/time
 
 // Set the output to "1.9.2018 18:01:36.386 GMT+02:00 (CEST)"
-const pattern = 'd.m.yyyy HH:mm:ss.SSS 'GMT' XXX (z)'
+const pattern = 'd.m.yyyy HH:mm:ss.SSS \'GMT\' XXX (z)'
 const output = format(zonedDate, pattern, { timeZone: 'Europe/Berlin' })
 ```
 


### PR DESCRIPTION
Code snippet does not run because of missing escaped quotes around GMT