### PR TITLE
Fix getTimezoneOffsetInMilliseconds to fix the tests failing after Chrome upgrade

### DIFF
--- a/src/_lib/getTimezoneOffsetInMilliseconds/index.js
+++ b/src/_lib/getTimezoneOffsetInMilliseconds/index.js
@@ -1,9 +1,3 @@
-var MILLISECONDS_IN_MINUTE = 60000
-
-function getDateMillisecondsPart(date) {
-  return date.getTime() % MILLISECONDS_IN_MINUTE
-}
-
 /**
  * Google Chrome as of 67.0.3396.87 introduced timezones with offset that includes seconds.
  * They usually appear for dates that denote time before the timezones were introduced
@@ -15,18 +9,18 @@ function getDateMillisecondsPart(date) {
  *
  * This function returns the timezone offset in milliseconds that takes seconds in account.
  */
-export default function getTimezoneOffsetInMilliseconds(dirtyDate) {
-  var date = new Date(dirtyDate.getTime())
-  var baseTimezoneOffset = Math.ceil(date.getTimezoneOffset())
-  date.setSeconds(0, 0)
-  var hasNegativeUTCOffset = baseTimezoneOffset > 0
-  var millisecondsPartOfTimezoneOffset = hasNegativeUTCOffset
-    ? (MILLISECONDS_IN_MINUTE + getDateMillisecondsPart(date)) %
-      MILLISECONDS_IN_MINUTE
-    : getDateMillisecondsPart(date)
-
-  return (
-    baseTimezoneOffset * MILLISECONDS_IN_MINUTE +
-    millisecondsPartOfTimezoneOffset
+export default function getTimezoneOffsetInMilliseconds(date) {
+  const utcDate = new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+      date.getMilliseconds()
+    )
   )
+  utcDate.setUTCFullYear(date.getFullYear())
+  return date.getTime() - utcDate.getTime()
 }

