### PR TITLE
fix: i18n example

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -57,7 +57,7 @@ export default function (date, formatStr = 'PP') {
 
 import format from 'app/_lib/format'
 
-window.__localeId__ = 'en'
+window.__localeId__ = 'enGB'
 format(friday13, 'EEEE d')
 //=> 'Friday 13'
 
@@ -66,7 +66,7 @@ format(friday13, 'EEEE d')
 //=> 'vendredo 13'
 
 // If the format string is omitted, it will take the default for the locale.
-window.__localeId__ = 'en'
+window.__localeId__ = 'enGB'
 format(friday13)
 //=> Jul 13, 2019
 


### PR DESCRIPTION
In i18n example, shouldn't it be `window.__localeId__ = 'enGB'` instead of `window.__localeId__ = 'en'`.
`window.__localeId__ = 'en'` is working but just because it uses `enUS` as a fallback.
(like it would have been the same if we had set `window.__localeId__ = 'load-english-plz'`)