### PR TITLE
add locale to formatDuration typings

### DIFF
--- a/src/formatDuration/index.js
+++ b/src/formatDuration/index.js
@@ -22,6 +22,7 @@ const defaultFormat = [
  * @param {Object} [options] - an object with options.
 
  * @param {string[]} [options.format=['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds']] - the array of units to format
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {boolean} [options.zero=false] - should be zeros be included in the output?
  * @param {string} [options.delimiter=' '] - delimiter string
  * @returns {string} the formatted date string

--- a/src/formatDuration/index.js.flow
+++ b/src/formatDuration/index.js.flow
@@ -51,6 +51,7 @@ declare module.exports: (
   duration: Duration,
   options?: {
     format?: string[],
+    locale?: Locale,
     zero?: boolean,
     delimiter?: string
   }

--- a/src/fp/formatDurationWithOptions/index.js.flow
+++ b/src/fp/formatDurationWithOptions/index.js.flow
@@ -57,6 +57,7 @@ declare module.exports: CurriedFn2<
   {
     delimiter?: string,
     zero?: boolean,
+    locale?: Locale,
     format?: string[]
   },
   Duration,

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -228,6 +228,7 @@ declare module.exports: {
     {
       delimiter?: string,
       zero?: boolean,
+      locale?: Locale,
       format?: string[]
     },
     Duration,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -317,6 +317,7 @@ declare module.exports: {
     duration: Duration,
     options?: {
       format?: string[],
+      locale?: Locale,
       zero?: boolean,
       delimiter?: string
     }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -423,6 +423,7 @@ declare module 'date-fns' {
     duration: Duration,
     options?: {
       format?: string[]
+      locale?: Locale
       zero?: boolean
       delimiter?: string
     }
@@ -4266,6 +4267,7 @@ declare module 'date-fns/fp' {
     {
       delimiter?: string
       zero?: boolean
+      locale?: Locale
       format?: string[]
     },
     Duration,
@@ -8295,6 +8297,7 @@ declare module 'date-fns/esm' {
     duration: Duration,
     options?: {
       format?: string[]
+      locale?: Locale
       zero?: boolean
       delimiter?: string
     }
@@ -12138,6 +12141,7 @@ declare module 'date-fns/esm/fp' {
     {
       delimiter?: string
       zero?: boolean
+      locale?: Locale
       format?: string[]
     },
     Duration,
@@ -18821,6 +18825,7 @@ interface dateFns {
     duration: Duration,
     options?: {
       format?: string[]
+      locale?: Locale
       zero?: boolean
       delimiter?: string
     }


### PR DESCRIPTION
Hi! I've just found that `locale` property missed in `formatDuration` typings. So, there is fix.

I would like to see it in next build, currently I have to use `// @ts-ignore` to allow use locale with this function. 

Thanks.