### PR TITLE
Removed periods for dutch month abbreviations

### DIFF
--- a/src/locale/nl/_lib/localize/index.js
+++ b/src/locale/nl/_lib/localize/index.js
@@ -15,18 +15,18 @@ var quarterValues = {
 var monthValues = {
   narrow: ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'],
   abbreviated: [
-    'jan.',
-    'feb.',
-    'mrt.',
-    'apr.',
+    'jan',
+    'feb',
+    'mrt',
+    'apr',
     'mei',
-    'jun.',
-    'jul.',
-    'aug.',
-    'sep.',
-    'okt.',
-    'nov.',
-    'dec.'
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'okt',
+    'nov',
+    'dec'
   ],
   wide: [
     'januari',


### PR DESCRIPTION
In the dutch language, abbreviating a month does not require to put a period ``.`` at the end, it's merely optional (and old fashioned).
Adding a period is easier than removing it from the format result.

https://onzetaal.nl/taaladvies/afkortingen-dagen-en-maanden/