### PR TITLE
Fix countReporter data type for node 14

### DIFF
--- a/config/_lib/countReporter.js
+++ b/config/_lib/countReporter.js
@@ -2,18 +2,21 @@ var fs = require('fs')
 
 var countFilename = './tmp/tests_count.txt'
 
-function countReporter () {
-  this.onRunComplete = function (_, result) {
+function countReporter() {
+  this.onRunComplete = function(_, result) {
     var runCount = result.success
 
-    fs.readFile(countFilename, {encoding: 'utf-8', flag: 'a+'}, function (err, data) {
+    fs.readFile(countFilename, { encoding: 'utf-8', flag: 'a+' }, function(
+      err,
+      data
+    ) {
       if (err) {
         throw err
       }
 
       var totalCount = (parseInt(data, 10) || 0) + runCount
 
-      fs.writeFile(countFilename, totalCount, 'utf-8', function (err) {
+      fs.writeFile(countFilename, String(totalCount), 'utf-8', function(err) {
         if (err) {
           throw err
         }


### PR DESCRIPTION
In Node v14 `fs.writeFile` validates incoming `data` type and number type is not acceptable, test runner crashes after that. I am aware that v12 is LTS right now, but fixing this issue a little bit ahead of time is a nice thing, I guess.