### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The library is available as an [npm package](https://www.npmjs.com/package/date-
 To install the package run:
 
 ```bash
-npm install date-fns --save
+npm i date-fns
 # or with yarn
 yarn add date-fns
 ```


### PR DESCRIPTION
minimal description correction: "npm install" saves the changes by default - doesn't need "--save" option. and nobody use npm with "install" instead of "i".