### PR TITLE
docs: change "rounding" explanation to "truncate"

### DIFF
--- a/src/add/index.ts
+++ b/src/add/index.ts
@@ -14,7 +14,7 @@ import { Duration } from '../types'
  * Add the specified years, months, weeks, days, hours, minutes and seconds to the given date.
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Duration} duration - the object with years, months, weeks, days, hours, minutes and seconds to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Duration} duration - the object with years, months, weeks, days, hours, minutes and seconds to be added. Fractional values are truncated towards zero.
  *
  * | Key            | Description                        |
  * |----------------|------------------------------------|

--- a/src/addBusinessDays/index.ts
+++ b/src/addBusinessDays/index.ts
@@ -14,7 +14,7 @@ import isSaturday from '../isSaturday/index'
  * Add the specified number of business days (mon - fri) to the given date, ignoring weekends.
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of business days to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of business days to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the business days added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addDays/index.ts
+++ b/src/addDays/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of days to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of days to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the days added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addHours/index.ts
+++ b/src/addHours/index.ts
@@ -17,7 +17,7 @@ const MILLISECONDS_IN_HOUR = 3600000
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of hours to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of hours to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the hours added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addISOWeekYears/index.ts
+++ b/src/addISOWeekYears/index.ts
@@ -23,7 +23,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   locale-dependent week-numbering year helpers, e.g., `addWeekYears`.
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of ISO week-numbering years to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of ISO week-numbering years to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the ISO week-numbering years added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addMilliseconds/index.ts
+++ b/src/addMilliseconds/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of milliseconds to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of milliseconds to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the milliseconds added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addMinutes/index.ts
+++ b/src/addMinutes/index.ts
@@ -17,7 +17,7 @@ const MILLISECONDS_IN_MINUTE = 60000
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of minutes to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of minutes to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the minutes added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addMonths/index.ts
+++ b/src/addMonths/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of months to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of months to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the months added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addQuarters/index.ts
+++ b/src/addQuarters/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of quarters to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of quarters to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the quarters added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addSeconds/index.ts
+++ b/src/addSeconds/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of seconds to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of seconds to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the seconds added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addWeeks/index.ts
+++ b/src/addWeeks/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of weeks to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of weeks to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the weeks added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/addYears/index.ts
+++ b/src/addYears/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of years to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of years to be added. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the years added
  * @throws {TypeError} 2 arguments required
  *

--- a/src/milliseconds/index.ts
+++ b/src/milliseconds/index.ts
@@ -20,7 +20,7 @@ const yearInDays = 365.2425
  * @description
  * Returns the number of milliseconds in the specified, years, months, weeks, days, hours, minutes and seconds.
  *
- * @param {Duration} duration - the object with years, months, weeks, days, hours, minutes and seconds to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Duration} duration - the object with years, months, weeks, days, hours, minutes and seconds to be added. Fractional values are truncated towards zero.
  * @returns {number} the milliseconds
  * @throws {TypeError} 1 argument required
  *

--- a/src/subBusinessDays/index.js
+++ b/src/subBusinessDays/index.js
@@ -11,7 +11,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * Substract the specified number of business days (mon - fri) to the given date, ignoring weekends.
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of business days to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of business days to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the business days subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subDays/index.ts
+++ b/src/subDays/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of days to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of days to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the days subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subHours/index.ts
+++ b/src/subHours/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of hours to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of hours to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the hours subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subISOWeekYears/index.ts
+++ b/src/subISOWeekYears/index.ts
@@ -22,7 +22,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   locale-dependent week-numbering year helpers, e.g., `setWeekYear`.
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of ISO week-numbering years to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of ISO week-numbering years to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the ISO week-numbering years subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subMilliseconds/index.ts
+++ b/src/subMilliseconds/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of milliseconds to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of milliseconds to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the milliseconds subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subMinutes/index.ts
+++ b/src/subMinutes/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of minutes to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of minutes to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the minutes subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subMonths/index.ts
+++ b/src/subMonths/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of months to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of months to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the months subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subQuarters/index.ts
+++ b/src/subQuarters/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of quarters to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of quarters to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the quarters subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subSeconds/index.ts
+++ b/src/subSeconds/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of seconds to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of seconds to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the seconds subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subWeeks/index.ts
+++ b/src/subWeeks/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of weeks to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of weeks to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the weeks subtracted
  * @throws {TypeError} 2 arguments required
  *

--- a/src/subYears/index.ts
+++ b/src/subYears/index.ts
@@ -15,7 +15,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the date to be changed
- * @param {Number} amount - the amount of years to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Number} amount - the amount of years to be subtracted. Fractional values are truncated towards zero.
  * @returns {Date} the new date with the years subtracted
  * @throws {TypeError} 2 arguments required
  *


### PR DESCRIPTION
Docs for `add` / `sub` functions say "Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`."

Docs for `differenceInDays` / `differenceInWeeks` say "Fractional days/weeks are truncated towards zero."

This PR changes the `add` / `sub` docs to use the latter, as it is more clear and concise.