--- a/src/addDays/test.ts
+++ b/src/addDays/test.ts
@@ -54,6 +54,9 @@ describe('addDays', function() {
   const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz
   const HOUR = 1000 * 60 * 60
+  const MINUTE = 1000 * 60
+  // It's usually 1 hour, but for some timezones, e.g. Australia/Lord_Howe, it is 30 minutes
+  const dstOffset = dstTransitions.start && dstTransitions.end ? ((dstTransitions.end.getTimezoneOffset() - dstTransitions.start.getTimezoneOffset()) * MINUTE) : NaN
 
   dstOnly(
     `works at DST-start boundary in local timezone: ${tz || '(unknown)'}`,
@@ -70,7 +73,7 @@ describe('addDays', function() {
       const date = new Date(dstTransitions.start!.getTime() - 0.5 * HOUR)
       const result = addDays(date, 1)
       // started before the transition so will only be 23 hours later in local time
-      assert.deepStrictEqual(result, new Date(date.getTime() + 23 * HOUR))
+      assert.deepStrictEqual(result, new Date(date.getTime() + 24 * HOUR - dstOffset))
     }
   )
 
@@ -80,7 +83,7 @@ describe('addDays', function() {
       const date = new Date(dstTransitions.start!.getTime() - 1 * HOUR)
       const result = addDays(date, 1)
       // started before the transition so will only be 23 hours later in local time
-      assert.deepStrictEqual(result, new Date(date.getTime() + 23 * HOUR))
+      assert.deepStrictEqual(result, new Date(date.getTime() + 24 * HOUR - dstOffset))
     }
   )
 
@@ -100,7 +103,7 @@ describe('addDays', function() {
       const result = addDays(date, 1)
       // started before the transition so will be 25 hours later in local
       // time because one hour repeats after DST ends.
-      assert.deepStrictEqual(result, new Date(date.getTime() + 25 * HOUR))
+      assert.deepStrictEqual(result, new Date(date.getTime() + 24 * HOUR + dstOffset))
     }
   )
 
@@ -111,7 +114,7 @@ describe('addDays', function() {
       const result = addDays(date, 1)
       // started before the transition so will be 25 hours later in local
       // time because one hour repeats after DST ends.
-      assert.deepStrictEqual(result, new Date(date.getTime() + 25 * HOUR))
+      assert.deepStrictEqual(result, new Date(date.getTime() + 24 * HOUR + dstOffset))
     }
   )
 

--- a/src/differenceInCalendarDays/test.js
+++ b/src/differenceInCalendarDays/test.js
@@ -5,8 +5,8 @@ import assert from 'power-assert'
 import differenceInCalendarDays from '.'
 import { getDstTransitions } from '../../test/dst/tzOffsetTransitions'
 
-describe('differenceInCalendarDays', function() {
-  it('returns the number of calendar days between the given dates', function() {
+describe('differenceInCalendarDays', function () {
+  it('returns the number of calendar days between the given dates', function () {
     var result = differenceInCalendarDays(
       new Date(2012, 6 /* Jul */, 2, 18, 0),
       new Date(2011, 6 /* Jul */, 2, 6, 0)
@@ -14,7 +14,7 @@ describe('differenceInCalendarDays', function() {
     assert(result === 366)
   })
 
-  it('returns a negative number if the time value of the first date is smaller', function() {
+  it('returns a negative number if the time value of the first date is smaller', function () {
     var result = differenceInCalendarDays(
       new Date(2011, 6 /* Jul */, 2, 6, 0),
       new Date(2012, 6 /* Jul */, 2, 18, 0)
@@ -22,7 +22,7 @@ describe('differenceInCalendarDays', function() {
     assert(result === -366)
   })
 
-  it('accepts timestamps', function() {
+  it('accepts timestamps', function () {
     var result = differenceInCalendarDays(
       new Date(2014, 8 /* Sep */, 5, 18, 0).getTime(),
       new Date(2014, 8 /* Sep */, 4, 6, 0).getTime()
@@ -30,8 +30,8 @@ describe('differenceInCalendarDays', function() {
     assert(result === 1)
   })
 
-  describe('edge cases', function() {
-    it('the difference is less than a day, but the given dates are in different calendar days', function() {
+  describe('edge cases', function () {
+    it('the difference is less than a day, but the given dates are in different calendar days', function () {
       var result = differenceInCalendarDays(
         new Date(2014, 8 /* Sep */, 5, 0, 0),
         new Date(2014, 8 /* Sep */, 4, 23, 59)
@@ -39,7 +39,7 @@ describe('differenceInCalendarDays', function() {
       assert(result === 1)
     })
 
-    it('the same for the swapped dates', function() {
+    it('the same for the swapped dates', function () {
       var result = differenceInCalendarDays(
         new Date(2014, 8 /* Sep */, 4, 23, 59),
         new Date(2014, 8 /* Sep */, 5, 0, 0)
@@ -47,7 +47,7 @@ describe('differenceInCalendarDays', function() {
       assert(result === -1)
     })
 
-    it('the time values of the given the given dates are the same', function() {
+    it('the time values of the given the given dates are the same', function () {
       var result = differenceInCalendarDays(
         new Date(2014, 8 /* Sep */, 6, 0, 0),
         new Date(2014, 8 /* Sep */, 5, 0, 0)
@@ -55,7 +55,7 @@ describe('differenceInCalendarDays', function() {
       assert(result === 1)
     })
 
-    it('the given the given dates are the same', function() {
+    it('the given the given dates are the same', function () {
       var result = differenceInCalendarDays(
         new Date(2014, 8 /* Sep */, 5, 0, 0),
         new Date(2014, 8 /* Sep */, 5, 0, 0)
@@ -78,7 +78,7 @@ describe('differenceInCalendarDays', function() {
     })
   })
 
-  it('returns NaN if the first date is `Invalid Date`', function() {
+  it('returns NaN if the first date is `Invalid Date`', function () {
     var result = differenceInCalendarDays(
       new Date(NaN),
       new Date(2017, 0 /* Jan */, 1)
@@ -86,7 +86,7 @@ describe('differenceInCalendarDays', function() {
     assert(isNaN(result))
   })
 
-  it('returns NaN if the second date is `Invalid Date`', function() {
+  it('returns NaN if the second date is `Invalid Date`', function () {
     var result = differenceInCalendarDays(
       new Date(2017, 0 /* Jan */, 1),
       new Date(NaN)
@@ -94,12 +94,12 @@ describe('differenceInCalendarDays', function() {
     assert(isNaN(result))
   })
 
-  it('returns NaN if the both dates are `Invalid Date`', function() {
+  it('returns NaN if the both dates are `Invalid Date`', function () {
     var result = differenceInCalendarDays(new Date(NaN), new Date(NaN))
     assert(isNaN(result))
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(differenceInCalendarDays.bind(null), TypeError)
     assert.throws(differenceInCalendarDays.bind(null, 1), TypeError)
   })
@@ -111,9 +111,10 @@ describe('differenceInCalendarDays', function() {
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz
   dstOnly(
     `works across DST start & end in local timezone: ${tz || '(unknown)'}`,
-    function() {
+    function () {
       const { start, end } = dstTransitions
       const HOUR = 1000 * 60 * 60
+      const MINUTE = 1000 * 60
       function sameTime(t1, t2) {
         return (
           t1.getHours() === t2.getHours() &&
@@ -123,13 +124,17 @@ describe('differenceInCalendarDays', function() {
         )
       }
 
+      // It's usually 1 hour, but for some timezones, e.g. Australia/Lord_Howe, it is 30 minutes
+      const dstOffset =
+        (end.getTimezoneOffset() - start.getTimezoneOffset()) * MINUTE
+
       // TEST DST START (SPRING)
 
       // anchor to one hour before the boundary
       {
         const a = new Date(start.getTime() - HOUR) // 1 hour before DST
-        const b = new Date(a.getTime() + 23 * HOUR) // 1 day later, same local time
-        const c = new Date(a.getTime() + 47 * HOUR) // 2 days later, same local time
+        const b = new Date(a.getTime() + 24 * HOUR - dstOffset) // 1 day later, same local time
+        const c = new Date(a.getTime() + 48 * HOUR - dstOffset) // 2 days later, same local time
 
         assert(sameTime(a, b))
         assert(sameTime(a, c))
@@ -158,8 +163,8 @@ describe('differenceInCalendarDays', function() {
       // until 25 hours have elapsed.
       {
         const a = new Date(end.getTime() - HOUR / 2) // 1 hour before Standard Time starts
-        const b = new Date(a.getTime() + 24.75 * HOUR) // 1 day later, 15 mins earlier local time
-        const c = new Date(a.getTime() + 48.75 * HOUR) // 2 days later, 15 mins earlier local time
+        const b = new Date(a.getTime() + 24 * HOUR + dstOffset - 15 * MINUTE) // 1 day later, 15 mins earlier local time
+        const c = new Date(a.getTime() + 48 * HOUR + dstOffset - 15 * MINUTE) // 2 days later, 15 mins earlier local time
 
         assert(differenceInCalendarDays(c, b) === 1) // normal 24-hour day
         assert(differenceInCalendarDays(b, a) === 1) // 24.75 hours but 1 calendar days
@@ -168,8 +173,8 @@ describe('differenceInCalendarDays', function() {
       // anchor to one hour before the boundary
       {
         const a = new Date(end.getTime() - HOUR) // 1 hour before Standard Time starts
-        const b = new Date(a.getTime() + 25 * HOUR) // 1 day later, same local time
-        const c = new Date(a.getTime() + 49 * HOUR) // 2 days later, same local time
+        const b = new Date(a.getTime() + 24 * HOUR + dstOffset) // 1 day later, same local time
+        const c = new Date(a.getTime() + 48 * HOUR + dstOffset) // 2 days later, same local time
 
         assert(sameTime(a, b))
         assert(sameTime(a, c))

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -4,7 +4,7 @@
 import assert from 'power-assert'
 import format from '.'
 
-describe('format', function() {
+describe('format', function () {
   var date = new Date(1986, 3 /* Apr */, 4, 10, 32, 55, 123)
 
   var offset = date.getTimezoneOffset()
@@ -35,33 +35,33 @@ describe('format', function() {
   var timestamp = date.getTime().toString()
   var secondsTimestamp = Math.floor(date.getTime() / 1000).toString()
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     var date = new Date(2014, 3, 4).getTime()
     assert(format(date, 'yyyy-MM-dd') === '2014-04-04')
   })
 
-  it('escapes characters between the single quote characters', function() {
+  it('escapes characters between the single quote characters', function () {
     var result = format(date, "'yyyy-'MM-dd'THH:mm:ss.SSSX' yyyy-'MM-dd'")
     assert(result === 'yyyy-04-04THH:mm:ss.SSSX 1986-MM-dd')
   })
 
-  it('two single quote characters are transformed into a "real" single quote', function() {
+  it('two single quote characters are transformed into a "real" single quote', function () {
     var date = new Date(2014, 3, 4, 5)
     assert(format(date, "''h 'o''clock'''") === "'5 o'clock'")
   })
 
-  it('accepts new line charactor', function() {
+  it('accepts new line charactor', function () {
     var date = new Date(2014, 3, 4, 5)
     assert.equal(format(date, "yyyy-MM-dd'\n'HH:mm:ss"), '2014-04-04\n05:00:00')
   })
 
-  describe('ordinal numbers', function() {
-    it('ordinal day of an ordinal month', function() {
+  describe('ordinal numbers', function () {
+    it('ordinal day of an ordinal month', function () {
       var result = format(date, "do 'day of the' Mo 'month of' yyyy")
       assert(result === '4th day of the 4th month of 1986')
     })
 
-    it('should return a correct ordinal number', function() {
+    it('should return a correct ordinal number', function () {
       var result = []
       for (var i = 1; i <= 31; i++) {
         result.push(format(new Date(2015, 0, i), 'do'))
@@ -97,150 +97,158 @@ describe('format', function() {
         '28th',
         '29th',
         '30th',
-        '31st'
+        '31st',
       ]
       assert.deepEqual(result, expected)
     })
   })
 
-  it('era', function() {
+  it('era', function () {
     var result = format(date, 'G GG GGG GGGG GGGGG')
     assert(result === 'AD AD AD Anno Domini A')
   })
 
-  describe('year', function() {
-    describe('regular year', function() {
-      it('works as expected', function() {
+  describe('year', function () {
+    describe('regular year', function () {
+      it('works as expected', function () {
         var result = format(date, 'y yo yy yyy yyyy yyyyy')
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
-      it('1 BC formats as 1', function() {
-        var date = new Date(0, 0 /* Jan */, 1)
-        date.setFullYear(0)
+      it('1 BC formats as 1', function () {
+        var date = new Date(0)
+        date.setFullYear(0, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'y')
         assert(result === '1')
       })
 
-      it('2 BC formats as 2', function() {
-        var date = new Date(0, 0 /* Jan */, 1)
-        date.setFullYear(-1)
+      it('2 BC formats as 2', function () {
+        var date = new Date(0)
+        date.setFullYear(-1, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'y')
         assert(result === '2')
       })
     })
 
-    describe('local week-numbering year', function() {
-      it('works as expected', function() {
+    describe('local week-numbering year', function () {
+      it('works as expected', function () {
         var result = format(date, 'Y Yo YY YYY YYYY YYYYY', {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
-      it('the first week of the next year', function() {
+      it('the first week of the next year', function () {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '2014')
       })
 
-      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
           weekStartsOn: 1,
           firstWeekContainsDate: 4,
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '2013')
       })
 
-      it('the first week of year', function() {
+      it('the first week of year', function () {
         var result = format(new Date(2016, 0 /* Jan */, 1), 'YYYY', {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '2016')
       })
 
-      it('1 BC formats as 1', function() {
-        var date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(0)
+      it('1 BC formats as 1', function () {
+        var date = new Date(0)
+        date.setFullYear(0, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'Y')
         assert(result === '1')
       })
 
-      it('2 BC formats as 2', function() {
-        var date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(-1)
+      it('2 BC formats as 2', function () {
+        var date = new Date(0)
+        date.setFullYear(-1, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'Y')
         assert(result === '2')
       })
     })
 
-    describe('ISO week-numbering year', function() {
-      it('works as expected', function() {
+    describe('ISO week-numbering year', function () {
+      it('works as expected', function () {
         var result = format(date, 'R RR RRR RRRR RRRRR')
         assert(result === '1986 1986 1986 1986 01986')
       })
 
-      it('the first week of the next year', function() {
+      it('the first week of the next year', function () {
         var result = format(new Date(2013, 11 /* Dec */, 30), 'RRRR')
         assert(result === '2014')
       })
 
-      it('the last week of the previous year', function() {
+      it('the last week of the previous year', function () {
         var result = format(new Date(2016, 0 /* Jan */, 1), 'RRRR')
         assert(result === '2015')
       })
 
-      it('1 BC formats as 0', function() {
-        var date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(0)
+      it('1 BC formats as 0', function () {
+        var date = new Date(0)
+        date.setFullYear(0, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'R')
         assert(result === '0')
       })
 
-      it('2 BC formats as -1', function() {
-        var date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(-1)
+      it('2 BC formats as -1', function () {
+        var date = new Date(0)
+        date.setFullYear(-1, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'R')
         assert(result === '-1')
       })
     })
 
-    describe('extended year', function() {
-      it('works as expected', function() {
+    describe('extended year', function () {
+      it('works as expected', function () {
         var result = format(date, 'u uu uuu uuuu uuuuu')
         assert(result === '1986 1986 1986 1986 01986')
       })
 
-      it('1 BC formats as 0', function() {
-        var date = new Date(0, 0, 1)
-        date.setFullYear(0)
+      it('1 BC formats as 0', function () {
+        var date = new Date(0)
+        date.setFullYear(0, 0, 1)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'u')
         assert(result === '0')
       })
 
-      it('2 BC formats as -1', function() {
-        var date = new Date(0, 0, 1)
-        date.setFullYear(-1)
+      it('2 BC formats as -1', function () {
+        var date = new Date(0)
+        date.setFullYear(-1, 0, 1)
+        date.setHours(0, 0, 0, 0)
         var result = format(date, 'u')
         assert(result === '-1')
       })
     })
   })
 
-  describe('quarter', function() {
-    it('formatting quarter', function() {
+  describe('quarter', function () {
+    it('formatting quarter', function () {
       var result = format(date, 'Q Qo QQ QQQ QQQQ QQQQQ')
       assert(result === '2 2nd 02 Q2 2nd quarter 2')
     })
 
-    it('stand-alone quarter', function() {
+    it('stand-alone quarter', function () {
       var result = format(date, 'q qo qq qqq qqqq qqqqq')
       assert(result === '2 2nd 02 Q2 2nd quarter 2')
     })
 
-    it('returns a correct quarter for each month', function() {
+    it('returns a correct quarter for each month', function () {
       var result = []
       for (var i = 0; i <= 11; i++) {
         result.push(format(new Date(1986, i, 1), 'Q'))
@@ -257,64 +265,64 @@ describe('format', function() {
         '3',
         '4',
         '4',
-        '4'
+        '4',
       ]
       assert.deepEqual(result, expected)
     })
   })
 
-  describe('month', function() {
-    it('formatting month', function() {
+  describe('month', function () {
+    it('formatting month', function () {
       var result = format(date, 'M Mo MM MMM MMMM MMMMM')
       assert(result === '4 4th 04 Apr April A')
     })
 
-    it('stand-alone month', function() {
+    it('stand-alone month', function () {
       var result = format(date, 'L Lo LL LLL LLLL LLLLL')
       assert(result === '4 4th 04 Apr April A')
     })
   })
 
-  describe('week', function() {
-    describe('local week of year', function() {
-      it('works as expected', function() {
+  describe('week', function () {
+    describe('local week of year', function () {
+      it('works as expected', function () {
         var date = new Date(1986, 3 /* Apr */, 6)
         var result = format(date, 'w wo ww')
         assert(result === '15 15th 15')
       })
 
-      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
         var date = new Date(1986, 3 /* Apr */, 6)
         var result = format(date, 'w wo ww', {
           weekStartsOn: 1,
-          firstWeekContainsDate: 4
+          firstWeekContainsDate: 4,
         })
         assert(result === '14 14th 14')
       })
     })
 
-    it('ISO week of year', function() {
+    it('ISO week of year', function () {
       var date = new Date(1986, 3 /* Apr */, 6)
       var result = format(date, 'I Io II')
       assert(result === '14 14th 14')
     })
   })
 
-  describe('day', function() {
-    it('date', function() {
+  describe('day', function () {
+    it('date', function () {
       var result = format(date, 'd do dd')
       assert(result === '4 4th 04')
     })
 
-    describe('day of year', function() {
-      it('works as expected', function() {
+    describe('day of year', function () {
+      it('works as expected', function () {
         var result = format(date, 'D Do DD DDD DDDDD', {
-          useAdditionalDayOfYearTokens: true
+          useAdditionalDayOfYearTokens: true,
         })
         assert(result === '94 94th 94 094 00094')
       })
 
-      it('returns a correct day number for the last day of a leap year', function() {
+      it('returns a correct day number for the last day of a leap year', function () {
         var result = format(
           new Date(1992, 11 /* Dec */, 31, 23, 59, 59, 999),
           'D',
@@ -325,21 +333,21 @@ describe('format', function() {
     })
   })
 
-  describe('week day', function() {
-    describe('day of week', function() {
-      it('works as expected', function() {
+  describe('week day', function () {
+    describe('day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'E EE EEE EEEE EEEEE EEEEEE')
         assert(result === 'Fri Fri Fri Friday F Fr')
       })
     })
 
-    describe('ISO day of week', function() {
-      it('works as expected', function() {
+    describe('ISO day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'i io ii iii iiii iiiii iiiiii')
         assert(result === '5 5th 05 Fri Friday F Fr')
       })
 
-      it('returns a correct day of an ISO week', function() {
+      it('returns a correct day of an ISO week', function () {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'i'))
@@ -349,13 +357,13 @@ describe('format', function() {
       })
     })
 
-    describe('formatting day of week', function() {
-      it('works as expected', function() {
+    describe('formatting day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'e eo ee eee eeee eeeee eeeeee')
         assert(result === '6 6th 06 Fri Friday F Fr')
       })
 
-      it('by default, 1 is Sunday, 2 is Monday, ...', function() {
+      it('by default, 1 is Sunday, 2 is Monday, ...', function () {
         var result = []
         for (var i = 7; i <= 13; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'e'))
@@ -364,7 +372,7 @@ describe('format', function() {
         assert.deepEqual(result, expected)
       })
 
-      it('allows to specify which day is the first day of the week', function() {
+      it('allows to specify which day is the first day of the week', function () {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(
@@ -376,13 +384,13 @@ describe('format', function() {
       })
     })
 
-    describe('stand-alone day of week', function() {
-      it('works as expected', function() {
+    describe('stand-alone day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'c co cc ccc cccc ccccc cccccc')
         assert(result === '6 6th 06 Fri Friday F Fr')
       })
 
-      it('by default, 1 is Sunday, 2 is Monday, ...', function() {
+      it('by default, 1 is Sunday, 2 is Monday, ...', function () {
         var result = []
         for (var i = 7; i <= 13; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'c'))
@@ -391,7 +399,7 @@ describe('format', function() {
         assert.deepEqual(result, expected)
       })
 
-      it('allows to specify which day is the first day of the week', function() {
+      it('allows to specify which day is the first day of the week', function () {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(
@@ -404,29 +412,29 @@ describe('format', function() {
     })
   })
 
-  describe('day period and hour', function() {
-    it('hour [1-12]', function() {
+  describe('day period and hour', function () {
+    it('hour [1-12]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'h ho hh')
       assert(result === '12 12th 12')
     })
 
-    it('hour [0-23]', function() {
+    it('hour [0-23]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'H Ho HH')
       assert(result === '0 0th 00')
     })
 
-    it('hour [0-11]', function() {
+    it('hour [0-11]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'K Ko KK')
       assert(result === '0 0th 00')
     })
 
-    it('hour [1-24]', function() {
+    it('hour [1-24]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'k ko kk')
       assert(result === '24 24th 24')
     })
 
-    describe('AM, PM', function() {
-      it('works as expected', function() {
+    describe('AM, PM', function () {
+      it('works as expected', function () {
         var result = format(
           new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0),
           'a aa aaa aaaa aaaaa'
@@ -434,19 +442,19 @@ describe('format', function() {
         assert(result === 'AM AM am a.m. a')
       })
 
-      it('12 PM', function() {
+      it('12 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'h H K k a') === '12 12 0 12 PM')
       })
 
-      it('12 AM', function() {
+      it('12 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, 'h H K k a') === '12 0 0 24 AM')
       })
     })
 
-    describe('AM, PM, noon, midnight', function() {
-      it('works as expected', function() {
+    describe('AM, PM, noon, midnight', function () {
+      it('works as expected', function () {
         var result = format(
           new Date(1986, 3 /* Apr */, 6, 2, 0, 0, 900),
           'b bb bbb bbbb bbbbb'
@@ -454,12 +462,12 @@ describe('format', function() {
         assert(result === 'AM AM am a.m. a')
       })
 
-      it('12 PM', function() {
+      it('12 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'b bb bbb bbbb bbbbb') === 'noon noon noon noon n')
       })
 
-      it('12 AM', function() {
+      it('12 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(
           format(date, 'b bb bbb bbbb bbbbb') ===
@@ -468,8 +476,8 @@ describe('format', function() {
       })
     })
 
-    describe('flexible day periods', function() {
-      it('works as expected', function() {
+    describe('flexible day periods', function () {
+      it('works as expected', function () {
         var result = format(date, 'B, BB, BBB, BBBB, BBBBB')
         assert(
           result ===
@@ -477,173 +485,173 @@ describe('format', function() {
         )
       })
 
-      it('12 PM', function() {
+      it('12 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'h B') === '12 in the afternoon')
       })
 
-      it('5 PM', function() {
+      it('5 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 17, 0, 0, 900)
         assert(format(date, 'h B') === '5 in the evening')
       })
 
-      it('12 AM', function() {
+      it('12 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, 'h B') === '12 at night')
       })
 
-      it('4 AM', function() {
+      it('4 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 4, 0, 0, 900)
         assert(format(date, 'h B') === '4 in the morning')
       })
     })
   })
 
-  it('minute', function() {
+  it('minute', function () {
     var result = format(date, 'm mo mm')
     assert(result === '32 32nd 32')
   })
 
-  describe('second', function() {
-    it('second', function() {
+  describe('second', function () {
+    it('second', function () {
       var result = format(date, 's so ss')
       assert(result === '55 55th 55')
     })
 
-    it('fractional seconds', function() {
+    it('fractional seconds', function () {
       var result = format(date, 'S SS SSS SSSS')
       assert(result === '1 12 123 1230')
     })
   })
 
-  describe('time zone', function() {
-    it('ISO-8601 with Z', function() {
+  describe('time zone', function () {
+    it('ISO-8601 with Z', function () {
       var result = format(date, 'X XX XXX XXXX XXXXX')
       var expectedResult = [
         timezoneWithOptionalMinutesAndZShort,
         timezoneWithZShort,
         timezoneWithZ,
         timezoneWithZShort,
-        timezoneWithZ
+        timezoneWithZ,
       ].join(' ')
       assert(result === expectedResult)
     })
 
-    it('ISO-8601 without Z', function() {
+    it('ISO-8601 without Z', function () {
       var result = format(date, 'x xx xxx xxxx xxxxx')
       var expectedResult = [
         timezoneWithOptionalMinutesShort,
         timezoneShort,
         timezone,
         timezoneShort,
-        timezone
+        timezone,
       ].join(' ')
       assert(result === expectedResult)
     })
 
-    it('GMT', function() {
+    it('GMT', function () {
       var result = format(date, 'O OO OOO OOOO')
       var expectedResult = [
         timezoneGMTShort,
         timezoneGMTShort,
         timezoneGMTShort,
-        timezoneGMT
+        timezoneGMT,
       ].join(' ')
       assert(result === expectedResult)
     })
 
-    it('Specific non-location', function() {
+    it('Specific non-location', function () {
       var result = format(date, 'z zz zzz zzzz')
       var expectedResult = [
         timezoneGMTShort,
         timezoneGMTShort,
         timezoneGMTShort,
-        timezoneGMT
+        timezoneGMT,
       ].join(' ')
       assert(result === expectedResult)
     })
   })
 
-  describe('timestamp', function() {
-    it('seconds timestamp', function() {
+  describe('timestamp', function () {
+    it('seconds timestamp', function () {
       var result = format(date, 't')
       assert(result === secondsTimestamp)
     })
 
-    it('milliseconds timestamp', function() {
+    it('milliseconds timestamp', function () {
       var result = format(date, 'T')
       assert(result === timestamp)
     })
   })
 
-  describe('long format', function() {
-    it('short date', function() {
+  describe('long format', function () {
+    it('short date', function () {
       var result = format(date, 'P')
       assert(result === '04/04/1986')
     })
 
-    it('medium date', function() {
+    it('medium date', function () {
       var result = format(date, 'PP')
       assert(result === 'Apr 4, 1986')
     })
 
-    it('long date', function() {
+    it('long date', function () {
       var result = format(date, 'PPP')
       assert(result === 'April 4th, 1986')
     })
 
-    it('full date', function() {
+    it('full date', function () {
       var result = format(date, 'PPPP')
       assert(result === 'Friday, April 4th, 1986')
     })
 
-    it('short time', function() {
+    it('short time', function () {
       var result = format(date, 'p')
       assert(result === '10:32 AM')
     })
 
-    it('medium time', function() {
+    it('medium time', function () {
       var result = format(date, 'pp')
       assert(result === '10:32:55 AM')
     })
 
-    it('long time', function() {
+    it('long time', function () {
       var result = format(date, 'ppp')
       assert(result === '10:32:55 AM ' + timezoneGMTShort)
     })
 
-    it('full time', function() {
+    it('full time', function () {
       var result = format(date, 'pppp')
       assert(result === '10:32:55 AM ' + timezoneGMT)
     })
 
-    it('short date + time', function() {
+    it('short date + time', function () {
       var result = format(date, 'Pp')
       assert(result === '04/04/1986, 10:32 AM')
     })
 
-    it('medium date + time', function() {
+    it('medium date + time', function () {
       var result = format(date, 'PPpp')
       assert(result === 'Apr 4, 1986, 10:32:55 AM')
     })
 
-    it('long date + time', function() {
+    it('long date + time', function () {
       var result = format(date, 'PPPppp')
       assert(result === 'April 4th, 1986 at 10:32:55 AM ' + timezoneGMTShort)
     })
 
-    it('full date + time', function() {
+    it('full date + time', function () {
       var result = format(date, 'PPPPpppp')
       assert(result === 'Friday, April 4th, 1986 at 10:32:55 AM ' + timezoneGMT)
     })
 
-    it('allows arbitrary combination of date and time', function() {
+    it('allows arbitrary combination of date and time', function () {
       var result = format(date, 'Ppppp')
       assert(result === '04/04/1986, 10:32:55 AM ' + timezoneGMT)
     })
   })
 
-  describe('edge cases', function() {
+  describe('edge cases', function () {
     it('throws RangeError if the time value is invalid', () => {
       assert.throws(
         format.bind(null, new Date(NaN), 'MMMM d, yyyy'),
@@ -651,7 +659,7 @@ describe('format', function() {
       )
     })
 
-    it('handles dates before 100 AD', function() {
+    it('handles dates before 100 AD', function () {
       var initialDate = new Date(0)
       initialDate.setFullYear(7, 11 /* Dec */, 31)
       initialDate.setHours(0, 0, 0, 0)
@@ -659,7 +667,7 @@ describe('format', function() {
     })
   })
 
-  it('implicitly converts `formatString`', function() {
+  it('implicitly converts `formatString`', function () {
     // eslint-disable-next-line no-new-wrappers
     var formatString = new String('yyyy-MM-dd')
 
@@ -669,70 +677,70 @@ describe('format', function() {
     assert(format(date, formatString) === '2014-04-04')
   })
 
-  describe('custom locale', function() {
-    it('allows to pass a custom locale', function() {
+  describe('custom locale', function () {
+    it('allows to pass a custom locale', function () {
       var customLocale = {
         localize: {
-          month: function() {
+          month: function () {
             return 'works'
-          }
+          },
         },
         formatLong: {
-          date: function() {
+          date: function () {
             return "'It' MMMM!"
-          }
-        }
+          },
+        },
       }
       // $ExpectedMistake
       var result = format(date, 'PPPP', { locale: customLocale })
       assert(result === 'It works!')
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function () {
       var customLocale = {
-        formatLong: {}
+        formatLong: {},
       }
       // $ExpectedMistake
       var block = format.bind(null, date, 'yyyy-MM-dd', {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function () {
       var customLocale = {
         // $ExpectedMistake
-        localize: {}
+        localize: {},
       }
       // $ExpectedMistake
       var block = format.bind(null, date, 'yyyy-MM-dd', {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
   })
 
-  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
     // $ExpectedMistake
     var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {
-      weekStartsOn: NaN
+      weekStartsOn: NaN,
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function() {
+  it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function () {
     // $ExpectedMistake
     var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {
-      firstWeekContainsDate: NaN
+      firstWeekContainsDate: NaN,
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function () {
     assert.throws(format.bind(null, date, 'yyyy-MM-dd-nnnn'), RangeError)
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(format.bind(null), TypeError)
     assert.throws(format.bind(null, 1), TypeError)
   })
@@ -749,7 +757,7 @@ describe('format', function() {
 
     it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = format(date, 'yyyy-MM-D', {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, '1986-04-94')
     })
@@ -765,7 +773,7 @@ describe('format', function() {
 
     it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = format(date, 'yyyy-MM-DD', {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, '1986-04-94')
     })
@@ -781,7 +789,7 @@ describe('format', function() {
 
     it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = format(date, 'YY-MM-dd', {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, '86-04-04')
     })
@@ -797,7 +805,7 @@ describe('format', function() {
 
     it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = format(date, 'YYYY-MM-dd', {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, '1986-04-04')
     })

--- a/src/lightFormat/test.js
+++ b/src/lightFormat/test.js
@@ -22,7 +22,7 @@ describe('lightFormat', () => {
     assert(lightFormat(date, "''h 'o''clock'''") === "'5 o'clock'")
   })
 
-  it('accepts new line charactor', function() {
+  it('accepts new line charactor', function () {
     var date = new Date(2014, 3, 4, 5)
     assert.equal(
       lightFormat(date, "yyyy-MM-dd'\n'HH:mm:ss"),
@@ -38,15 +38,17 @@ describe('lightFormat', () => {
       })
 
       it('1 BC formats as 1', () => {
-        var date = new Date(0, 0 /* Jan */, 1)
-        date.setFullYear(0)
+        var date = new Date(0)
+        date.setFullYear(0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         var result = lightFormat(date, 'y')
         assert(result === '1')
       })
 
       it('2 BC formats as 2', () => {
-        var date = new Date(0, 0 /* Jan */, 1)
-        date.setFullYear(-1)
+        var date = new Date(0)
+        date.setFullYear(-1, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         var result = lightFormat(date, 'y')
         assert(result === '2')
       })
@@ -117,7 +119,7 @@ describe('lightFormat', () => {
     })
   })
 
-  it('fractional seconds', function() {
+  it('fractional seconds', function () {
     var result = lightFormat(date, 'S SS SSS SSSS')
     assert(result === '1 12 123 1230')
   })
@@ -139,7 +141,7 @@ describe('lightFormat', () => {
     assert(lightFormat(date, formatString) === '2014-04-04')
   })
 
-  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function () {
     assert.throws(lightFormat.bind(null, date, 'yyyy-MM-dd-nnnn'), RangeError)
   })
 

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -3,10 +3,10 @@
 import assert from 'power-assert'
 import parse from '.'
 
-describe('parse', function() {
+describe('parse', function () {
   var referenceDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900)
 
-  it('escapes characters between the single quote characters', function() {
+  it('escapes characters between the single quote characters', function () {
     var result = parse(
       '2018 hello world July 2nd',
       "yyyy 'hello world' MMMM do",
@@ -15,12 +15,12 @@ describe('parse', function() {
     assert.deepEqual(result, new Date(2018, 6 /* Jul */, 2))
   })
 
-  it('two single quote characters are transformed into a "real" single quote', function() {
+  it('two single quote characters are transformed into a "real" single quote', function () {
     var result = parse("'5 o'clock'", "''h 'o''clock'''", referenceDate)
     assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 5))
   })
 
-  it('accepts new line charactor', function() {
+  it('accepts new line charactor', function () {
     var result = parse(
       '2014-04-04\n05:00:00',
       "yyyy-MM-dd'\n'HH:mm:ss",
@@ -29,38 +29,40 @@ describe('parse', function() {
     assert.deepEqual(result, new Date(2014, 3 /* Apr */, 4, 5))
   })
 
-  describe('era', function() {
-    it('abbreviated', function() {
+  describe('era', function () {
+    it('abbreviated', function () {
       var result = parse('10000 BC', 'yyyyy G', referenceDate)
       assert.deepEqual(result, new Date(-9999, 0 /* Jan */, 1))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('2018 Anno Domini', 'yyyy GGGG', referenceDate)
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('44 B', 'y GGGGG', referenceDate)
       assert.deepEqual(result, new Date(-43, 0 /* Jan */, 1))
     })
 
-    it('with week-numbering year', function() {
+    it('with week-numbering year', function () {
       var result = parse('44 B', 'Y GGGGG', referenceDate)
       assert.deepEqual(result, new Date(-44, 11 /* Dec */, 30))
     })
 
-    it('parses stand-alone BC', function() {
+    it('parses stand-alone BC', function () {
       var result = parse('BC', 'G', referenceDate)
-      const expectedResult = new Date(0, 0 /* Jan */, 1)
-      expectedResult.setFullYear(0)
+      const expectedResult = new Date(0)
+      expectedResult.setFullYear(0, 0 /* Jan */, 1)
+      expectedResult.setHours(0, 0, 0, 0)
       assert.deepEqual(result, expectedResult)
     })
 
-    it('parses stand-alone AD', function() {
+    it('parses stand-alone AD', function () {
       var result = parse('AD', 'G', referenceDate)
-      const expectedResult = new Date(1, 0 /* Jan */, 1)
-      expectedResult.setFullYear(1)
+      const expectedResult = new Date(0)
+      expectedResult.setFullYear(1, 0 /* Jan */, 1)
+      expectedResult.setHours(0, 0, 0, 0)
       assert.deepEqual(result, expectedResult)
     })
 
@@ -70,7 +72,7 @@ describe('parse', function() {
         ['R', '2019'],
         ['u', '2019'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when G is used after ${token}`, () => {
           const block = parse.bind(
@@ -91,45 +93,47 @@ describe('parse', function() {
     })
   })
 
-  describe('calendar year', function() {
-    it('numeric', function() {
+  describe('calendar year', function () {
+    it('numeric', function () {
       var result = parse('2017', 'y', referenceDate)
       assert.deepEqual(result, new Date(2017, 0 /* Jan */, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('2017th', 'yo', referenceDate)
       assert.deepEqual(result, new Date(2017, 0 /* Jan */, 1))
     })
 
-    describe('two-digit numeric year', function() {
-      it('works as expected', function() {
+    describe('two-digit numeric year', function () {
+      it('works as expected', function () {
         var result = parse('02', 'yy', referenceDate)
         assert.deepEqual(result, new Date(2002, 0 /* Jan */, 1))
       })
 
-      it('gets the 100 year range from `referenceDate`', function() {
+      it('gets the 100 year range from `referenceDate`', function () {
         var result = parse('02', 'yy', new Date(1860, 6 /* Jul */, 2))
         assert.deepEqual(result, new Date(1902, 0 /* Jan */, 1))
       })
     })
 
-    it('three-digit zero-padding', function() {
+    it('three-digit zero-padding', function () {
       var result = parse('123', 'yyy', referenceDate)
       assert.deepEqual(result, new Date(123, 0 /* Jan */, 1))
     })
 
-    it('four-digit zero-padding', function() {
+    it('four-digit zero-padding', function () {
       var result = parse('0044', 'yyyy', referenceDate)
-      var expectedResult = new Date(44, 0 /* Jan */, 1)
-      expectedResult.setFullYear(44)
+      var expectedResult = new Date(0)
+      expectedResult.setFullYear(44, 0 /* Jan */, 1)
+      expectedResult.setHours(0, 0, 0, 0)
       assert.deepEqual(result, expectedResult)
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse('000001', 'yyyyyy', referenceDate)
-      var expectedResult = new Date(1, 0 /* Jan */, 1)
-      expectedResult.setFullYear(1)
+      var expectedResult = new Date(0)
+      expectedResult.setFullYear(1, 0 /* Jan */, 1)
+      expectedResult.setHours(0, 0, 0, 0)
       assert.deepEqual(result, expectedResult)
     })
 
@@ -145,7 +149,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when y is used after ${token}`, () => {
           const block = parse.bind(
@@ -166,46 +170,46 @@ describe('parse', function() {
     })
   })
 
-  describe('local week-numbering year', function() {
-    it('numeric', function() {
+  describe('local week-numbering year', function () {
+    it('numeric', function () {
       var result = parse('2002', 'Y', referenceDate)
       assert.deepEqual(result, new Date(2001, 11 /* Dec */, 30))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('12345th', 'Yo', referenceDate)
       assert.deepEqual(result, new Date(12344, 11 /* Dec */, 31))
     })
 
-    describe('two-digit numeric year', function() {
-      it('works as expected', function() {
+    describe('two-digit numeric year', function () {
+      it('works as expected', function () {
         var result = parse('02', 'YY', referenceDate, {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert.deepEqual(result, new Date(2001, 11 /* Dec */, 30))
       })
 
-      it('gets the 100 year range from `referenceDate`', function() {
+      it('gets the 100 year range from `referenceDate`', function () {
         var result = parse('02', 'YY', new Date(1860, 6 /* Jul */, 2), {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert.deepEqual(result, new Date(1901, 11 /* Dec */, 29))
       })
     })
 
-    it('three-digit zero-padding', function() {
+    it('three-digit zero-padding', function () {
       var result = parse('123', 'YYY', referenceDate)
       assert.deepEqual(result, new Date(122, 11 /* Dec */, 27))
     })
 
-    it('four-digit zero-padding', function() {
+    it('four-digit zero-padding', function () {
       var result = parse('2018', 'YYYY', referenceDate, {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, new Date(2017, 11 /* Dec */, 31))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse('000001', 'YYYYYY', referenceDate)
       var expectedResult = new Date(0)
       expectedResult.setFullYear(0, 11 /* Dec */, 31)
@@ -213,10 +217,10 @@ describe('parse', function() {
       assert.deepEqual(result, expectedResult)
     })
 
-    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
       var result = parse('2018', 'Y', referenceDate, {
         weekStartsOn: 1 /* Mon */,
-        firstWeekContainsDate: 4
+        firstWeekContainsDate: 4,
       })
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
@@ -236,7 +240,7 @@ describe('parse', function() {
         ['D', '1', { useAdditionalDayOfYearTokens: true }],
         ['i', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when Y is used after ${token}`, () => {
           const block = parse.bind(
@@ -258,31 +262,32 @@ describe('parse', function() {
     })
   })
 
-  describe('ISO week-numbering year', function() {
-    it('numeric', function() {
+  describe('ISO week-numbering year', function () {
+    it('numeric', function () {
       var result = parse('-1234', 'R', referenceDate)
       assert.deepEqual(result, new Date(-1234, 0 /* Jan */, 3))
     })
 
-    it('two-digit zero-padding', function() {
+    it('two-digit zero-padding', function () {
       var result = parse('-02', 'RR', referenceDate)
       assert.deepEqual(result, new Date(-3, 11 /* Dec */, 29))
     })
 
-    it('three-digit zero-padding', function() {
+    it('three-digit zero-padding', function () {
       var result = parse('123', 'RRR', referenceDate)
       assert.deepEqual(result, new Date(123, 0 /* Jan */, 4))
     })
 
-    it('four-digit zero-padding', function() {
+    it('four-digit zero-padding', function () {
       var result = parse('2018', 'RRRR', referenceDate)
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse('000001', 'RRRRRR', referenceDate)
-      var expectedResult = new Date(1, 0 /* Jan */, 1)
-      expectedResult.setFullYear(1)
+      var expectedResult = new Date(0)
+      expectedResult.setFullYear(1, 0 /* Jan */, 1)
+      expectedResult.setHours(0, 0, 0, 0)
       assert.deepEqual(result, expectedResult)
     })
 
@@ -303,7 +308,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when R is used after ${token}`, () => {
           const block = parse.bind(
@@ -325,31 +330,32 @@ describe('parse', function() {
     })
   })
 
-  describe('extended year', function() {
-    it('numeric', function() {
+  describe('extended year', function () {
+    it('numeric', function () {
       var result = parse('-1234', 'u', referenceDate)
       assert.deepEqual(result, new Date(-1234, 0 /* Jan */, 1))
     })
 
-    it('two-digit zero-padding', function() {
+    it('two-digit zero-padding', function () {
       var result = parse('-02', 'uu', referenceDate)
       assert.deepEqual(result, new Date(-2, 0 /* Jan */, 1))
     })
 
-    it('three-digit zero-padding', function() {
+    it('three-digit zero-padding', function () {
       var result = parse('123', 'uuu', referenceDate)
       assert.deepEqual(result, new Date(123, 0 /* Jan */, 1))
     })
 
-    it('four-digit zero-padding', function() {
+    it('four-digit zero-padding', function () {
       var result = parse('2018', 'uuuu', referenceDate)
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse('000001', 'uuuuuu', referenceDate)
-      var expectedResult = new Date(1, 0 /* Jan */, 1)
-      expectedResult.setFullYear(1)
+      var expectedResult = new Date(0)
+      expectedResult.setFullYear(1, 0 /* Jan */, 1)
+      expectedResult.setHours(0, 0, 0, 0)
       assert.deepEqual(result, expectedResult)
     })
 
@@ -366,7 +372,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when u is used after ${token}`, () => {
           const block = parse.bind(
@@ -387,55 +393,55 @@ describe('parse', function() {
     })
   })
 
-  describe('quarter with following year', function() {
-    it('first quarter', function() {
+  describe('quarter with following year', function () {
+    it('first quarter', function () {
       var result = parse('Q1/2020', 'QQQ/yyyy', referenceDate)
       assert.deepEqual(result, new Date(2020, 0 /* Jan */, 1))
     })
 
-    it('second quarter', function() {
+    it('second quarter', function () {
       var result = parse('Q2/2020', 'QQQ/yyyy', referenceDate)
       assert.deepEqual(result, new Date(2020, 3 /* Apr */, 1))
     })
 
-    it('third quarter', function() {
+    it('third quarter', function () {
       var result = parse('Q3/2020', 'QQQ/yyyy', referenceDate)
       assert.deepEqual(result, new Date(2020, 6 /* Jul */, 1))
     })
 
-    it('fourth quarter', function() {
+    it('fourth quarter', function () {
       var result = parse('Q4/2020', 'QQQ/yyyy', referenceDate)
       assert.deepEqual(result, new Date(2020, 9 /* Oct */, 1))
     })
   })
 
-  describe('quarter (formatting)', function() {
-    it('numeric', function() {
+  describe('quarter (formatting)', function () {
+    it('numeric', function () {
       var result = parse('1', 'Q', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('1st', 'Qo', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('02', 'QQ', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Q3', 'QQQ', referenceDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 1))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('4st quarter', 'QQQQ', referenceDate)
       assert.deepEqual(result, new Date(1986, 9 /* Oct */, 1))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('1', 'QQQQQ', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
@@ -456,7 +462,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when Q is used after ${token}`, () => {
           const block = parse.bind(
@@ -478,33 +484,33 @@ describe('parse', function() {
     })
   })
 
-  describe('quarter (stand-alone)', function() {
-    it('numeric', function() {
+  describe('quarter (stand-alone)', function () {
+    it('numeric', function () {
       var result = parse('1', 'q', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('1th', 'qo', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('02', 'qq', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Q3', 'qqq', referenceDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 1))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('4th quarter', 'qqqq', referenceDate)
       assert.deepEqual(result, new Date(1986, 9 /* Oct */, 1))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('1', 'qqqqq', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
@@ -525,7 +531,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when q is used after ${token}`, () => {
           const block = parse.bind(
@@ -547,33 +553,33 @@ describe('parse', function() {
     })
   })
 
-  describe('month (formatting)', function() {
-    it('numeric', function() {
+  describe('month (formatting)', function () {
+    it('numeric', function () {
       var result = parse('6', 'M', referenceDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('6th', 'Mo', referenceDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('01', 'MM', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Nov', 'MMM', referenceDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 1))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('February', 'MMMM', referenceDate)
       assert.deepEqual(result, new Date(1986, 1 /* Feb */, 1))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('J', 'MMMMM', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
@@ -593,7 +599,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when M is used after ${token}`, () => {
           const block = parse.bind(
@@ -615,33 +621,33 @@ describe('parse', function() {
     })
   })
 
-  describe('month (stand-alone)', function() {
-    it('numeric', function() {
+  describe('month (stand-alone)', function () {
+    it('numeric', function () {
       var result = parse('6', 'L', referenceDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('6th', 'Lo', referenceDate)
       assert.deepEqual(result, new Date(1986, 5 /* Jun */, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('01', 'LL', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Nov', 'LLL', referenceDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 1))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('February', 'LLLL', referenceDate)
       assert.deepEqual(result, new Date(1986, 1 /* Feb */, 1))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('J', 'LLLLL', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
@@ -661,7 +667,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when L is used after ${token}`, () => {
           const block = parse.bind(
@@ -683,26 +689,26 @@ describe('parse', function() {
     })
   })
 
-  describe('local week of year', function() {
-    it('numeric', function() {
+  describe('local week of year', function () {
+    it('numeric', function () {
       var result = parse('49', 'w', referenceDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 30))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('49th', 'wo', referenceDate)
       assert.deepEqual(result, new Date(1986, 10 /* Nov */, 30))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('01', 'ww', referenceDate)
       assert.deepEqual(result, new Date(1985, 11 /* Dec */, 29))
     })
 
-    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+    it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
       var result = parse('49', 'w', referenceDate, {
         weekStartsOn: 1 /* Mon */,
-        firstWeekContainsDate: 4
+        firstWeekContainsDate: 4,
       })
       assert.deepEqual(result, new Date(1986, 11 /* Dec */, 1))
     })
@@ -722,7 +728,7 @@ describe('parse', function() {
         ['D', '1', { useAdditionalDayOfYearTokens: true }],
         ['i', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when w is used after ${token}`, () => {
           const block = parse.bind(
@@ -744,18 +750,18 @@ describe('parse', function() {
     })
   })
 
-  describe('ISO week of year', function() {
-    it('numeric', function() {
+  describe('ISO week of year', function () {
+    it('numeric', function () {
       var result = parse('49', 'I', referenceDate)
       assert.deepEqual(result, new Date(1986, 11 /* Dec */, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('49th', 'Io', referenceDate)
       assert.deepEqual(result, new Date(1986, 11 /* Dec */, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('01', 'II', referenceDate)
       assert.deepEqual(result, new Date(1985, 11 /* Dec */, 30))
     })
@@ -776,7 +782,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when I is used after ${token}`, () => {
           const block = parse.bind(
@@ -798,18 +804,18 @@ describe('parse', function() {
     })
   })
 
-  describe('day of month', function() {
-    it('numeric', function() {
+  describe('day of month', function () {
+    it('numeric', function () {
       var result = parse('28', 'd', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 28))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('28th', 'do', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 28))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('01', 'dd', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
@@ -828,7 +834,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when d is used after ${token}`, () => {
           const block = parse.bind(
@@ -850,32 +856,32 @@ describe('parse', function() {
     })
   })
 
-  describe('day of year', function() {
-    it('numeric', function() {
+  describe('day of year', function () {
+    it('numeric', function () {
       var result = parse('200', 'D', referenceDate, {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('200th', 'Do', referenceDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
 
-    it('two-digit zero-padding', function() {
+    it('two-digit zero-padding', function () {
       var result = parse('01', 'DD', referenceDate, {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('three-digit zero-padding', function() {
+    it('three-digit zero-padding', function () {
       var result = parse('001', 'DDD', referenceDate)
       assert.deepEqual(result, new Date(1986, 0 /* Jan */, 1))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse('000200', 'DDDDDD', referenceDate)
       assert.deepEqual(result, new Date(1986, 6 /* Jul */, 19))
     })
@@ -897,7 +903,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, _options]) => {
         it(`throws an error when D is used after ${token}`, () => {
           const block = parse.bind(
@@ -919,30 +925,30 @@ describe('parse', function() {
     })
   })
 
-  describe('day of week (formatting)', function() {
-    it('abbreviated', function() {
+  describe('day of week (formatting)', function () {
+    it('abbreviated', function () {
       var result = parse('Mon', 'E', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('Tuesday', 'EEEE', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('W', 'EEEEE', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('short', function() {
+    it('short', function () {
       var result = parse('Th', 'EEEEEE', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('allows to specify which day is the first day of the week', function() {
+    it('allows to specify which day is the first day of the week', function () {
       var result = parse('Thursday', 'EEEE', referenceDate, {
-        weekStartsOn: /* Fri */ 5
+        weekStartsOn: /* Fri */ 5,
       })
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 10))
     })
@@ -955,7 +961,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when E is used after ${token}`, () => {
           const block = parse.bind(
@@ -977,38 +983,38 @@ describe('parse', function() {
     })
   })
 
-  describe('ISO day of week (formatting)', function() {
-    it('numeric', function() {
+  describe('ISO day of week (formatting)', function () {
+    it('numeric', function () {
       var result = parse('1', 'i', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('1st', 'io', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('02', 'ii', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Wed', 'iii', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('Thursday', 'iiii', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('S', 'iiiii', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 6))
     })
 
-    it('short', function() {
+    it('short', function () {
       var result = parse('Fr', 'iiiiii', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4))
     })
@@ -1030,7 +1036,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when i is used after ${token}`, () => {
           const block = parse.bind(
@@ -1052,45 +1058,45 @@ describe('parse', function() {
     })
   })
 
-  describe('local day of week (formatting)', function() {
-    it('numeric', function() {
+  describe('local day of week (formatting)', function () {
+    it('numeric', function () {
       var result = parse('2', 'e', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('2nd', 'eo', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('03', 'ee', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Wed', 'eee', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('Thursday', 'eeee', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('S', 'eeeee', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 30))
     })
 
-    it('short', function() {
+    it('short', function () {
       var result = parse('Fr', 'eeeeee', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4))
     })
 
-    it('allows to specify which day is the first day of the week', function() {
+    it('allows to specify which day is the first day of the week', function () {
       var result = parse('7th', 'eo', referenceDate, {
-        weekStartsOn: /* Fri */ 5
+        weekStartsOn: /* Fri */ 5,
       })
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 10))
     })
@@ -1112,7 +1118,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when e is used after ${token}`, () => {
           const block = parse.bind(
@@ -1134,45 +1140,45 @@ describe('parse', function() {
     })
   })
 
-  describe('local day of week (stand-alone)', function() {
-    it('numeric', function() {
+  describe('local day of week (stand-alone)', function () {
+    it('numeric', function () {
       var result = parse('2', 'c', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('2nd', 'co', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 31))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('03', 'cc', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 1))
     })
 
-    it('abbreviated', function() {
+    it('abbreviated', function () {
       var result = parse('Wed', 'ccc', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 2))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('Thursday', 'cccc', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 3))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('S', 'ccccc', referenceDate)
       assert.deepEqual(result, new Date(1986, 2 /* Mar */, 30))
     })
 
-    it('short', function() {
+    it('short', function () {
       var result = parse('Fr', 'cccccc', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4))
     })
 
-    it('allows to specify which day is the first day of the week', function() {
+    it('allows to specify which day is the first day of the week', function () {
       var result = parse('7th', 'co', referenceDate, {
-        weekStartsOn: /* Fri */ 5
+        weekStartsOn: /* Fri */ 5,
       })
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 10))
     })
@@ -1194,7 +1200,7 @@ describe('parse', function() {
         ['e', '1'],
         ['c', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example, options]) => {
         it(`throws an error when c is used after ${token}`, () => {
           const block = parse.bind(
@@ -1216,28 +1222,28 @@ describe('parse', function() {
     })
   })
 
-  describe('AM, PM', function() {
-    it('abbreviated', function() {
+  describe('AM, PM', function () {
+    it('abbreviated', function () {
       var result = parse('5 AM', 'h a', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 5))
     })
 
-    it('12 AM', function() {
+    it('12 AM', function () {
       var result = parse('12 AM', 'h aa', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
 
-    it('12 PM', function() {
+    it('12 PM', function () {
       var result = parse('12 PM', 'h aaa', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('5 p.m.', 'h aaaa', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 17))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('11 a', 'h aaaaa', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 11))
     })
@@ -1251,7 +1257,7 @@ describe('parse', function() {
         ['K', '1'],
         ['k', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when a is used after ${token}`, () => {
           const block = parse.bind(
@@ -1272,18 +1278,18 @@ describe('parse', function() {
     })
   })
 
-  describe('AM, PM, noon, midnight', function() {
-    it('abbreviated', function() {
+  describe('AM, PM, noon, midnight', function () {
+    it('abbreviated', function () {
       var result = parse('noon', 'b', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('midnight', 'bbbb', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('mi', 'bbbbb', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
@@ -1297,7 +1303,7 @@ describe('parse', function() {
         ['K', '1'],
         ['k', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when b is used after ${token}`, () => {
           const block = parse.bind(
@@ -1318,18 +1324,18 @@ describe('parse', function() {
     })
   })
 
-  describe('flexible day period', function() {
-    it('abbreviated', function() {
+  describe('flexible day period', function () {
+    it('abbreviated', function () {
       var result = parse('2 at night', 'h B', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 2))
     })
 
-    it('wide', function() {
+    it('wide', function () {
       var result = parse('12 in the afternoon', 'h BBBB', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('narrow', function() {
+    it('narrow', function () {
       var result = parse('5 in the evening', 'h BBBBB', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 17))
     })
@@ -1340,7 +1346,7 @@ describe('parse', function() {
         ['b', 'AM'],
         ['B', 'in the morning'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when B is used after ${token}`, () => {
           const block = parse.bind(
@@ -1361,18 +1367,18 @@ describe('parse', function() {
     })
   })
 
-  describe('hour [1-12]', function() {
-    it('numeric', function() {
+  describe('hour [1-12]', function () {
+    it('numeric', function () {
       var result = parse('1', 'h', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('1st', 'ho', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('01', 'hh', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
@@ -1384,7 +1390,7 @@ describe('parse', function() {
         ['K', '1'],
         ['k', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when h is used after ${token}`, () => {
           const block = parse.bind(
@@ -1405,18 +1411,18 @@ describe('parse', function() {
     })
   })
 
-  describe('hour [0-23]', function() {
-    it('numeric', function() {
+  describe('hour [0-23]', function () {
+    it('numeric', function () {
       var result = parse('12', 'H', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('12th', 'Ho', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('00', 'HH', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
@@ -1430,7 +1436,7 @@ describe('parse', function() {
         ['K', '1'],
         ['k', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when H is used after ${token}`, () => {
           const block = parse.bind(
@@ -1451,18 +1457,18 @@ describe('parse', function() {
     })
   })
 
-  describe('hour [0-11]', function() {
-    it('numeric', function() {
+  describe('hour [0-11]', function () {
+    it('numeric', function () {
       var result = parse('1', 'K', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('1st', 'Ko', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('1', 'KK', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 1))
     })
@@ -1476,7 +1482,7 @@ describe('parse', function() {
         ['K', '1'],
         ['k', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when K is used after ${token}`, () => {
           const block = parse.bind(
@@ -1497,18 +1503,18 @@ describe('parse', function() {
     })
   })
 
-  describe('hour [1-24]', function() {
-    it('numeric', function() {
+  describe('hour [1-24]', function () {
+    it('numeric', function () {
       var result = parse('12', 'k', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('12th', 'ko', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 12))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('24', 'kk', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 0))
     })
@@ -1522,7 +1528,7 @@ describe('parse', function() {
         ['K', '1'],
         ['k', '1'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when k is used after ${token}`, () => {
           const block = parse.bind(
@@ -1543,131 +1549,137 @@ describe('parse', function() {
     })
   })
 
-  describe('minute', function() {
-    it('numeric', function() {
+  describe('minute', function () {
+    it('numeric', function () {
       var result = parse('25', 'm', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 25))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('25th', 'mo', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 25))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('05', 'mm', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 5))
     })
 
     describe('validation', () => {
-      ;[['m', '1'], ['t', '512969520'], ['T', '512969520900']].forEach(
-        ([token, example]) => {
-          it(`throws an error when m is used after ${token}`, () => {
-            const block = parse.bind(
-              null,
-              `${example} 1`,
-              `${token} m`,
-              referenceDate
+      ;[
+        ['m', '1'],
+        ['t', '512969520'],
+        ['T', '512969520900'],
+      ].forEach(([token, example]) => {
+        it(`throws an error when m is used after ${token}`, () => {
+          const block = parse.bind(
+            null,
+            `${example} 1`,
+            `${token} m`,
+            referenceDate
+          )
+          assert.throws(block, RangeError)
+          assert.throws(
+            block,
+            new RegExp(
+              `The format string mustn't contain \`${token}\` and \`m\` at the same time`
             )
-            assert.throws(block, RangeError)
-            assert.throws(
-              block,
-              new RegExp(
-                `The format string mustn't contain \`${token}\` and \`m\` at the same time`
-              )
-            )
-          })
-        }
-      )
+          )
+        })
+      })
     })
   })
 
-  describe('second', function() {
-    it('numeric', function() {
+  describe('second', function () {
+    it('numeric', function () {
       var result = parse('25', 's', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 25))
     })
 
-    it('ordinal', function() {
+    it('ordinal', function () {
       var result = parse('25th', 'so', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 25))
     })
 
-    it('zero-padding', function() {
+    it('zero-padding', function () {
       var result = parse('05', 'ss', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 5))
     })
 
     describe('validation', () => {
-      ;[['s', '1'], ['t', '512969520'], ['T', '512969520900']].forEach(
-        ([token, example]) => {
-          it(`throws an error when s is used after ${token}`, () => {
-            const block = parse.bind(
-              null,
-              `${example} 1`,
-              `${token} s`,
-              referenceDate
+      ;[
+        ['s', '1'],
+        ['t', '512969520'],
+        ['T', '512969520900'],
+      ].forEach(([token, example]) => {
+        it(`throws an error when s is used after ${token}`, () => {
+          const block = parse.bind(
+            null,
+            `${example} 1`,
+            `${token} s`,
+            referenceDate
+          )
+          assert.throws(block, RangeError)
+          assert.throws(
+            block,
+            new RegExp(
+              `The format string mustn't contain \`${token}\` and \`s\` at the same time`
             )
-            assert.throws(block, RangeError)
-            assert.throws(
-              block,
-              new RegExp(
-                `The format string mustn't contain \`${token}\` and \`s\` at the same time`
-              )
-            )
-          })
-        }
-      )
+          )
+        })
+      })
     })
   })
 
-  describe('fraction of second', function() {
-    it('1/10 of second', function() {
+  describe('fraction of second', function () {
+    it('1/10 of second', function () {
       var result = parse('1', 'S', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 100))
     })
 
-    it('1/100 of second', function() {
+    it('1/100 of second', function () {
       var result = parse('12', 'SS', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 120))
     })
 
-    it('millisecond', function() {
+    it('millisecond', function () {
       var result = parse('123', 'SSS', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 123))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse('567890', 'SSSSSS', referenceDate)
       assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 567))
     })
 
     describe('validation', () => {
-      ;[['S', '1'], ['t', '512969520'], ['T', '512969520900']].forEach(
-        ([token, example]) => {
-          it(`throws an error when S is used after ${token}`, () => {
-            const block = parse.bind(
-              null,
-              `${example} 1`,
-              `${token} S`,
-              referenceDate
+      ;[
+        ['S', '1'],
+        ['t', '512969520'],
+        ['T', '512969520900'],
+      ].forEach(([token, example]) => {
+        it(`throws an error when S is used after ${token}`, () => {
+          const block = parse.bind(
+            null,
+            `${example} 1`,
+            `${token} S`,
+            referenceDate
+          )
+          assert.throws(block, RangeError)
+          assert.throws(
+            block,
+            new RegExp(
+              `The format string mustn't contain \`${token}\` and \`S\` at the same time`
             )
-            assert.throws(block, RangeError)
-            assert.throws(
-              block,
-              new RegExp(
-                `The format string mustn't contain \`${token}\` and \`S\` at the same time`
-              )
-            )
-          })
-        }
-      )
+          )
+        })
+      })
     })
   })
 
-  describe('timezone (ISO-8601 w/ Z)', function() {
-    describe('X', function() {
-      it('hours and minutes', function() {
+  describe('timezone (ISO-8601 w/ Z)', function () {
+    describe('X', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-0530',
           "yyyy-MM-dd'T'HH:mm:ss.SSSX",
@@ -1676,7 +1688,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123Z',
           "yyyy-MM-dd'T'HH:mm:ss.SSSX",
@@ -1685,7 +1697,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours', function() {
+      it('hours', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+05',
           "yyyy-MM-dd'T'HH:mm:ss.SSSX",
@@ -1695,8 +1707,8 @@ describe('parse', function() {
       })
     })
 
-    describe('XX', function() {
-      it('hours and minutes', function() {
+    describe('XX', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-0530',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXX",
@@ -1705,7 +1717,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123Z',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXX",
@@ -1715,8 +1727,8 @@ describe('parse', function() {
       })
     })
 
-    describe('XXX', function() {
-      it('hours and minutes', function() {
+    describe('XXX', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-05:30',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
@@ -1725,7 +1737,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123Z',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
@@ -1735,8 +1747,8 @@ describe('parse', function() {
       })
     })
 
-    describe('XXXX', function() {
-      it('hours and minutes', function() {
+    describe('XXXX', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-0530',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
@@ -1745,7 +1757,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123Z',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
@@ -1754,7 +1766,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function() {
+      it('hours, minutes and seconds', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+053045',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX",
@@ -1764,8 +1776,8 @@ describe('parse', function() {
       })
     })
 
-    describe('XXXXX', function() {
-      it('hours and minutes', function() {
+    describe('XXXXX', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-05:30',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
@@ -1774,7 +1786,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123Z',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
@@ -1783,7 +1795,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function() {
+      it('hours, minutes and seconds', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+05:30:45',
           "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
@@ -1798,7 +1810,7 @@ describe('parse', function() {
         ['X', '-0530'],
         ['x', '-0530'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when X is used after ${token}`, () => {
           const block = parse.bind(
@@ -1819,9 +1831,9 @@ describe('parse', function() {
     })
   })
 
-  describe('timezone (ISO-8601 w/o Z)', function() {
-    describe('x', function() {
-      it('hours and minutes', function() {
+  describe('timezone (ISO-8601 w/o Z)', function () {
+    describe('x', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-0530',
           "yyyy-MM-dd'T'HH:mm:ss.SSSx",
@@ -1830,7 +1842,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+0000',
           "yyyy-MM-dd'T'HH:mm:ss.SSSx",
@@ -1839,7 +1851,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours', function() {
+      it('hours', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+05',
           "yyyy-MM-dd'T'HH:mm:ss.SSSx",
@@ -1849,8 +1861,8 @@ describe('parse', function() {
       })
     })
 
-    describe('xx', function() {
-      it('hours and minutes', function() {
+    describe('xx', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-0530',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxx",
@@ -1859,7 +1871,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+0000',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxx",
@@ -1869,8 +1881,8 @@ describe('parse', function() {
       })
     })
 
-    describe('xxx', function() {
-      it('hours and minutes', function() {
+    describe('xxx', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-05:30',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
@@ -1879,7 +1891,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+00:00',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
@@ -1889,8 +1901,8 @@ describe('parse', function() {
       })
     })
 
-    describe('xxxx', function() {
-      it('hours and minutes', function() {
+    describe('xxxx', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-0530',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx",
@@ -1899,7 +1911,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+0000',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx",
@@ -1908,7 +1920,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function() {
+      it('hours, minutes and seconds', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+053045',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxxx",
@@ -1918,8 +1930,8 @@ describe('parse', function() {
       })
     })
 
-    describe('xxxxx', function() {
-      it('hours and minutes', function() {
+    describe('xxxxx', function () {
+      it('hours and minutes', function () {
         var result = parse(
           '2016-11-25T16:38:38.123-05:30',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx",
@@ -1928,7 +1940,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123-05:30'))
       })
 
-      it('GMT', function() {
+      it('GMT', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+00:00',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx",
@@ -1937,7 +1949,7 @@ describe('parse', function() {
         assert.deepEqual(result, new Date('2016-11-25T16:38:38.123Z'))
       })
 
-      it('hours, minutes and seconds', function() {
+      it('hours, minutes and seconds', function () {
         var result = parse(
           '2016-11-25T16:38:38.123+05:30:45',
           "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx",
@@ -1952,7 +1964,7 @@ describe('parse', function() {
         ['X', '-0530'],
         ['x', '-0530'],
         ['t', '512969520'],
-        ['T', '512969520900']
+        ['T', '512969520900'],
       ].forEach(([token, example]) => {
         it(`throws an error when x is used after ${token}`, () => {
           const block = parse.bind(
@@ -1973,13 +1985,13 @@ describe('parse', function() {
     })
   })
 
-  describe('seconds timestamp', function() {
-    it('numeric', function() {
+  describe('seconds timestamp', function () {
+    it('numeric', function () {
       var result = parse('512969520', 't', referenceDate)
       assert.deepEqual(result, new Date(512969520000))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse(
         '00000000000512969520',
         'tttttttttttttttttttt',
@@ -2000,13 +2012,13 @@ describe('parse', function() {
     })
   })
 
-  describe('milliseconds timestamp', function() {
-    it('numeric', function() {
+  describe('milliseconds timestamp', function () {
+    it('numeric', function () {
       var result = parse('512969520900', 'T', referenceDate)
       assert.deepEqual(result, new Date(512969520900))
     })
 
-    it('specified amount of digits', function() {
+    it('specified amount of digits', function () {
       var result = parse(
         '00000000512969520900',
         'TTTTTTTTTTTTTTTTTTTT',
@@ -2027,13 +2039,13 @@ describe('parse', function() {
     })
   })
 
-  describe('common formats', function() {
-    it('ISO-8601', function() {
+  describe('common formats', function () {
+    it('ISO-8601', function () {
       var result = parse('20161105T040404', "yyyyMMdd'T'HHmmss", referenceDate)
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5, 4, 4, 4, 0))
     })
 
-    it('ISO week-numbering date', function() {
+    it('ISO week-numbering date', function () {
       var result = parse(
         '2016W474T153005',
         "RRRR'W'IIi'T'HHmmss",
@@ -2042,26 +2054,26 @@ describe('parse', function() {
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 24, 15, 30, 5, 0))
     })
 
-    it('ISO day of year date', function() {
+    it('ISO day of year date', function () {
       var result = parse('2010123T235959', "yyyyDDD'T'HHmmss", referenceDate)
       assert.deepEqual(result, new Date(2010, 4 /* May */, 3, 23, 59, 59, 0))
     })
 
-    it('Date.prototype.toString()', function() {
+    it('Date.prototype.toString()', function () {
       var dateString = 'Wed Jul 02 2014 05:30:15 GMT+0600'
       var formatString = "EEE MMM dd yyyy HH:mm:ss 'GMT'xx"
       var result = parse(dateString, formatString, referenceDate)
       assert.deepEqual(result, new Date(dateString))
     })
 
-    it('Date.prototype.toISOString()', function() {
+    it('Date.prototype.toISOString()', function () {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       var result = parse(dateString, formatString, referenceDate)
       assert.deepEqual(result, new Date(dateString))
     })
 
-    it('middle-endian', function() {
+    it('middle-endian', function () {
       var result = parse(
         '5 a.m. 07/02/2016',
         'h aaaa MM/dd/yyyy',
@@ -2070,14 +2082,14 @@ describe('parse', function() {
       assert.deepEqual(result, new Date(2016, 6 /* Jul */, 2, 5, 0, 0, 0))
     })
 
-    it('little-endian', function() {
+    it('little-endian', function () {
       var result = parse('02.07.1995', 'dd.MM.yyyy', referenceDate)
       assert.deepEqual(result, new Date(1995, 6 /* Jul */, 2, 0, 0, 0, 0))
     })
   })
 
-  describe('priority', function() {
-    it("units of lower priority don't overwrite values of higher priority", function() {
+  describe('priority', function () {
+    it("units of lower priority don't overwrite values of higher priority", function () {
       var dateString = '+06:00 123 15 30 05 02 07 2014'
       var formatString = 'xxx SSS ss mm HH dd MM yyyy'
       var result = parse(dateString, formatString, referenceDate)
@@ -2085,8 +2097,8 @@ describe('parse', function() {
     })
   })
 
-  describe('implicit conversion of arguments', function() {
-    it('`dateString`', function() {
+  describe('implicit conversion of arguments', function () {
+    it('`dateString`', function () {
       // eslint-disable-next-line no-new-wrappers
       var dateString = new String('20161105T040404')
       // $ExpectedMistake
@@ -2094,7 +2106,7 @@ describe('parse', function() {
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5, 4, 4, 4, 0))
     })
 
-    it('`formatString`', function() {
+    it('`formatString`', function () {
       // eslint-disable-next-line no-new-wrappers
       var formatString = new String("yyyyMMdd'T'HHmmss")
       // $ExpectedMistake
@@ -2102,243 +2114,243 @@ describe('parse', function() {
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5, 4, 4, 4, 0))
     })
 
-    it('`options.weekStartsOn`', function() {
+    it('`options.weekStartsOn`', function () {
       // $ExpectedMistake
       var result = parse('2018', 'Y', referenceDate, {
         weekStartsOn: '1' /* Mon */,
-        firstWeekContainsDate: 4
+        firstWeekContainsDate: 4,
       })
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
 
-    it('`options.firstWeekContainsDate`', function() {
+    it('`options.firstWeekContainsDate`', function () {
       // $ExpectedMistake
       var result = parse('2018', 'Y', referenceDate, {
         weekStartsOn: 1 /* Mon */,
-        firstWeekContainsDate: '4'
+        firstWeekContainsDate: '4',
       })
       assert.deepEqual(result, new Date(2018, 0 /* Jan */, 1))
     })
   })
 
-  describe('with `options.strictValidation` = true', function() {
-    describe('calendar year', function() {
-      it('returns `Invalid Date` for year zero', function() {
+  describe('with `options.strictValidation` = true', function () {
+    describe('calendar year', function () {
+      it('returns `Invalid Date` for year zero', function () {
         var result = parse('0', 'y', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('works correctly for two-digit year zero', function() {
+      it('works correctly for two-digit year zero', function () {
         var result = parse('00', 'yy', referenceDate)
         assert.deepEqual(result, new Date(2000, 0 /* Jan */, 1))
       })
     })
 
-    describe('local week-numbering year', function() {
-      it('returns `Invalid Date` for year zero', function() {
+    describe('local week-numbering year', function () {
+      it('returns `Invalid Date` for year zero', function () {
         var result = parse('0', 'Y', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('works correctly for two-digit year zero', function() {
+      it('works correctly for two-digit year zero', function () {
         var result = parse('00', 'YY', referenceDate, {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert.deepEqual(result, new Date(1999, 11 /* Dec */, 26))
       })
     })
 
-    describe('quarter (formatting)', function() {
-      it('returns `Invalid Date` for invalid quarter', function() {
+    describe('quarter (formatting)', function () {
+      it('returns `Invalid Date` for invalid quarter', function () {
         var result = parse('0', 'Q', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('quarter (stand-alone)', function() {
-      it('returns `Invalid Date` for invalid quarter', function() {
+    describe('quarter (stand-alone)', function () {
+      it('returns `Invalid Date` for invalid quarter', function () {
         var result = parse('5', 'q', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('month (formatting)', function() {
-      it('returns `Invalid Date` for invalid month', function() {
+    describe('month (formatting)', function () {
+      it('returns `Invalid Date` for invalid month', function () {
         var result = parse('00', 'MM', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('month (stand-alone)', function() {
-      it('returns `Invalid Date` for invalid month', function() {
+    describe('month (stand-alone)', function () {
+      it('returns `Invalid Date` for invalid month', function () {
         var result = parse('13', 'LL', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('local week of year', function() {
-      it('returns `Invalid Date` for invalid week', function() {
+    describe('local week of year', function () {
+      it('returns `Invalid Date` for invalid week', function () {
         var result = parse('0', 'w', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('ISO week of year', function() {
-      it('returns `Invalid Date` for invalid week', function() {
+    describe('ISO week of year', function () {
+      it('returns `Invalid Date` for invalid week', function () {
         var result = parse('54', 'II', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('day of month', function() {
-      it('returns `Invalid Date` for invalid day of the month', function() {
+    describe('day of month', function () {
+      it('returns `Invalid Date` for invalid day of the month', function () {
         var result = parse('30', 'd', new Date(2012, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for 29th of February of non-leap year', function() {
+      it('returns `Invalid Date` for 29th of February of non-leap year', function () {
         var result = parse('29', 'd', new Date(2014, 1 /* Feb */, 1))
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('parses 29th of February of leap year', function() {
+      it('parses 29th of February of leap year', function () {
         var result = parse('29', 'd', new Date(2012, 1 /* Feb */, 1))
         assert.deepEqual(result, new Date(2012, 1 /* Feb */, 29))
       })
     })
 
-    describe('day of year', function() {
-      it('returns `Invalid Date` for invalid day of the year', function() {
+    describe('day of year', function () {
+      it('returns `Invalid Date` for invalid day of the year', function () {
         var result = parse('0', 'D', referenceDate, {
-          useAdditionalDayOfYearTokens: true
+          useAdditionalDayOfYearTokens: true,
         })
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for 366th day of non-leap year', function() {
+      it('returns `Invalid Date` for 366th day of non-leap year', function () {
         var result = parse('366', 'D', new Date(2014, 1 /* Feb */, 1), {
-          useAdditionalDayOfYearTokens: true
+          useAdditionalDayOfYearTokens: true,
         })
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('parses 366th day of leap year', function() {
+      it('parses 366th day of leap year', function () {
         var result = parse('366', 'D', new Date(2012, 1 /* Feb */, 1), {
-          useAdditionalDayOfYearTokens: true
+          useAdditionalDayOfYearTokens: true,
         })
         assert.deepEqual(result, new Date(2012, 11 /* Dec */, 31))
       })
     })
 
-    describe('ISO day of week (formatting)', function() {
-      it('returns `Invalid Date` for day zero', function() {
+    describe('ISO day of week (formatting)', function () {
+      it('returns `Invalid Date` for day zero', function () {
         var result = parse('0', 'i', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for eight day of week', function() {
+      it('returns `Invalid Date` for eight day of week', function () {
         var result = parse('8', 'i', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('local day of week (formatting)', function() {
-      it('returns `Invalid Date` for day zero', function() {
+    describe('local day of week (formatting)', function () {
+      it('returns `Invalid Date` for day zero', function () {
         var result = parse('0', 'e', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for eight day of week', function() {
+      it('returns `Invalid Date` for eight day of week', function () {
         var result = parse('8', 'e', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('local day of week (stand-alone)', function() {
-      it('returns `Invalid Date` for day zero', function() {
+    describe('local day of week (stand-alone)', function () {
+      it('returns `Invalid Date` for day zero', function () {
         var result = parse('0', 'c', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for eight day of week', function() {
+      it('returns `Invalid Date` for eight day of week', function () {
         var result = parse('8', 'c', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [1-12]', function() {
-      it('returns `Invalid Date` for hour zero', function() {
+    describe('hour [1-12]', function () {
+      it('returns `Invalid Date` for hour zero', function () {
         var result = parse('00', 'hh', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for invalid hour', function() {
+      it('returns `Invalid Date` for invalid hour', function () {
         var result = parse('13', 'hh', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [0-23]', function() {
-      it('returns `Invalid Date` for invalid hour', function() {
+    describe('hour [0-23]', function () {
+      it('returns `Invalid Date` for invalid hour', function () {
         var result = parse('24', 'HH', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [0-11]', function() {
-      it('returns `Invalid Date` for invalid hour', function() {
+    describe('hour [0-11]', function () {
+      it('returns `Invalid Date` for invalid hour', function () {
         var result = parse('12', 'KK', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('hour [1-24]', function() {
-      it('returns `Invalid Date` for hour zero', function() {
+    describe('hour [1-24]', function () {
+      it('returns `Invalid Date` for hour zero', function () {
         var result = parse('00', 'kk', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
 
-      it('returns `Invalid Date` for invalid hour', function() {
+      it('returns `Invalid Date` for invalid hour', function () {
         var result = parse('25', 'kk', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('minute', function() {
-      it('returns `Invalid Date` for invalid minute', function() {
+    describe('minute', function () {
+      it('returns `Invalid Date` for invalid minute', function () {
         var result = parse('60', 'mm', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
 
-    describe('second', function() {
-      it('returns `Invalid Date` for invalid second', function() {
+    describe('second', function () {
+      it('returns `Invalid Date` for invalid second', function () {
         var result = parse('60', 'ss', referenceDate)
         assert(result instanceof Date && isNaN(result))
       })
     })
   })
 
-  describe('custom locale', function() {
-    it('allows to pass a custom locale', function() {
+  describe('custom locale', function () {
+    it('allows to pass a custom locale', function () {
       var customLocale = {
         match: {
-          era: function() {
+          era: function () {
             return {
               value: 0,
-              rest: ' it works!'
+              rest: ' it works!',
             }
-          }
-        }
+          },
+        },
       }
       // $ExpectedMistake
       var result = parse('2018 foobar', "y G 'it works!'", referenceDate, {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.deepEqual(result, new Date(-2017, 0 /* Jan */, 1))
     })
 
-    it('throws `RangeError` if `options.locale` does not contain `match` property', function() {
+    it('throws `RangeError` if `options.locale` does not contain `match` property', function () {
       var block = parse.bind(
         null,
         '2016-11-25 04 AM',
@@ -2351,14 +2363,14 @@ describe('parse', function() {
     })
   })
 
-  it('accepts a timestamp as `referenceDate`', function() {
+  it('accepts a timestamp as `referenceDate`', function () {
     var dateString = '6 p.m.'
     var formatString = 'h aaaa'
     var result = parse(dateString, formatString, referenceDate.getTime())
     assert.deepEqual(result, new Date(1986, 3 /* Apr */, 4, 18))
   })
 
-  it('does not mutate `referenceDate`', function() {
+  it('does not mutate `referenceDate`', function () {
     var referenceDateClone1 = new Date(referenceDate.getTime())
     var referenceDateClone2 = new Date(referenceDate.getTime())
     var dateString = '6 p.m.'
@@ -2367,71 +2379,71 @@ describe('parse', function() {
     assert.deepEqual(referenceDateClone1, referenceDateClone2)
   })
 
-  describe('failure', function() {
-    it('returns `referenceDate` if `dateString` and `formatString` are empty strings', function() {
+  describe('failure', function () {
+    it('returns `referenceDate` if `dateString` and `formatString` are empty strings', function () {
       var dateString = ''
       var formatString = ''
       var result = parse(dateString, formatString, referenceDate)
       assert.deepEqual(result, referenceDate)
     })
 
-    it('returns `referenceDate` if no tokens in `formatString` are provided', function() {
+    it('returns `referenceDate` if no tokens in `formatString` are provided', function () {
       var dateString = 'not a token'
       var formatString = "'not a token'"
       var result = parse(dateString, formatString, referenceDate)
       assert.deepEqual(result, referenceDate)
     })
 
-    it("returns `Invalid Date`  if `formatString` doesn't match `dateString`", function() {
+    it("returns `Invalid Date`  if `formatString` doesn't match `dateString`", function () {
       var dateString = '2017-01-01'
       var formatString = 'yyyy/MM/dd'
       var result = parse(dateString, formatString, referenceDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('returns `Invalid Date`  if `formatString` tokens failed to parse a value', function() {
+    it('returns `Invalid Date`  if `formatString` tokens failed to parse a value', function () {
       var dateString = '2017-01-01'
       var formatString = 'MMMM do yyyy'
       var result = parse(dateString, formatString, referenceDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('returns `Invalid Date` if `formatString` is empty string but `dateString` is not', function() {
+    it('returns `Invalid Date` if `formatString` is empty string but `dateString` is not', function () {
       var dateString = '2017-01-01'
       var formatString = ''
       var result = parse(dateString, formatString, referenceDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('returns `Invalid Date` if `referenceDate` is `Invalid Date`', function() {
+    it('returns `Invalid Date` if `referenceDate` is `Invalid Date`', function () {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       var result = parse(dateString, formatString, new Date(NaN))
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
+    it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       // $ExpectedMistake
       var block = parse.bind(null, dateString, formatString, referenceDate, {
-        weekStartsOn: NaN
+        weekStartsOn: NaN,
       })
       assert.throws(block, RangeError)
     })
 
-    it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function() {
+    it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function () {
       var dateString = '2014-07-02T05:30:15.123+06:00'
       var formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
       // $ExpectedMistake
       var block = parse.bind(null, dateString, formatString, referenceDate, {
-        firstWeekContainsDate: NaN
+        firstWeekContainsDate: NaN,
       })
       assert.throws(block, RangeError)
     })
   })
 
-  it('throws TypeError exception if passed less than 3 arguments', function() {
+  it('throws TypeError exception if passed less than 3 arguments', function () {
     assert.throws(parse.bind(null), TypeError)
     // $ExpectedMistake
     assert.throws(parse.bind(null, 1), TypeError)
@@ -2439,18 +2451,18 @@ describe('parse', function() {
     assert.throws(parse.bind(null, 1, 2), TypeError)
   })
 
-  describe('edge cases', function() {
-    it('returns Invalid Date if the string contains some remaining input after parsing', function() {
+  describe('edge cases', function () {
+    it('returns Invalid Date if the string contains some remaining input after parsing', function () {
       var result = parse('2016-11-05T040404', 'yyyy-MM-dd', referenceDate)
       assert(result instanceof Date && isNaN(result))
     })
 
-    it('parses normally if the remaining input is just whitespace', function() {
+    it('parses normally if the remaining input is just whitespace', function () {
       var result = parse('2016-11-05   \n', 'yyyy-MM-dd', referenceDate)
       assert.deepEqual(result, new Date(2016, 10 /* Nov */, 5))
     })
 
-    it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+    it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function () {
       assert.throws(
         parse.bind(null, '2016-11-05-nnnn', 'yyyy-MM-dd-nnnn', referenceDate),
         RangeError
@@ -2470,7 +2482,7 @@ describe('parse', function() {
 
     it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = parse('2016 5', 'yyyy D', referenceDate, {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, new Date(2016, 0, 5))
     })
@@ -2486,7 +2498,7 @@ describe('parse', function() {
 
     it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = parse('2016 05', 'yyyy DD', referenceDate, {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, new Date(2016, 0, 5))
     })
@@ -2502,7 +2514,7 @@ describe('parse', function() {
 
     it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = parse('16 1', 'YY w', referenceDate, {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, new Date(2015, 11, 27))
     })
@@ -2518,14 +2530,14 @@ describe('parse', function() {
 
     it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = parse('2016 1', 'YYYY w', referenceDate, {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, new Date(2015, 11, 27))
     })
   })
 
-  describe('long format', function() {
-    it('short date', function() {
+  describe('long format', function () {
+    it('short date', function () {
       var expected = new Date(1995, 4 /* May */, 26)
       var dateString = '05/26/1995'
       var formatString = 'P'
@@ -2533,7 +2545,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('medium date', function() {
+    it('medium date', function () {
       var expected = new Date(1995, 4 /* May */, 26)
       var dateString = 'May 26, 1995'
       var formatString = 'PP'
@@ -2541,7 +2553,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('long date', function() {
+    it('long date', function () {
       var expected = new Date(1995, 4 /* May */, 26)
       var dateString = 'May 26th, 1995'
       var formatString = 'PPP'
@@ -2549,7 +2561,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('full date', function() {
+    it('full date', function () {
       var expected = new Date(1995, 4 /* May */, 26)
       var dateString = 'Friday, May 26th, 1995'
       var formatString = 'PPPP'
@@ -2557,7 +2569,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('short time', function() {
+    it('short time', function () {
       var expected = new Date(
         referenceDate.getFullYear(),
         referenceDate.getMonth(),
@@ -2571,7 +2583,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('medium time', function() {
+    it('medium time', function () {
       var expected = new Date(
         referenceDate.getFullYear(),
         referenceDate.getMonth(),
@@ -2586,7 +2598,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('short date + short time', function() {
+    it('short date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32)
       var dateTimeString = '05/26/1995, 10:32 AM'
       var formatString = 'Pp'
@@ -2594,7 +2606,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('medium date + short time', function() {
+    it('medium date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32)
       var dateTimeString = 'May 26, 1995, 10:32 AM'
       var formatString = 'PPp'
@@ -2602,7 +2614,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('long date + short time', function() {
+    it('long date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32)
       var dateTimeString = 'May 26th, 1995 at 10:32 AM'
       var formatString = 'PPPp'
@@ -2610,7 +2622,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('full date + short time', function() {
+    it('full date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32)
       var dateTimeString = 'Friday, May 26th, 1995 at 10:32 AM'
       var formatString = 'PPPPp'
@@ -2618,7 +2630,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('short date + short time', function() {
+    it('short date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32, 55)
       var dateTimeString = '05/26/1995, 10:32:55 AM'
       var formatString = 'Ppp'
@@ -2626,7 +2638,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('medium date + short time', function() {
+    it('medium date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32, 55)
       var dateTimeString = 'May 26, 1995, 10:32:55 AM'
       var formatString = 'PPpp'
@@ -2634,7 +2646,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('long date + short time', function() {
+    it('long date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32, 55)
       var dateTimeString = 'May 26th, 1995 at 10:32:55 AM'
       var formatString = 'PPPpp'
@@ -2642,7 +2654,7 @@ describe('parse', function() {
       assert.deepEqual(result, expected)
     })
 
-    it('full date + short time', function() {
+    it('full date + short time', function () {
       var expected = new Date(1995, 4 /* May */, 26, 10, 32, 55)
       var dateTimeString = 'Friday, May 26th, 1995 at 10:32:55 AM'
       var formatString = 'PPPPpp'

--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -8,7 +8,7 @@ var DEFAULT_ADDITIONAL_DIGITS = 2
 var patterns = {
   dateTimeDelimiter: /[T ]/,
   timeZoneDelimiter: /[Z ]/i,
-  timezone: /([Z+-].*)$/
+  timezone: /([Z+-].*)$/,
 }
 
 var dateRegex = /^-?(?:(\d{3})|(\d{2})(?:-?(\d{2}))?|W(\d{2})(?:-?(\d{1}))?|)$/
@@ -133,16 +133,18 @@ export default function parseISO(argument, dirtyOptions) {
     // so we use utc values to build date in our timezone.
     // Year values from 0 to 99 map to the years 1900 to 1999
     // so set year explicitly with setFullYear.
-    var result = new Date(
+    var result = new Date(0)
+    result.setFullYear(
       dirtyDate.getUTCFullYear(),
       dirtyDate.getUTCMonth(),
-      dirtyDate.getUTCDate(),
+      dirtyDate.getUTCDate()
+    )
+    result.setHours(
       dirtyDate.getUTCHours(),
       dirtyDate.getUTCMinutes(),
       dirtyDate.getUTCSeconds(),
       dirtyDate.getUTCMilliseconds()
     )
-    result.setFullYear(dirtyDate.getUTCFullYear())
     return result
   }
 
@@ -203,7 +205,7 @@ function parseYear(dateString, additionalDigits) {
 
   return {
     year: century == null ? year : century * 100,
-    restDateString: dateString.slice((captures[1] || captures[2]).length)
+    restDateString: dateString.slice((captures[1] || captures[2]).length),
   }
 }
 

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -95,15 +95,17 @@ describe('parseISO', () => {
     describe('extended century representation', () => {
       it('parses century 101 BC - 2 BC', () => {
         const result = parseISO('-0001')
-        const date = new Date(-100, 0 /* Jan */, 1)
-        date.setFullYear(-100)
+        const date = new Date(0)
+        date.setFullYear(-100, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         assert.deepEqual(result, date)
       })
 
       it('parses century 1 BC - 99 AD', () => {
         const result = parseISO('00')
-        const date = new Date(0, 0 /* Jan */, 1)
-        date.setFullYear(0)
+        const date = new Date(0)
+        date.setFullYear(0, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         assert.deepEqual(result, date)
       })
 
@@ -114,8 +116,9 @@ describe('parseISO', () => {
 
       it('allows to specify the number of additional digits', () => {
         const result = parseISO('-20', { additionalDigits: 0 })
-        const date = new Date(-2000, 0 /* Jan */, 1)
-        date.setFullYear(-2000)
+        const date = new Date(0)
+        date.setFullYear(-2000, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
         assert.deepEqual(result, date)
       })
     })
@@ -123,8 +126,9 @@ describe('parseISO', () => {
     describe('extended year representation', () => {
       it('correctly parses years from 1 AD to 99 AD', () => {
         const result = parseISO('0095-07-02')
-        const date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(95)
+        const date = new Date(0)
+        date.setFullYear(95, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         assert.deepEqual(result, date)
       })
 
@@ -140,15 +144,17 @@ describe('parseISO', () => {
 
       it('parses year 1 BC', () => {
         const result = parseISO('0000-07-02')
-        const date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(0)
+        const date = new Date(0)
+        date.setFullYear(0, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         assert.deepEqual(result, date)
       })
 
       it('parses years less than 1 BC', () => {
         const result = parseISO('-000001-07-02')
-        const date = new Date(0, 6 /* Jul */, 2)
-        date.setFullYear(-1)
+        const date = new Date(0)
+        date.setFullYear(-1, 6 /* Jul */, 2)
+        date.setHours(0, 0, 0, 0)
         assert.deepEqual(result, date)
       })
     })


### PR DESCRIPTION
I've no idea how it works, but @leshakoss said that's the way