### PR TITLE
fix: correction in flow types `unknown` is not a type in flowjs

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -475,7 +475,7 @@ declare module.exports: {
 
   isBefore: (date: Date | number, dateToCompare: Date | number) => boolean,
 
-  isDate: (value: unknown) => boolean,
+  isDate: (value: any) => boolean,
 
   isEqual: (dateLeft: Date | number, dateRight: Date | number) => boolean,
 


### PR DESCRIPTION
Fixes: https://github.com/date-fns/date-fns/issues/2398

**What has changed:**
revert change that introduced a flow type that does not exist 
