### PR TITLE
add types.ts to ignoredFiles of list locales

### DIFF
--- a/scripts/_lib/listLocales.js
+++ b/scripts/_lib/listLocales.js
@@ -1,7 +1,13 @@
 const path = require('path')
 const fs = require('fs')
 
-const ignoredFiles = ['index.js', 'test.js', 'index.js.flow', 'package.json']
+const ignoredFiles = [
+  'index.js',
+  'test.js',
+  'index.js.flow',
+  'package.json',
+  'types.ts'
+]
 
 module.exports = listLocales
 

--- a/scripts/build/fp.js
+++ b/scripts/build/fp.js
@@ -26,8 +26,8 @@ buildFP(fpFns)
 function getFPFn(resultFnName, initialFnName, arity) {
   return [generatedAutomaticallyMessage]
     .concat('')
-    .concat(`import fn from '../../${initialFnName}/index.js'`)
-    .concat(`import convertToFP from '../_lib/convertToFP/index.js'`)
+    .concat(`import fn from '../../${initialFnName}/index'`)
+    .concat(`import convertToFP from '../_lib/convertToFP/index'`)
     .concat('')
     .concat(`var ${resultFnName} = convertToFP(fn, ${arity})`)
     .concat('')


### PR DESCRIPTION
- add `types.ts` to `ignoredFiles` in `listLocales.js`. fixes syntax error for generated files.

./scripts/build/typings.js

```
SyntaxError: ',' expected. (16366:14)
  16364 |   namespace tr {}
  16365 | 
> 16366 |   const types.ts: Locale
        |              ^
  16367 |   namespace types.ts {}
  16368 | 
  16369 |   const ug: Locale
```

- Remove `.js` from fp imports
