### PR TITLE
Add weekStartsOn options to getDay

### DIFF
--- a/src/getDay/index.ts
+++ b/src/getDay/index.ts
@@ -1,5 +1,7 @@
+import toInteger from '../_lib/toInteger/index'
 import toDate from '../toDate/index'
 import requiredArgs from '../_lib/requiredArgs/index'
+import { WeekStartOptions } from '../types'
 
 /**
  * @name getDay
@@ -14,6 +16,9 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
  * @param {Date|Number} date - the given date
+ * @param {Object} [options] - an object with options.
+ * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @returns {0|1|2|3|4|5|6} the day of week, 0 represents Sunday
  * @throws {TypeError} 1 argument required
  *
@@ -21,11 +26,29 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * // Which day of the week is 29 February 2012?
  * const result = getDay(new Date(2012, 1, 29))
  * //=> 3
+ * @example
+ * // Which day of the week is 29 February 2012, with a weekStartsOn of Monday:
+ * const result = getDay(new Date(2012, 1, 29), { weekStartsOn: 1 })
+ * //=> 2
  */
-export default function getDay(dirtyDate: Date | number): number {
+export default function getDay(
+  dirtyDate: Date | number,
+  dirtyOptions?: WeekStartOptions
+): number {
   requiredArgs(1, arguments)
+
+  var options = dirtyOptions || {}
+  var locale = options.locale
+  var localeWeekStartsOn =
+    locale && locale.options && locale.options.weekStartsOn
+  var defaultWeekStartsOn =
+    localeWeekStartsOn == null ? 0 : toInteger(localeWeekStartsOn)
+  var weekStartsOn =
+    options.weekStartsOn == null
+      ? defaultWeekStartsOn
+      : toInteger(options.weekStartsOn)
 
   const date = toDate(dirtyDate)
   const day = date.getDay()
-  return day
+  return (((day - weekStartsOn) % 7) + 7) % 7
 }

--- a/src/getDay/test.ts
+++ b/src/getDay/test.ts
@@ -10,6 +10,34 @@ describe('getDay', function() {
     assert(result === 3)
   })
 
+  it('allows to specify which day is the first day of the week', function() {
+    const result = getDay(new Date(2012, 1 /* Feb */, 29), { weekStartsOn: 1 })
+    assert(result === 2)
+  })
+
+  it('allows to specify which day is the first day of the week (with a weekStartsOn of Saturday)', function() {
+    const result = getDay(new Date(2012, 1 /* Feb */, 29), { weekStartsOn: 6 })
+    assert(result === 4)
+  })
+
+  it('allows to specify which day is the first day of the week in locale', function() {
+    const result = getDay(new Date(2012, 1 /* Feb */, 29), {
+      locale: {
+        options: { weekStartsOn: 1 }
+      }
+    })
+    assert(result === 2)
+  })
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function() {
+    const result = getDay(new Date(2012, 1 /* Feb */, 29), {
+      weekStartsOn: 1,
+      locale: {
+        options: { weekStartsOn: 0 }
+      }
+    })
+    assert(result === 2)
+  })
+
   it('accepts a timestamp', function() {
     const result = getDay(new Date(2014, 5 /* Jun */, 1).getTime())
     assert(result === 0)

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export interface StepOptions {
 }
 
 export interface WeekStartOptions {
-  weekStartsOn?: number
+  weekStartsOn?: 0|1|2|3|4|5|6
+  locale?: { options?: { weekStartsOn?: 0|1|2|3|4|5|6 } }
 }
 
 export interface LocaleOptions {


### PR DESCRIPTION
Most of the week-related functions have `weekStartsOn` options, but `getDay` doesn't.

```js
// Which day of the week is 29 February 2012?
getDay(new Date(2012, 1, 29))
//=> 3

// Which day of the week is 29 February 2012, with a weekStartsOn of Monday:
getDay(new Date(2012, 1, 29), { weekStartsOn: 1 })
//=> 2
```