### PR TITLE
Fix short date separator for Romanian locale

### DIFF
--- a/src/locale/ro/_lib/formatLong/index.js
+++ b/src/locale/ro/_lib/formatLong/index.js
@@ -4,7 +4,7 @@ var dateFormats = {
   full: 'EEEE, d MMMM yyyy',
   long: 'd MMMM yyyy',
   medium: 'd MMM yyyy',
-  short: 'dd/MM/yyyy'
+  short: 'dd.MM.yyyy'
 }
 
 var timeFormats = {


### PR DESCRIPTION
The correct and most used separator in Romanian language is . (period) not / (slash)