### PR TITLE
Add Type Guard to isDate

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -585,7 +585,7 @@ declare module 'date-fns' {
   function isBefore(date: Date | number, dateToCompare: Date | number): boolean
   namespace isBefore {}
 
-  function isDate(value: any): boolean
+  function isDate(value: any): value is Date
   namespace isDate {}
 
   function isEqual(dateLeft: Date | number, dateRight: Date | number): boolean


### PR DESCRIPTION
Apply a [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates) to the return type of `isDate`