### PR TITLE
Basque (eu) lange correction

### DIFF
--- a/src/locale/eu/_lib/formatLong/index.js
+++ b/src/locale/eu/_lib/formatLong/index.js
@@ -1,12 +1,11 @@
 import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index'
 
 var dateFormats = {
-  full: "EEEE, d 'de' MMMM y",
-  long: "d 'de' MMMM y",
-  medium: 'd MMM y',
-  short: 'dd/MM/y'
+  full: "EEEE, y'ko' MMMM'ren' d'a' y'ren'",
+  long: "y'ko' MMMM'ren' d'a'",
+  medium: 'y MMM d',
+  short: 'yy/MM/dd',
 }
-
 var timeFormats = {
   full: 'HH:mm:ss zzzz',
   long: 'HH:mm:ss z',


### PR DESCRIPTION
Datefomats is modified for basque language correct translation, because there was some text from spanish copied incorrectly. 