### PR TITLE
Keep docs links inside date-fns.org

### DIFF
--- a/src/_lib/protectedTokens/index.js
+++ b/src/_lib/protectedTokens/index.js
@@ -12,19 +12,19 @@ export function isProtectedWeekYearToken(token) {
 export function throwProtectedError(token, format, input) {
   if (token === 'YYYY') {
     throw new RangeError(
-      `Use \`yyyy\` instead of \`YYYY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`yyyy\` instead of \`YYYY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://date-fns.org/docs/Unicode-Tokens`
     )
   } else if (token === 'YY') {
     throw new RangeError(
-      `Use \`yy\` instead of \`YY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`yy\` instead of \`YY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://date-fns.org/docs/Unicode-Tokens`
     )
   } else if (token === 'D') {
     throw new RangeError(
-      `Use \`d\` instead of \`D\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`d\` instead of \`D\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://date-fns.org/docs/Unicode-Tokens`
     )
   } else if (token === 'DD') {
     throw new RangeError(
-      `Use \`dd\` instead of \`DD\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`dd\` instead of \`DD\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://date-fns.org/docs/Unicode-Tokens`
     )
   }
 }

--- a/src/addMinutes/index.ts
+++ b/src/addMinutes/index.ts
@@ -14,7 +14,7 @@ const MILLISECONDS_IN_MINUTE = 60000
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date to be changed
  * @param {Number} amount - the amount of minutes to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.

--- a/src/differenceInISOWeekYears/index.js
+++ b/src/differenceInISOWeekYears/index.js
@@ -16,7 +16,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * - The function was renamed from `differenceInISOYears` to `differenceInISOWeekYears`.
  *   "ISO week year" is short for [ISO week-numbering year](https://en.wikipedia.org/wiki/ISO_week_date).

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -43,7 +43,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * Return the formatted date string in the given format. The result may vary by locale.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://date-fns.org/docs/Unicode-Tokens
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -277,10 +277,10 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *    - `p`: long localized time
  *
  * 8. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://date-fns.org/docs/Unicode-Tokens
  *
  * 9. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://date-fns.org/docs/Unicode-Tokens
  *
  * ### v2.0.0 breaking changes:
  *
@@ -309,9 +309,9 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {Number} [options.firstWeekContainsDate=1] - the day of January, which is
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
- *   see: https://git.io/fxCyr
+ *   see: https://date-fns.org/docs/Unicode-Tokens
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
- *   see: https://git.io/fxCyr
+ *   see: https://date-fns.org/docs/Unicode-Tokens
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `date` must not be Invalid Date
@@ -319,10 +319,10 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @throws {RangeError} `options.locale` must contain `formatLong` property
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
- * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
  * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -743,7 +743,7 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `d` instead of `D` \(in `yyyy-MM-D`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `d` instead of `D` \(in `yyyy-MM-D`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens)/g
       )
     })
 
@@ -759,7 +759,7 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `dd` instead of `DD` \(in `yyyy-MM-DD`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `dd` instead of `DD` \(in `yyyy-MM-DD`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens)/g
       )
     })
 
@@ -775,7 +775,7 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `yy` instead of `YY` \(in `YY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `yy` instead of `YY` \(in `YY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens)/g
       )
     })
 
@@ -791,7 +791,7 @@ describe('format', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `yyyy` instead of `YYYY` \(in `YYYY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `yyyy` instead of `YYYY` \(in `YYYY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens)/g
       )
     })
 

--- a/src/getDay/index.js
+++ b/src/getDay/index.js
@@ -11,7 +11,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the given date
  * @returns {0|1|2|3|4|5|6} the day of week, 0 represents Sunday

