### PR TITLE
Fix formatDuration week translation in pt and pt-BR locales

### DIFF
--- a/src/locale/pt-BR/_lib/formatDistance/index.js
+++ b/src/locale/pt-BR/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'cerca de 1 mês',
-    other: 'cerca de {{count}} meses'
+    one: 'cerca de 1 semana',
+    other: 'cerca de {{count}} semanas'
   },
 
   xWeeks: {
-    one: '1 mês',
-    other: '{{count}} meses'
+    one: '1 semana',
+    other: '{{count}} semanas'
   },
 
   aboutXMonths: {

--- a/src/locale/pt/_lib/formatDistance/index.js
+++ b/src/locale/pt/_lib/formatDistance/index.js
@@ -37,13 +37,13 @@ var formatDistanceLocale = {
   },
 
   aboutXWeeks: {
-    one: 'aproximadamente 1 mês', // TODO
-    other: 'aproximadamente {{count}} meses' // TODO
+    one: 'aproximadamente 1 semana',
+    other: 'aproximadamente {{count}} semanas'
   },
 
   xWeeks: {
-    one: '1 mês', // TODO
-    other: '{{count}} meses' // TODO
+    one: '1 semana',
+    other: '{{count}} semanas'
   },
 
   aboutXMonths: {


### PR DESCRIPTION
`formatDuration` output when using pt-BR locale was the following:
![formatDuration_wrong](https://user-images.githubusercontent.com/18372991/102826090-c3a2b680-43be-11eb-8944-1c683f474e2d.PNG)

_mês_ translates to _month_. _Week_ in Portuguese is translated as _semana_, so the correct output is:
![formatDuration_right](https://user-images.githubusercontent.com/18372991/102826165-e2a14880-43be-11eb-8b48-c9fcda5486b3.PNG)
