### PR TITLE
Fix czech short and medium date formats

### DIFF
--- a/src/locale/cs/_lib/formatLong/index.js
+++ b/src/locale/cs/_lib/formatLong/index.js
@@ -3,8 +3,8 @@ import buildFormatLongFn from '../../../_lib/buildFormatLongFn/index'
 var dateFormats = {
   full: 'EEEE, d. MMMM yyyy',
   long: 'd. MMMM yyyy',
-  medium: 'd.M.yyyy',
-  short: 'd.M.yy'
+  medium: 'd. M. yyyy',
+  short: 'dd.MM.yyyy'
 }
 
 var timeFormats = {


### PR DESCRIPTION
According to the official Czech language maintainer (https://prirucka.ujc.cas.cz/?id=810), current date-fns short and medium date formats are not allowed. Moreover, officially acknowledged formats are not parsed by date-fns properly.

The changes are as follows:
 - two-digits year is not allowed
 - if there are no spaces after `.` in the date, month and day must be two-digits
 - format with 1-2 digits and a space after `.` is the most common one

Note for the PR: I have run the `./scripts/build/build.sh` command, but it made many (693) formatting changes in js and flow files, which is not intended, I guess.
