### PR TITLE
Add index information to `getDay` docs

### DIFF
--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -14,7 +14,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the given date
- * @returns {0|1|2|3|4|5|6} the day of week
+ * @returns {0|1|2|3|4|5|6} the day of week, 0 represents Sunday
  * @throws {TypeError} 1 argument required
  *
  * @example


### PR DESCRIPTION
I was just using this function, and had to refer back to the MDN docs on [getDay](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay) to remind myself of the indexing of the output. I think it'd be useful to add this to the `date-fns` docs for this function, so that referencing outside the docs website isn't needed.