### PR TITLE
feat: Add strict parse feature

### DIFF
--- a/src/parse/_lib/parsers/index.js
+++ b/src/parse/_lib/parsers/index.js
@@ -71,14 +71,11 @@ function parseNumber(string, options) {
     return null
   }
   var match = matchResult[0]
-  var negative = match[0] === '-'
+  var negative = match[0] === '-' ? 1 : 0
   if (negative && !options.allowSigned) {
     return null
   }
-  var digits = match.slice(
-    negative ? 1 : 0,
-    (negative ? 1 : 0) + options.length || undefined
-  )
+  var digits = match.slice(negative, negative + options.length || undefined)
   if (options.length && options.strict && digits.length < options.length) {
     return null
   }

--- a/src/parse/_lib/parsers/index.js
+++ b/src/parse/_lib/parsers/index.js
@@ -22,16 +22,7 @@ var numericPatterns = {
   minute: /^[0-5]?\d/, // 0 to 59
   second: /^[0-5]?\d/, // 0 to 59
 
-  singleDigit: /^\d/, // 0 to 9
-  twoDigits: /^\d{1,2}/, // 0 to 99
-  threeDigits: /^\d{1,3}/, // 0 to 999
-  fourDigits: /^\d{1,4}/, // 0 to 9999
-
-  anyDigitsSigned: /^-?\d+/,
-  singleDigitSigned: /^-?\d/, // 0 to 9, -0 to -9
-  twoDigitsSigned: /^-?\d{1,2}/, // 0 to 99, -0 to -99
-  threeDigitsSigned: /^-?\d{1,3}/, // 0 to 999, -0 to -999
-  fourDigitsSigned: /^-?\d{1,4}/ // 0 to 9999, -0 to -9999
+  anyDigitsSigned: /^-?\d+/
 }
 
 var timezonePatterns = {

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -327,6 +327,8 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
+ * @param {Boolean} [options.strict=false] - in strict mode the length of tokens matters, i.e. date parts must be properly zero padded;
+ *   e.g. `912` wont match `yyyy` but `0912` will. Contraty `0912` wont match `yyy` as it unnecessary exceeds length of tokens
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
  *   see: https://git.io/fxCyr
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
@@ -414,8 +416,9 @@ export default function parse(
 
   var subFnOptions = {
     firstWeekContainsDate: firstWeekContainsDate,
-    weekStartsOn: weekStartsOn,
-    locale: locale
+    locale: locale,
+    strict: options.strict,
+    weekStartsOn: weekStartsOn
   }
 
   // If timezone isn't specified, it will be set to the system timezone

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -2650,4 +2650,64 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
   })
+
+  describe('strict parse', function() {
+    it(`valid ISO date`, function() {
+      var expected = new Date(476, 0 /* Jan */, 1)
+      var dateTimeString = `0476-01-01`
+      var formatString = `yyyy-MM-dd`
+      var result = parse(dateTimeString, formatString, referenceDate, {
+        strict: true
+      })
+      assert.deepEqual(result, expected)
+    })
+    ;[
+      [`year`, `yyyy`, `476`],
+      [`ISO week-numbering year`, `RRRR`, `-123`],
+      [`month`, `dd`, `1`],
+      [`extended year`, `uuu`, `-42`],
+      [`querter stand-alone`, `qq`, `1`],
+      [`month`, `MM`, `1`],
+      [`month stand-alone`, `LL`, `1`],
+      [`local week of year`, `ww`, `1`],
+      [`ISO week of year`, `II`, `1`],
+      [`day of year`, `DD`, `1`, { useAdditionalDayOfYearTokens: true }],
+      [`local day of week`, `ee`, `1`],
+      [`local day of week stand-alone`, `cc`, `1`],
+      [`local week of year`, `ww`, `1`],
+      [`iso day of week`, `ii`, `1`],
+      [`hour [1-12]`, `hh`, `1`],
+      [`hour [0-23]`, `HH`, `1`],
+      [`hour [0-11]`, `KK`, `1`],
+      [`hour [1-24]`, `kk`, `1`],
+      [`minute`, `mm`, `1`],
+      [`fraction of seconds`, `SS`, `1`]
+    ].forEach(([name, formatString, dateTimeString, extraOptions]) => {
+      it(`insufficient length ${name}`, () => {
+        var result = parse(dateTimeString, formatString, referenceDate, {
+          strict: true,
+          ...extraOptions
+        })
+        assert(result instanceof Date && isNaN(result))
+      })
+    })
+
+    it(`excessive zero pad year`, function() {
+      var result = parse(`00476`, `yyyy`, referenceDate, { strict: true })
+      assert(result instanceof Date && isNaN(result))
+    })
+    it(`excessive zero pad ISO week-numbering year`, function() {
+      var result = parse(`-00123`, `RRRR`, referenceDate, { strict: true })
+      assert(result instanceof Date && isNaN(result))
+    })
+
+    // it('valid ISO date year larger than tokens', function() {
+    //   var result = parse('10476', 'yyyy', referenceDate, { strict: true })
+    //   var expected = new Date(10476, 0 /* Jan */, 1)
+    //   var dateTimeString = '10476-01-01'
+    //   var formatString = 'yyyy-MM-dd'
+    //   var result = parse(dateTimeString, formatString, referenceDate)
+    //   assert.deepEqual(result, expected)
+    // })
+  })
 })


### PR DESCRIPTION
This PR adds a new option `strict` to [`parse`](https://date-fns.org/v2.16.1/docs/parse) to enforce the same length of the date part in the date string as the length of tokens in the format string.

See #1849 