--- a/src/getISOWeekYear/index.js
+++ b/src/getISOWeekYear/index.js
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * - The function was renamed from `getISOYear` to `getISOWeekYear`.
  *   "ISO week year" is short for [ISO week-numbering year](https://en.wikipedia.org/wiki/ISO_week_date).

--- a/src/getOverlappingDaysInIntervals/index.js
+++ b/src/getOverlappingDaysInIntervals/index.js
@@ -13,7 +13,7 @@ var MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * - The function was renamed from `getOverlappingDaysInRanges` to `getOverlappingDaysInIntervals`.
  *   This change was made to mirror the use of the word "interval" in standard ISO 8601:2004 terminology:

--- a/src/getQuarter/index.js
+++ b/src/getQuarter/index.js
@@ -11,7 +11,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the given date
  * @returns {Number} the quarter

--- a/src/getWeek/index.js
+++ b/src/getWeek/index.js
@@ -21,7 +21,7 @@ var MILLISECONDS_IN_WEEK = 604800000
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the given date
  * @param {Object} [options] - an object with options.

--- a/src/isBefore/index.js
+++ b/src/isBefore/index.js
@@ -11,7 +11,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date that should be before the other one to return true
  * @param {Date|Number} dateToCompare - the date to compare with

--- a/src/isFuture/index.js
+++ b/src/isFuture/index.js
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date to check
  * @returns {Boolean} the date is in the future

--- a/src/isMatch/index.js
+++ b/src/isMatch/index.js
@@ -12,7 +12,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * will return false.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://date-fns.org/docs/Unicode-Tokens
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -235,10 +235,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://date-fns.org/docs/Unicode-Tokens
  *
  * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://date-fns.org/docs/Unicode-Tokens
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -267,18 +267,18 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
- *   see: https://git.io/fxCyr
+ *   see: https://date-fns.org/docs/Unicode-Tokens
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
- *   see: https://git.io/fxCyr
+ *   see: https://date-fns.org/docs/Unicode-Tokens
  * @returns {Boolean}
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
  * @throws {RangeError} `options.locale` must contain `match` property
- * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years; see: https://git.io/fxCyr
- * @throws {RangeError} use `yy` instead of `YY` for formatting years; see: https://git.io/fxCyr
- * @throws {RangeError} use `d` instead of `D` for formatting days of the month; see: https://git.io/fxCyr
- * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `yy` instead of `YY` for formatting years; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `d` instead of `D` for formatting days of the month; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month; see: https://date-fns.org/docs/Unicode-Tokens
  * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/isThisMonth/index.js
+++ b/src/isThisMonth/index.js
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date to check
  * @returns {Boolean} the date is in this month

--- a/src/isThisSecond/index.js
+++ b/src/isThisSecond/index.js
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date to check
  * @returns {Boolean} the date is in this second

--- a/src/lastDayOfISOWeekYear/index.js
+++ b/src/lastDayOfISOWeekYear/index.js
@@ -16,7 +16,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * - The function was renamed from `lastDayOfISOYear` to `lastDayOfISOWeekYear`.
  *   "ISO week year" is short for [ISO week-numbering year](https://en.wikipedia.org/wiki/ISO_week_date).

--- a/src/lightFormat/index.js
+++ b/src/lightFormat/index.js
@@ -30,7 +30,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * `lightFormat` doesn't use locales and outputs date using the most popular tokens.
  *
  * > ⚠️ Please note that the `lightFormat` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://date-fns.org/docs/Unicode-Tokens
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.

--- a/src/max/index.js
+++ b/src/max/index.js
@@ -11,7 +11,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * - `max` function now accepts an array of dates rather than spread arguments.
  *

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -47,7 +47,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * Return the date parsed from string using the given format string.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://date-fns.org/docs/Unicode-Tokens
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -270,10 +270,10 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://date-fns.org/docs/Unicode-Tokens
  *
  * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://date-fns.org/docs/Unicode-Tokens
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -328,18 +328,18 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
- *   see: https://git.io/fxCyr
+ *   see: https://date-fns.org/docs/Unicode-Tokens
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
- *   see: https://git.io/fxCyr
+ *   see: https://date-fns.org/docs/Unicode-Tokens
  * @returns {Date} the parsed date
  * @throws {TypeError} 3 arguments required
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
  * @throws {RangeError} `options.locale` must contain `match` property
- * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
+ * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://date-fns.org/docs/Unicode-Tokens
  * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -2464,7 +2464,7 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `d` instead of `D` \(in `yyyy D`\) for formatting days of the month to the input `2016 5`; see: https:\/\/git.io\/fxCyr/
+        /Use `d` instead of `D` \(in `yyyy D`\) for formatting days of the month to the input `2016 5`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens/
       )
     })
 
@@ -2480,7 +2480,7 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `dd` instead of `DD` \(in `yyyy DD`\) for formatting days of the month to the input `2016 05`; see: https:\/\/git.io\/fxCyr/
+        /Use `dd` instead of `DD` \(in `yyyy DD`\) for formatting days of the month to the input `2016 05`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens/
       )
     })
 
@@ -2496,7 +2496,7 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `yy` instead of `YY` \(in `YY w`\) for formatting years to the input `16 1`; see: https:\/\/git.io\/fxCyr/
+        /Use `yy` instead of `YY` \(in `YY w`\) for formatting years to the input `16 1`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens/
       )
     })
 
@@ -2512,7 +2512,7 @@ describe('parse', function() {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `yyyy` instead of `YYYY` \(in `YYYY w`\) for formatting years to the input `2016 1`; see: https:\/\/git.io\/fxCyr/
+        /Use `yyyy` instead of `YYYY` \(in `YYYY w`\) for formatting years to the input `2016 1`; see: https:\/\/date-fns.org\/docs\/Unicode-Tokens/
       )
     })
 

--- a/src/setDate/index.js
+++ b/src/setDate/index.js
@@ -12,7 +12,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date to be changed
  * @param {Number} dayOfMonth - the day of the month of the new date

--- a/src/setISODay/index.js
+++ b/src/setISODay/index.js
@@ -16,7 +16,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the date to be changed
  * @param {Number} day - the day of the ISO week of the new date

--- a/src/startOfWeekYear/index.js
+++ b/src/startOfWeekYear/index.js
@@ -19,7 +19,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the original date
  * @param {Object} [options] - an object with options.

--- a/src/startOfYear/index.js
+++ b/src/startOfYear/index.js
@@ -12,7 +12,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * ### v2.0.0 breaking changes:
  *
- * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
+ * - [Changes that are common for the whole library](https://date-fns.org/docs/Upgrade-Guide#common-changes).
  *
  * @param {Date|Number} date - the original date
  * @returns {Date} the start of a year

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -51,7 +51,7 @@ export default function toDate(argument) {
     ) {
       // eslint-disable-next-line no-console
       console.warn(
-        "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
+        "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://date-fns.org/docs/Upgrade-Guide#string-arguments"
       )
       // eslint-disable-next-line no-console
       console.warn(new Error().stack)

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -41,7 +41,7 @@ describe('toDate', () => {
       assert(
         // eslint-disable-next-line no-console
         console.warn.calledWith(
-          "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
+          "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://date-fns.org/docs/Upgrade-Guide#string-arguments"
         )
       )
     })


### PR DESCRIPTION
I found it a little jarring to bounce from date-fns.org into pages like https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md and https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md , which are the _source_ for documentation pages rather than nicely formatted documentation.

Are you willing to replace those links with proper date-fns.org targets?