### PR TITLE
Update `isMonday` to use correct argument name

### DIFF
--- a/src/isMonday/index.ts
+++ b/src/isMonday/index.ts
@@ -25,5 +25,5 @@ import requiredArgs from '../_lib/requiredArgs/index'
 export default function isMonday(date: Date | number): boolean {
   requiredArgs(1, arguments)
 
-  return toDate(dirtyDate).getDay() === 1
+  return toDate(date).getDay() === 1
 }


### PR DESCRIPTION
A regression was introduced in https://github.com/date-fns/date-fns/pull/2230 where the argument name was changed but the name passed to `toDate()` was missed. This change addresses that regression.