### PR TITLE
Update formatRFC3339 documentation

### DIFF
--- a/src/formatRFC3339/index.js
+++ b/src/formatRFC3339/index.js
@@ -6,10 +6,10 @@ import toInteger from '../_lib/toInteger/index'
 /**
  * @name formatRFC3339
  * @category Common Helpers
- * @summary Format the date according to the ISO 3339 standard (https://tools.ietf.org/html/rfc3339#section-5.6).
+ * @summary Format the date according to the RFC 3339 standard (https://tools.ietf.org/html/rfc3339#section-5.6).
  *
  * @description
- * Return the formatted date string in ISO 3339 format. Options may be passed to control the parts and notations of the date.
+ * Return the formatted date string in RFC 3339 format. Options may be passed to control the parts and notations of the date.
  *
  * @param {Date|Number} date - the original date
  * @param {Object} [options] - an object with options.
@@ -20,17 +20,17 @@ import toInteger from '../_lib/toInteger/index'
  * @throws {RangeError} `options.fractionDigits` must be between 0 and 3
  *
  * @example
- * // Represent 18 September 2019 in ISO 3339 format:
+ * // Represent 18 September 2019 in RFC 3339 format:
  * const result = formatRFC3339(new Date(2019, 8, 18, 19, 0, 52))
  * //=> '2019-09-18T19:00:52Z'
  *
  * @example
- * // Represent 18 September 2019 in ISO 3339 format, 2 digits of second fraction:
+ * // Represent 18 September 2019 in RFC 3339 format, 2 digits of second fraction:
  * const result = formatRFC3339(new Date(2019, 8, 18, 19, 0, 52, 234), { fractionDigits: 2 })
  * //=> '2019-09-18T19:00:52.23Z'
  *
  * @example
- * // Represent 18 September 2019 in ISO 3339 format, 3 digits of second fraction
+ * // Represent 18 September 2019 in RFC 3339 format, 3 digits of second fraction
  * const result = formatRFC3339(new Date(2019, 8, 18, 19, 0, 52, 234), { fractionDigits: 3 })
  * //=> '2019-09-18T19:00:52.234Z'
  */


### PR DESCRIPTION
It should be about the RFC 3339 (Date and Time on the Internet: Timestamps) and not the ISO 3339 (Tractors and Machinery for Agriculture and Forestry - Classification and Terminology).