### PR TITLE
Add accept offsets positive and negative

### DIFF
--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -16,7 +16,8 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`
  * - `2000-03-15T05:20:10Z`: Without milliseconds
- * - `2000-03-15T05:20:10+00:00`: With a zero, positive or negative offset, the default JSON encoded format in some other languages
+ * - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
+ * - `2000-03-15T05:20:10+05:45`: With a positive or negative offset, the default JSON encoded format in some other languages
  * - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
  * - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
  * - `2000-03-15T05:20:10.1234567`: Up to 7 digits in milliseconds field. Only first 3 are taken into account since JS does not allow fractional milliseconds

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -39,7 +39,7 @@ export default function parseJSON(argument) {
 
   if (typeof argument === 'string') {
     var parts = argument.match(
-      /(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,7}))?(?:Z|\+00:?00)?/
+      /(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,7}))?(?:Z|(.\d{2}):?00)?/
     )
     if (parts) {
       return new Date(
@@ -47,7 +47,7 @@ export default function parseJSON(argument) {
           +parts[1],
           parts[2] - 1,
           +parts[3],
-          +parts[4],
+          +parts[4] - (parts[8] || '0'),
           +parts[5],
           +parts[6],
           +((parts[7] || '0') + '00').substring(0, 3)

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -36,19 +36,19 @@ import requiredArgs from '../_lib/requiredArgs/index'
  */
 export default function parseJSON(argument) {
   requiredArgs(1, arguments)
-
   if (typeof argument === 'string') {
     var parts = argument.match(
-      /(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,7}))?(?:Z|(.\d{2}):?00)?/
+      /(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,7}))?(?:Z|(.)(\d{2}):?(\d{2})?)?/
     )
     if (parts) {
+      // Group 8 matches the sign
       return new Date(
         Date.UTC(
           +parts[1],
           parts[2] - 1,
           +parts[3],
-          +parts[4] - (parts[8] || '0'),
-          +parts[5],
+          +parts[4] - (parts[9] || 0) * (parts[8] == '-' ? -1 : 1),
+          +parts[5] - (parts[10] || 0) * (parts[8] == '-' ? -1 : 1),
           +parts[6],
           +((parts[7] || '0') + '00').substring(0, 3)
         )

--- a/src/parseJSON/index.js
+++ b/src/parseJSON/index.js
@@ -16,7 +16,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`
  * - `2000-03-15T05:20:10Z`: Without milliseconds
- * - `2000-03-15T05:20:10+00:00`: With a zero offset, the default JSON encoded format in some other languages
+ * - `2000-03-15T05:20:10+00:00`: With a zero, positive or negative offset, the default JSON encoded format in some other languages
  * - `2000-03-15T05:20:10+0000`: With a zero offset without a colon
  * - `2000-03-15T05:20:10`: Without a trailing 'Z' symbol
  * - `2000-03-15T05:20:10.1234567`: Up to 7 digits in milliseconds field. Only first 3 are taken into account since JS does not allow fractional milliseconds

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -34,6 +34,13 @@ describe('parseJSON', function () {
     assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
   })
 
+  it('parses a formatted Indian Standart Time with +5:30 hours of offset back to UTC - issue 2149', () => {
+    const date = '2021-02-15T02:56:04.678+05:30'
+    const expectedDate = new Date('2021-02-14T21:26:04.678Z')
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
+  })
+
   it('parses a fully formed ISO date with Z', () => {
     const date = '2000-03-15T05:20:10.123Z'
     const parsedDate = parseJSON(date)

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -3,8 +3,37 @@
 
 import assert from 'power-assert'
 import parseJSON from '.'
+import format from '../format/index'
 
-describe('parseJSON', function() {
+describe('parseJSON', function () {
+  it('parses a formatted new Date() back to UTC - issue 2149', () => {
+    const date = new Date()
+    const jsonFormat = format(date, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx")
+    const parsedDate = parseJSON(jsonFormat)
+    assert.equal(parsedDate.toISOString(), date.toISOString())
+  })
+
+  it('parses a formatted date with an hour of offset back to UTC - issue 2149', () => {
+    const date = '2021-01-09T13:18:10.873+01:00'
+    const expectedDate = new Date('2021-01-09T12:18:10.873Z')
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
+  })
+
+  it('parses a formatted date with 2 hours of offset back to UTC - issue 2149', () => {
+    const date = '2021-01-09T13:18:10.873+02:00'
+    const expectedDate = new Date('2021-01-09T11:18:10.873Z')
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
+  })
+
+  it('parses a formatted date with -2 hours of offset back to UTC - issue 2149', () => {
+    const date = '2021-01-09T13:18:10.873-02:00'
+    const expectedDate = new Date('2021-01-09T15:18:10.873Z')
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
+  })
+
   it('parses a fully formed ISO date with Z', () => {
     const date = '2000-03-15T05:20:10.123Z'
     const parsedDate = parseJSON(date)

--- a/src/parseJSON/test.js
+++ b/src/parseJSON/test.js
@@ -34,9 +34,16 @@ describe('parseJSON', function () {
     assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
   })
 
-  it('parses a formatted Indian Standart Time with +5:30 hours of offset back to UTC - issue 2149', () => {
+  it('parses a formatted Indian Standart Time in Asia/Kolkata with +5:30 hours of offset back to UTC - issue 2149', () => {
     const date = '2021-02-15T02:56:04.678+05:30'
     const expectedDate = new Date('2021-02-14T21:26:04.678Z')
+    const parsedDate = parseJSON(date)
+    assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
+  })
+
+  it('parses a formatted time in Asia/Kathmandu with +5:45 hours of offset back to UTC - issue 2149', () => {
+    const date = '2021-02-15T17:45:00.900+05:45'
+    const expectedDate = new Date('2021-02-15T12:00:00.900Z')
     const parsedDate = parseJSON(date)
     assert.equal(parsedDate.toISOString(), expectedDate.toISOString())
   })


### PR DESCRIPTION
This will allow parseJSON to accept formats with positive and negative offsets. 
Documentation pending.
WIP