### PR TITLE
Add options.unit check

### DIFF
--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -262,7 +262,7 @@ export default function formatDistanceStrict(
     // 1 up to 12 months
   } else if (unit === 'month') {
     var months = roundingMethodFn(dstNormalizedMinutes / MINUTES_IN_MONTH)
-    return months === 12
+    return months === 12 && options.unit !== 'month'
       ? locale.formatDistance('xYears', 1, localizeOptions)
       : locale.formatDistance('xMonths', months, localizeOptions)
 

--- a/src/formatDistanceStrict/test.js
+++ b/src/formatDistanceStrict/test.js
@@ -266,6 +266,15 @@ describe('formatDistanceStrict', function () {
         assert(result === '4 months')
       })
 
+      it('12 months - see issue 2388', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 7, 4, 10, 32, 0),
+          new Date(1985, 7, 4, 10, 32, 0),
+          { unit: 'month' }
+        )
+        assert(result === '12 months')
+      })
+
       it('24 months', function () {
         var result = formatDistanceStrict(
           new Date(1986, 3, 4, 10, 32, 0),


### PR DESCRIPTION
#### Changes
Now if the distance is 12 month, it returns `1 year.`
This change will allow to force a `month` unit if specified in options.