### PR TITLE
A week should start on Sunday in Japanese locale

### DIFF
--- a/src/locale/ja/index.js
+++ b/src/locale/ja/index.js
@@ -24,7 +24,7 @@ var locale = {
   localize: localize,
   match: match,
   options: {
-    weekStartsOn: 1 /* Monday */,
+    weekStartsOn: 0 /* Sunday */,
     firstWeekContainsDate: 1
   }
 }


### PR DESCRIPTION
I know this PR should be written in TypeScript, but currently other locales are in pure JavaScript, so I decided not to change the language.
Thanks for the amazing product!

https://en.wikipedia.org/wiki/Week
> While, for example, the United States, Canada, Brazil, Japan and other countries consider Sunday as the first day of the week, and while the week begins with Saturday in much of the Middle East, the international ISO 8601 standard[a] and most of Europe has Monday as the first day of the week.