### PR TITLE
Update Webpack docs

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -36,8 +36,8 @@ import { supportedLocales } from './config.js'
 export default const config = {
   plugins: [
     new webpack.ContextReplacementPlugin(
-      /date\-fns[\/\\]/,
-      new RegExp(`[/\\\\\](${supportedLocales.join('|')})[/\\\\\]index\.js$`)
+      /^date-fns[/\\]locale$/,
+      new RegExp(`\\.[/\\\\](${supportedLocales.join('|')})[/\\\\]index\\.js$`)
     )
   ]
 }


### PR DESCRIPTION
Webpack did not include the supportedLocales in the build because the newContentRegExp was an absolute path whereas the ContextReplacementPlugin doc says: "If newContentResource is relative, it is resolved relative to the previous resource."