### PR TITLE
Missing locale type definition for formatDuration

### DIFF
--- a/src/formatDuration/index.js
+++ b/src/formatDuration/index.js
@@ -24,6 +24,7 @@ const defaultFormat = [
  * @param {string[]} [options.format=['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds']] - the array of units to format
  * @param {boolean} [options.zero=false] - should be zeros be included in the output?
  * @param {string} [options.delimiter=' '] - delimiter string
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @returns {string} the formatted date string
  * @throws {TypeError} 1 argument required
  *

--- a/src/formatDuration/index.js.flow
+++ b/src/formatDuration/index.js.flow
@@ -52,6 +52,7 @@ declare module.exports: (
   options?: {
     format?: string[],
     zero?: boolean,
-    delimiter?: string
+    delimiter?: string,
+    locale?: Locale
   }
 ) => string

--- a/src/fp/formatDurationWithOptions/index.js.flow
+++ b/src/fp/formatDurationWithOptions/index.js.flow
@@ -55,6 +55,7 @@ type CurriedFn2<A, B, R> = <A>(
 
 declare module.exports: CurriedFn2<
   {
+    locale?: Locale,
     delimiter?: string,
     zero?: boolean,
     format?: string[]

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -226,6 +226,7 @@ declare module.exports: {
   formatDuration: CurriedFn1<Duration, string>,
   formatDurationWithOptions: CurriedFn2<
     {
+      locale?: Locale,
       delimiter?: string,
       zero?: boolean,
       format?: string[]

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -318,7 +318,8 @@ declare module.exports: {
     options?: {
       format?: string[],
       zero?: boolean,
-      delimiter?: string
+      delimiter?: string,
+      locale?: Locale
     }
   ) => string,
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -425,6 +425,7 @@ declare module 'date-fns' {
       format?: string[]
       zero?: boolean
       delimiter?: string
+      locale?: Locale
     }
   ): string
   namespace formatDuration {}
@@ -4264,6 +4265,7 @@ declare module 'date-fns/fp' {
 
   const formatDurationWithOptions: CurriedFn2<
     {
+      locale?: Locale
       delimiter?: string
       zero?: boolean
       format?: string[]
@@ -8297,6 +8299,7 @@ declare module 'date-fns/esm' {
       format?: string[]
       zero?: boolean
       delimiter?: string
+      locale?: Locale
     }
   ): string
   namespace formatDuration {}
@@ -12136,6 +12139,7 @@ declare module 'date-fns/esm/fp' {
 
   const formatDurationWithOptions: CurriedFn2<
     {
+      locale?: Locale
       delimiter?: string
       zero?: boolean
       format?: string[]
@@ -18823,6 +18827,7 @@ interface dateFns {
       format?: string[]
       zero?: boolean
       delimiter?: string
+      locale?: Locale
     }
   ): string
 


### PR DESCRIPTION
With the great work done in #1671 this is my way to contribute to this wonderful piece of code :)
Unfortunately the comment for the locale type definition was missing so hereby a PR to update the type def.

Cheers.