### PR TITLE
Fix typos in JSDoc example section of milliseconds

### DIFF
--- a/src/milliseconds/index.ts
+++ b/src/milliseconds/index.ts
@@ -26,11 +26,11 @@ const yearInDays = 365.2425
  *
  * @example
  * // 1 year in milliseconds
- * milliseconds({ year: 1 })
+ * milliseconds({ years: 1 })
  * //=> 31556952000
  *
  * // 3 months in milliseconds
- * milliseconds({ month: 3 })
+ * milliseconds({ months: 3 })
  * //=> 7889238000
  */
 export default function milliseconds({


### PR DESCRIPTION
The example did not match the actual functionality since the time units passed as parameter must be plural