### PR TITLE
Clarifies that strings are still allowed as arguments, but not when a date is expected

### DIFF
--- a/docs/upgradeGuide.md
+++ b/docs/upgradeGuide.md
@@ -22,7 +22,7 @@ See [Unicode Tokens doc](./unicodeTokens.md) for more details.
 
 ### String arguments
 
-Functions now don't accept strings as arguments. Strings should
+Functions now don't accept strings as date arguments. Strings should
 be parsed using `parseISO` (ISO 8601) or `parse`.
 
 See [this post](https://blog.date-fns.org/post/we-cut-date-fns-v2-minimal-build-size-down-to-300-bytes-and-now-its-the-smallest-date-library-18f2nvh2z0yal) for more details.

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -51,7 +51,7 @@ export default function toDate(argument) {
     ) {
       // eslint-disable-next-line no-console
       console.warn(
-        "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
+        "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
       )
       // eslint-disable-next-line no-console
       console.warn(new Error().stack)

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -41,7 +41,7 @@ describe('toDate', () => {
       assert(
         // eslint-disable-next-line no-console
         console.warn.calledWith(
-          "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
+          "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
         )
       )
     })


### PR DESCRIPTION
After upgrading to v2 I kept seeing this warning. I just felt that it was somewhat misleading and could be clarified.