### PR TITLE
Switch dateLeft and dateRight in intervalToDuration

### DIFF
--- a/src/intervalToDuration/index.js
+++ b/src/intervalToDuration/index.js
@@ -37,14 +37,14 @@ import sub from '../sub/index'
 export default function intervalToDuration({ start, end }) {
   requiredArgs(1, arguments)
 
-  const dateLeft = toDate(start)
-  const dateRight = toDate(end)
+  const dateLeft = toDate(end)
+  const dateRight = toDate(start)
 
   if (!isValid(dateLeft)) {
-    throw new RangeError('Start Date is invalid')
+    throw new RangeError('End Date is invalid')
   }
   if (!isValid(dateRight)) {
-    throw new RangeError('End Date is invalid')
+    throw new RangeError('Start Date is invalid')
   }
 
   const duration = {
@@ -53,7 +53,7 @@ export default function intervalToDuration({ start, end }) {
     days: 0,
     hours: 0,
     minutes: 0,
-    seconds: 0
+    seconds: 0,
   }
 
   const sign = compareAsc(dateLeft, dateRight)
@@ -73,7 +73,7 @@ export default function intervalToDuration({ start, end }) {
   duration.minutes = Math.abs(differenceInMinutes(remainingMinutes, dateRight))
 
   const remainingSeconds = sub(remainingMinutes, {
-    minutes: sign * duration.minutes
+    minutes: sign * duration.minutes,
   })
   duration.seconds = Math.abs(differenceInSeconds(remainingSeconds, dateRight))
 


### PR DESCRIPTION
Functions like differenceInMonths, differenceInDays, ... , which are used in intervalToDuration, expect dateLeft to be the later date and dateRight the earlier date. Currently, intervalToDuration sets its dateLeft to its earlier date and dateRight to its later date. This has been fixed in this PR: by setting dateLeft to the end date and dateRight to the start date.

While the dateLeft and dateRight arguments can normally be switched in these functions, because they work in both cases as they use Math.abs, a sign variable, ..., meaning that it shouldn't matter in what order intervalToDuration passes dateLeft and dateRight to these functions, there are two reasons why I still think this change is useful:
- It's more logical that if the dateLeft is the later date in these 'difference' functions, this is also the case in the intervalToDuration function
- In my case, the intervalToDuration bug with Feb 28th #2255, would not have occurred if dateLeft would have been set as the later date in intervalToDuration