### PR TITLE
Make differenceInBusinessDays return NaN instead of Invalid Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "date-fns",
+  "version": "DON'T CHANGE; IT'S SET AUTOMATICALLY DURING DEPLOYMENT; ALSO, USE YARN FOR DEVELOPMENT",
+  "lockfileVersion": 1
+}

--- a/src/differenceInBusinessDays/index.js
+++ b/src/differenceInBusinessDays/index.js
@@ -41,7 +41,9 @@ export default function differenceInBusinessDays(
   var dateLeft = toDate(dirtyDateLeft)
   var dateRight = toDate(dirtyDateRight)
 
-  if (!isValid(dateLeft) || !isValid(dateRight)) return new Date(NaN)
+  // fix for issue # 2012
+  // returning undefined to fix issue of returning a Date when either date is invalid
+  if (!isValid(dateLeft) || !isValid(dateRight)) return NaN
 
   var calendarDifference = differenceInCalendarDays(dateLeft, dateRight)
   var sign = calendarDifference < 0 ? -1 : 1


### PR DESCRIPTION
Saw there were already tests in place for this issue. I got them to pass by changing the return from new Date(NaN), which returns invalid date, to NaN.