### PR TITLE
Add check for 12 months to formatDistanceStrict

### DIFF
--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -262,7 +262,9 @@ export default function formatDistanceStrict(
     // 1 up to 12 months
   } else if (unit === 'month') {
     var months = roundingMethodFn(dstNormalizedMinutes / MINUTES_IN_MONTH)
-    return locale.formatDistance('xMonths', months, localizeOptions)
+    return months === 12
+      ? locale.formatDistance('xYears', 1, localizeOptions)
+      : locale.formatDistance('xMonths', months, localizeOptions)
 
     // 1 year up to max Date
   } else if (unit === 'year') {

--- a/src/formatDistanceStrict/test.js
+++ b/src/formatDistanceStrict/test.js
@@ -98,6 +98,22 @@ describe('formatDistanceStrict', function () {
   })
 
   describe('years', function () {
+    it('returns `1 year` - see issue 2388', () => {
+      const result = formatDistanceStrict(
+        new Date(2015, 0, 2),
+        new Date(2016, 0, 1)
+      )
+      assert(result === '1 year')
+    })
+
+    it('returns `2 years` - see issue 2388', () => {
+      const result = formatDistanceStrict(
+        new Date(2014, 0, 2),
+        new Date(2016, 0, 1)
+      )
+      assert(result === '2 years')
+    })
+
     it('1 year', function () {
       var result = formatDistanceStrict(
         new Date(1986, 3, 4, 10, 32, 0),

--- a/src/formatDistanceToNowStrict/index.js
+++ b/src/formatDistanceToNowStrict/index.js
@@ -1,4 +1,4 @@
-import distanceInStrictWords from '../formatDistanceStrict/index'
+import formatDistanceStrict from '../formatDistanceStrict/index'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
@@ -78,5 +78,5 @@ import requiredArgs from '../_lib/requiredArgs/index'
 export default function formatDistanceToNowStrict(dirtyDate, dirtyOptions) {
   requiredArgs(1, arguments)
 
-  return distanceInStrictWords(dirtyDate, Date.now(), dirtyOptions)
+  return formatDistanceStrict(dirtyDate, Date.now(), dirtyOptions)
 }

--- a/src/formatDistanceToNowStrict/test.js
+++ b/src/formatDistanceToNowStrict/test.js
@@ -220,6 +220,20 @@ describe('formatDistanceToNowStrict', function () {
     })
 
     describe('year', function () {
+      it('returns `1 year` - see issue 2388', () => {
+        const result = formatDistanceToNowStrict(
+          new Date(1985, 3, 4, 10, 32, 0)
+        )
+        assert(result === '1 year')
+      })
+
+      it('returns `2 years` - see issue 2388', () => {
+        const result = formatDistanceToNowStrict(
+          new Date(1984, 3, 4, 10, 32, 0)
+        )
+        assert(result === '2 years')
+      })
+
       it('0 years', function () {
         var result = formatDistanceToNowStrict(
           new Date(1986, 3, 4, 10, 32, 0),


### PR DESCRIPTION
#### Changes
This PR will allow `formatDistanceStrict` and `formatDistanceToNowStrict` to return **'1 year'** rather than **'12 months'** if
` dstNormalizedMinutes < MINUTES_IN_YEAR &&  months === 12`