### PR TITLE
Spanish accents fixes

### DIFF
--- a/src/locale/es/_lib/localize/index.js
+++ b/src/locale/es/_lib/localize/index.js
@@ -14,15 +14,49 @@ var quarterValues = {
 
 var monthValues = {
   narrow: ['e', 'f', 'm', 'a', 'm', 'j', 'j', 'a', 's', 'o', 'n', 'd'],
-  abbreviated: ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'],
-  wide: ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre']
+  abbreviated: [
+    'ene',
+    'feb',
+    'mar',
+    'abr',
+    'may',
+    'jun',
+    'jul',
+    'ago',
+    'sep',
+    'oct',
+    'nov',
+    'dic'
+  ],
+  wide: [
+    'enero',
+    'febrero',
+    'marzo',
+    'abril',
+    'mayo',
+    'junio',
+    'julio',
+    'agosto',
+    'septiembre',
+    'octubre',
+    'noviembre',
+    'diciembre'
+  ]
 }
 
 var dayValues = {
   narrow: ['d', 'l', 'm', 'm', 'j', 'v', 's'],
   short: ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
-  abbreviated: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sab'],
-  wide: ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado']
+  abbreviated: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'],
+  wide: [
+    'domingo',
+    'lunes',
+    'martes',
+    'miércoles',
+    'jueves',
+    'viernes',
+    'sábado'
+  ]
 }
 
 var dayPeriodValues = {
@@ -90,7 +124,7 @@ var formattingDayPeriodValues = {
   }
 }
 
-function ordinalNumber (dirtyNumber) {
+function ordinalNumber(dirtyNumber) {
   var number = Number(dirtyNumber)
   return number + 'º'
 }
@@ -106,7 +140,7 @@ var localize = {
   quarter: buildLocalizeFn({
     values: quarterValues,
     defaultWidth: 'wide',
-    argumentCallback: function (quarter) {
+    argumentCallback: function(quarter) {
       return Number(quarter) - 1
     }
   }),

--- a/src/locale/es/_lib/match/index.js
+++ b/src/locale/es/_lib/match/index.js
@@ -11,7 +11,10 @@ var matchEraPatterns = {
 }
 var parseEraPatterns = {
   any: [/^ac/i, /^dc/i],
-  wide: [/^(antes de cristo|antes de la era com[uú]n)/i, /^(despu[eé]s de cristo|era com[uú]n)/i]
+  wide: [
+    /^(antes de cristo|antes de la era com[uú]n)/i,
+    /^(despu[eé]s de cristo|era com[uú]n)/i
+  ]
 }
 
 var matchQuarterPatterns = {
@@ -29,15 +32,41 @@ var matchMonthPatterns = {
   wide: /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)/i
 }
 var parseMonthPatterns = {
-  narrow: [/^e/i, /^f/i, /^m/i, /^a/i, /^m/i, /^j/i, /^j/i, /^a/i, /^s/i, /^o/i, /^n/i, /^d/i],
-  any: [/^en/i, /^feb/i, /^mar/i, /^abr/i, /^may/i, /^jun/i, /^jul/i, /^ago/i, /^sep/i, /^oct/i, /^nov/i, /^dic/i]
+  narrow: [
+    /^e/i,
+    /^f/i,
+    /^m/i,
+    /^a/i,
+    /^m/i,
+    /^j/i,
+    /^j/i,
+    /^a/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i
+  ],
+  any: [
+    /^en/i,
+    /^feb/i,
+    /^mar/i,
+    /^abr/i,
+    /^may/i,
+    /^jun/i,
+    /^jul/i,
+    /^ago/i,
+    /^sep/i,
+    /^oct/i,
+    /^nov/i,
+    /^dic/i
+  ]
 }
 
 var matchDayPatterns = {
   narrow: /^[dlmjvs]/i,
   short: /^(do|lu|ma|mi|ju|vi|sa)/i,
   abbreviated: /^(dom|lun|mar|mie|jue|vie|sab)/i,
-  wide: /^(domingo|lunes|martes|miercoles|jueves|viernes|s[áa]bado)/i
+  wide: /^(domingo|lunes|martes|mi[ée]rcoles|jueves|viernes|s[áa]bado)/i
 }
 var parseDayPatterns = {
   narrow: [/^d/i, /^l/i, /^m/i, /^m/i, /^j/i, /^v/i, /^s/i],
@@ -65,7 +94,7 @@ var match = {
   ordinalNumber: buildMatchPatternFn({
     matchPattern: matchOrdinalNumberPattern,
     parsePattern: parseOrdinalNumberPattern,
-    valueCallback: function (value) {
+    valueCallback: function(value) {
       return parseInt(value, 10)
     }
   }),
@@ -82,7 +111,7 @@ var match = {
     defaultMatchWidth: 'wide',
     parsePatterns: parseQuarterPatterns,
     defaultParseWidth: 'any',
-    valueCallback: function (index) {
+    valueCallback: function(index) {
       return index + 1
     }
   }),

--- a/src/locale/es/snapshot.md
+++ b/src/locale/es/snapshot.md
@@ -166,7 +166,7 @@
 |                                 |              | 1453-05-29T23:59:59.999Z | 29 may 1453                                               | 1453-05-29T00:00:00.000Z |
 |                                 | PPP          | 1987-02-11T12:13:14.015Z | 11 de febrero de 1987                                     | 1987-02-11T00:00:00.000Z |
 |                                 |              | 1453-05-29T23:59:59.999Z | 29 de mayo de 1453                                        | 1453-05-29T00:00:00.000Z |
-|                                 | PPPP         | 1987-02-11T12:13:14.015Z | miércoles, 11 de febrero de 1987                          | Invalid Date             |
+|                                 | PPPP         | 1987-02-11T12:13:14.015Z | miércoles, 11 de febrero de 1987                          | 1987-02-11T00:00:00.000Z |
 |                                 |              | 1453-05-29T23:59:59.999Z | domingo, 29 de mayo de 1453                               | 1453-05-29T00:00:00.000Z |
 | Long localized time             | p            | 1987-02-11T12:13:14.015Z | 12:13                                                     | 1987-02-11T12:13:00.000Z |
 |                                 |              | 1453-05-29T23:59:59.999Z | 23:59                                                     | 1453-05-29T23:59:00.000Z |
@@ -182,7 +182,7 @@
 |                                 |              | 1453-05-29T23:59:59.999Z | 29 may 1453, 23:59:59                                     | 1453-05-29T23:59:59.000Z |
 |                                 | PPPppp       | 1987-02-11T12:13:14.015Z | 11 de febrero de 1987 a las 12:13:14 GMT+0                | Errored                  |
 |                                 |              | 1453-05-29T23:59:59.999Z | 29 de mayo de 1453 a las 23:59:59 GMT+0                   | Errored                  |
-|                                 | PPPPpppp     | 1987-02-11T12:13:14.015Z | miércoles, 11 de febrero de 1987 a las 12:13:14 GMT+00:00 | Invalid Date             |
+|                                 | PPPPpppp     | 1987-02-11T12:13:14.015Z | miércoles, 11 de febrero de 1987 a las 12:13:14 GMT+00:00 | Errored                  |
 |                                 |              | 1453-05-29T23:59:59.999Z | domingo, 29 de mayo de 1453 a las 23:59:59 GMT+00:00      | Errored                  |
 
 ## `formatDistance`


### PR DESCRIPTION
In the Spanish localization, the abbreviated Saturday is missing the accent, which is present for Wednesday, and for the match, Wednesday was missing the accent as well,

In Spanish, Saturday has a tilde, https://dle.rae.es/s%C3%A1bado
and
Wednesday as a tilde as well, https://dle.rae.es/mi%C3%A9rcoles