### PR TITLE
fix(HungarianLocale): Use IE 11 friendly syntax for object keys

### DIFF
--- a/src/locale/hu/_lib/formatDistance/index.js
+++ b/src/locale/hu/_lib/formatDistance/index.js
@@ -18,44 +18,44 @@ const withoutSuffixes = {
 
 const withSuffixes = {
   xseconds: {
-    [-1]: ' másodperccel ezelőtt',
-    [1]: ' másodperc múlva',
-    [0]: ' másodperce'
+    '-1': ' másodperccel ezelőtt',
+    '1': ' másodperc múlva',
+    '0': ' másodperce'
   },
   halfaminute: {
-    [-1]: 'fél perccel ezelőtt',
-    [1]: 'fél perc múlva',
-    [0]: 'fél perce'
+    '-1': 'fél perccel ezelőtt',
+    '1': 'fél perc múlva',
+    '0': 'fél perce'
   },
   xminutes: {
-    [-1]: ' perccel ezelőtt',
-    [1]: ' perc múlva',
-    [0]: ' perce'
+    '-1': ' perccel ezelőtt',
+    '1': ' perc múlva',
+    '0': ' perce'
   },
   xhours: {
-    [-1]: ' órával ezelőtt',
-    [1]: ' óra múlva',
-    [0]: ' órája'
+    '-1': ' órával ezelőtt',
+    '1': ' óra múlva',
+    '0': ' órája'
   },
   xdays: {
-    [-1]: ' nappal ezelőtt',
-    [1]: ' nap múlva',
-    [0]: ' napja'
+    '-1': ' nappal ezelőtt',
+    '1': ' nap múlva',
+    '0': ' napja'
   },
   xweeks: {
-    [-1]: ' héttel ezelőtt',
-    [1]: ' hét múlva',
-    [0]: ' hete'
+    '-1': ' héttel ezelőtt',
+    '1': ' hét múlva',
+    '0': ' hete'
   },
   xmonths: {
-    [-1]: ' hónappal ezelőtt',
-    [1]: ' hónap múlva',
-    [0]: ' hónapja'
+    '-1': ' hónappal ezelőtt',
+    '1': ' hónap múlva',
+    '0': ' hónapja'
   },
   xyears: {
-    [-1]: ' évvel ezelőtt',
-    [1]: ' év múlva',
-    [0]: ' éve'
+    '-1': ' évvel ezelőtt',
+    '1': ' év múlva',
+    '0': ' éve'
   }
 }
 


### PR DESCRIPTION
Fix for #1833 

IE 11 doesn't support object keys as variables e.g `{....[-1]: 1...}`.
The keys must be string or number literals.