### PR TITLE
Fix formatRFC3339: adjust formatting offset for timezones with minutes

### DIFF
--- a/scripts/test/formatRFC3339.sh
+++ b/scripts/test/formatRFC3339.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# The script runs formatRFC3339 in a non%60 timezone offset
+#
+# It's a part of the test process.
+
+set -ex
+
+export PATH="$(yarn bin):$PATH"
+export NODE_ENV=test
+
+env TZ=Asia/Kolkata babel-node ./test/formatRFC3339/india.js
+env TZ=America/St_Johns babel-node ./test/formatRFC3339/newfoundland.js
+env TZ=Australia/Eucla babel-node ./test/formatRFC3339/australia.js
+env TZ=Pacific/Chatham babel-node ./test/formatRFC3339/newzealand.js
+env TZ=Europe/Warsaw babel-node ./test/formatRFC3339/poland.js
+

--- a/scripts/test/travis.sh
+++ b/scripts/test/travis.sh
@@ -24,6 +24,7 @@ then
 
   ./scripts/test/dst.sh
   ./scripts/test/formatISO.sh
+  ./scripts/test/formatRFC3339.sh
 
   prebuild
   ./scripts/test/tz.sh

--- a/src/formatRFC3339/index.js
+++ b/src/formatRFC3339/index.js
@@ -78,7 +78,7 @@ export default function formatRFC3339(dirtyDate, dirtyOptions) {
 
   if (tzOffset !== 0) {
     const absoluteOffset = Math.abs(tzOffset)
-    const hourOffset = addLeadingZeros(absoluteOffset / 60, 2)
+    const hourOffset = addLeadingZeros(toInteger(absoluteOffset / 60), 2)
     const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2)
     // If less than 0, the sign is +, because it is ahead of time.
     const sign = tzOffset < 0 ? '+' : '-'

--- a/src/formatRFC3339/test.js
+++ b/src/formatRFC3339/test.js
@@ -3,6 +3,7 @@
 
 import assert from 'power-assert'
 import formatRFC3339 from '.'
+import toInteger from '../_lib/toInteger/index.js'
 import addLeadingZeros from '../_lib/addLeadingZeros/index.js'
 
 // This makes sure we create the consistent offsets across timezones, no matter where these tests are ran.
@@ -12,7 +13,7 @@ function generateOffset(date) {
 
   if (tzOffset !== 0) {
     const absoluteOffset = Math.abs(tzOffset)
-    const hourOffset = addLeadingZeros(absoluteOffset / 60, 2)
+    const hourOffset = addLeadingZeros(toInteger(absoluteOffset / 60), 2)
     const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2)
     // If less than 0, the sign is +, because it is ahead of time.
     const sign = tzOffset < 0 ? '+' : '-'

--- a/test/formatRFC3339/australia.js
+++ b/test/formatRFC3339/australia.js
@@ -1,0 +1,30 @@
+import formatRFC3339 from '../../src/formatRFC3339'
+import assert from 'assert'
+
+/**
+ * Australia/Eucla (Australia) is interesting for its positive to UTC time, with 45 minutes offset.
+ * It's independent from Standard and Summer time.
+ */
+if (process.env.TZ !== 'Australia/Eucla')
+  throw new Error('The test must be run with TZ=Australia/Eucla (UTC+08:45)')
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+// Old date
+assert.equal(
+  formatRFC3339(new Date(1986, 3, 4, 10, 33, 1)),
+  '1986-04-04T10:33:01+08:45'
+)
+
+// Standard time (Eucla have +08:45)
+assert.equal(
+  formatRFC3339(new Date(2020, 0, 23, 5, 0, 54)),
+  '2020-01-23T05:00:54+08:45'
+)
+
+// Summer time (Eucla have +08:45)
+assert.equal(
+  formatRFC3339(new Date(2020, 6, 30, 20, 59, 1)),
+  '2020-07-30T20:59:01+08:45'
+)

--- a/test/formatRFC3339/india.js
+++ b/test/formatRFC3339/india.js
@@ -1,0 +1,30 @@
+import formatRFC3339 from '../../src/formatRFC3339'
+import assert from 'assert'
+
+/**
+ * Asia/Kolkata (India) is interesting for its positive to UTC time, with 30 minutes offset.
+ * It's independent from Standard and Summer time.
+ */
+if (process.env.TZ !== 'Asia/Kolkata')
+  throw new Error('The test must be run with TZ=Asia/Kolkata')
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+// Old date
+assert.equal(
+  formatRFC3339(new Date(1986, 3, 4, 10, 33, 1)),
+  '1986-04-04T10:33:01+05:30'
+)
+
+// Standard time (india always have +05:30)
+assert.equal(
+  formatRFC3339(new Date(2020, 0, 23, 5, 0, 54)),
+  '2020-01-23T05:00:54+05:30'
+)
+
+// Summer time (india always have +05:30)
+assert.equal(
+  formatRFC3339(new Date(2020, 6, 30, 20, 59, 1)),
+  '2020-07-30T20:59:01+05:30'
+)

--- a/test/formatRFC3339/newfoundland.js
+++ b/test/formatRFC3339/newfoundland.js
@@ -1,0 +1,32 @@
+import formatRFC3339 from '../../src/formatRFC3339'
+import assert from 'assert'
+
+/**
+ * America/St_Johns (Canada) is interesting for its negative to UTC time, with 30 minutes offset.
+ * Bonus: It depends on Standard and Summer time.
+ */
+if (process.env.TZ !== 'America/St_Johns')
+  throw new Error(
+    'The test must be run with TZ=America/St_Johns (UTC-02:30 or UTC-03:30)'
+  )
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+// Old date
+assert.equal(
+  formatRFC3339(new Date(1986, 3, 4, 10, 33, 1)),
+  '1986-04-04T10:33:01-03:30'
+)
+
+// Standard time (Newfoundland and Labrador have -03:30)
+assert.equal(
+  formatRFC3339(new Date(2020, 0, 23, 5, 0, 54)),
+  '2020-01-23T05:00:54-03:30'
+)
+
+// Summer time (Newfoundland and Labrador have -02:30)
+assert.equal(
+  formatRFC3339(new Date(2020, 6, 30, 20, 59, 1)),
+  '2020-07-30T20:59:01-02:30'
+)

--- a/test/formatRFC3339/newzealand.js
+++ b/test/formatRFC3339/newzealand.js
@@ -1,0 +1,32 @@
+import formatRFC3339 from '../../src/formatRFC3339'
+import assert from 'assert'
+
+/**
+ * Pacific/Chatham (Chatham Islands, New Zealand) is interesting for being the farthest from UTC.
+ * It depends on Standard (+12:45) and Summer time (+13:45).
+ */
+if (process.env.TZ !== 'Pacific/Chatham')
+  throw new Error(
+    'The test must be run with TZ=Pacific/Chatham (UTC+12:45 or UTC+13:45)'
+  )
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+// Old date
+assert.equal(
+  formatRFC3339(new Date(1986, 3, 4, 10, 33, 1)),
+  '1986-04-04T10:33:01+12:45'
+)
+
+// Standard time (Chatham have +13:45)
+assert.equal(
+  formatRFC3339(new Date(2020, 8, 27, 20, 59, 1)),
+  '2020-09-27T20:59:01+13:45'
+)
+
+// Summer time (Chatham have +12:45)
+assert.equal(
+  formatRFC3339(new Date(2020, 3, 5, 5, 0, 54)),
+  '2020-04-05T05:00:54+12:45'
+)

--- a/test/formatRFC3339/poland.js
+++ b/test/formatRFC3339/poland.js
@@ -1,0 +1,31 @@
+import formatRFC3339 from '../../src/formatRFC3339'
+import assert from 'assert'
+
+/**
+ * Europe/Warsaw (Poland) is regular full-hours timezone
+ */
+if (process.env.TZ !== 'Europe/Warsaw')
+  throw new Error(
+    'The test must be run with TZ=Europe/Warsaw (UTC+02:00 or UTC+01:00)'
+  )
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+// Old date
+assert.equal(
+  formatRFC3339(new Date(1986, 3, 4, 10, 33, 1)),
+  '1986-04-04T10:33:01+02:00'
+)
+
+// Standard time (Warsaw have +01:00)
+assert.equal(
+  formatRFC3339(new Date(2020, 0, 23, 5, 0, 54)),
+  '2020-01-23T05:00:54+01:00'
+)
+
+// Summer time (Warsaw have +02:00)
+assert.equal(
+  formatRFC3339(new Date(2020, 6, 30, 20, 59, 1)),
+  '2020-07-30T20:59:01+02:00'
+)


### PR DESCRIPTION
…with minutes (e.g. India, Australia).

First of all, thanks for making such a modular library! Once we found the issue, we could fix it in minutes in production by forking single-function :)

* Affected time-zones: 
  * Australia, 
  * East of Canada, 
  * India and Sri Lanka, 
  * Islands near by New Zealand
  * I think India is the most populated affected timezone
* Caused formatting offset in expression like `+5.5:30` instead `+05:30`) which makes invalid date in `parseISO()`
* It was simple mistake in division (`-330/60` caused `5.5` hours offset instead full hour)
* I used `toInteger` as it already have condition for positive and negative offset, using `Math.floot()` or `Math.ceil()`. I see in some other functions
* Add specs for interesting and regular timezones for this use case