### PR TITLE
Migrate _lib/format/*

### DIFF
--- a/src/_lib/addLeadingZeros/index.js
+++ b/src/_lib/addLeadingZeros/index.js
@@ -1,8 +1,0 @@
-export default function addLeadingZeros(number, targetLength) {
-  var sign = number < 0 ? '-' : ''
-  var output = Math.abs(number).toString()
-  while (output.length < targetLength) {
-    output = '0' + output
-  }
-  return sign + output
-}

--- a/src/_lib/addLeadingZeros/index.ts
+++ b/src/_lib/addLeadingZeros/index.ts
@@ -1,0 +1,8 @@
+export default function addLeadingZeros(value: number, targetLength: number): string {
+  var sign = value < 0 ? '-' : ''
+  var output = Math.abs(value).toString()
+  while (output.length < targetLength) {
+    output = '0' + output
+  }
+  return sign + output
+}

--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -1,21 +1,12 @@
 import lightFormatters from '../lightFormatters/index'
-import getUTCDayOfYear from '../../../_lib/getUTCDayOfYear/index'
-import getUTCISOWeek from '../../../_lib/getUTCISOWeek/index'
-import getUTCISOWeekYear from '../../../_lib/getUTCISOWeekYear/index'
-import getUTCWeek from '../../../_lib/getUTCWeek/index'
-import getUTCWeekYear from '../../../_lib/getUTCWeekYear/index'
+import getUTCDayOfYear from '../../getUTCDayOfYear/index'
+import getUTCISOWeek from '../../getUTCISOWeek/index'
+import getUTCISOWeekYear from '../../getUTCISOWeekYear/index'
+import getUTCWeek from '../../getUTCWeek/index'
+import getUTCWeekYear from '../../getUTCWeekYear/index'
 import addLeadingZeros from '../../addLeadingZeros/index'
-
-var dayPeriodEnum = {
-  am: 'am',
-  pm: 'pm',
-  midnight: 'midnight',
-  noon: 'noon',
-  morning: 'morning',
-  afternoon: 'afternoon',
-  evening: 'evening',
-  night: 'night'
-}
+import { Localize } from '@/locale/types'
+import { Month, Quarter, DayPeriod } from '@/types'
 
 /*
  * |     | Unit                           |     | Unit                           |
@@ -63,10 +54,10 @@ var dayPeriodEnum = {
  * - `p` is long localized time format
  */
 
-var formatters = {
+const FORMATTERS = {
   // Era
-  G: function(date, token, localize) {
-    var era = date.getUTCFullYear() > 0 ? 1 : 0
+  G: function (date: Date, token: string, localize: Localize): string {
+    const era = date.getUTCFullYear() > 0 ? 1 : 0
     switch (token) {
       // AD, BC
       case 'G':
@@ -84,12 +75,12 @@ var formatters = {
   },
 
   // Year
-  y: function(date, token, localize) {
+  y: function (date: Date, token: string, localize: Localize): string {
     // Ordinal number
     if (token === 'yo') {
-      var signedYear = date.getUTCFullYear()
+      const signedYear = date.getUTCFullYear()
       // Returns 1 for 1 BC (which is year 0 in JavaScript)
-      var year = signedYear > 0 ? signedYear : 1 - signedYear
+      const year = signedYear > 0 ? signedYear : 1 - signedYear
       return localize.ordinalNumber(year, { unit: 'year' })
     }
 
@@ -97,14 +88,14 @@ var formatters = {
   },
 
   // Local week-numbering year
-  Y: function(date, token, localize, options) {
-    var signedWeekYear = getUTCWeekYear(date, options)
+  Y: function (date: Date, token: string, localize: Localize, options): string {
+    const signedWeekYear = getUTCWeekYear(date, options)
     // Returns 1 for 1 BC (which is year 0 in JavaScript)
-    var weekYear = signedWeekYear > 0 ? signedWeekYear : 1 - signedWeekYear
+    const weekYear = signedWeekYear > 0 ? signedWeekYear : 1 - signedWeekYear
 
     // Two digit year
     if (token === 'YY') {
-      var twoDigitYear = weekYear % 100
+      const twoDigitYear = weekYear % 100
       return addLeadingZeros(twoDigitYear, 2)
     }
 
@@ -118,8 +109,8 @@ var formatters = {
   },
 
   // ISO week-numbering year
-  R: function(date, token) {
-    var isoWeekYear = getUTCISOWeekYear(date)
+  R: function (date: Date, token: string): string {
+    const isoWeekYear = getUTCISOWeekYear(date)
 
     // Padding
     return addLeadingZeros(isoWeekYear, token.length)
@@ -134,14 +125,14 @@ var formatters = {
   // | BC 2 |   2 |  -1 |
   // Also `yy` always returns the last two digits of a year,
   // while `uu` pads single digit years to 2 characters and returns other years unchanged.
-  u: function(date, token) {
-    var year = date.getUTCFullYear()
+  u: function (date: Date, token: string): string {
+    const year = date.getUTCFullYear()
     return addLeadingZeros(year, token.length)
   },
 
   // Quarter
-  Q: function(date, token, localize) {
-    var quarter = Math.ceil((date.getUTCMonth() + 1) / 3)
+  Q: function (date: Date, token: string, localize: Localize): string {
+    const quarter = Math.ceil((date.getUTCMonth() + 1) / 3) as Quarter
     switch (token) {
       // 1, 2, 3, 4
       case 'Q':
@@ -175,8 +166,8 @@ var formatters = {
   },
 
   // Stand-alone quarter
-  q: function(date, token, localize) {
-    var quarter = Math.ceil((date.getUTCMonth() + 1) / 3)
+  q: function (date: Date, token: string, localize: Localize): string {
+    const quarter = Math.ceil((date.getUTCMonth() + 1) / 3) as Quarter
     switch (token) {
       // 1, 2, 3, 4
       case 'q':
@@ -210,8 +201,8 @@ var formatters = {
   },
 
   // Month
-  M: function(date, token, localize) {
-    var month = date.getUTCMonth()
+  M: function (date: Date, token: string, localize: Localize): string {
+    const month = date.getUTCMonth() as Month
     switch (token) {
       case 'M':
       case 'MM':
@@ -236,8 +227,8 @@ var formatters = {
   },
 
   // Stand-alone month
-  L: function(date, token, localize) {
-    var month = date.getUTCMonth()
+  L: function (date: Date, token: string, localize: Localize): string {
+    const month = date.getUTCMonth() as Month
     switch (token) {
       // 1, 2, ..., 12
       case 'L':
@@ -265,8 +256,8 @@ var formatters = {
   },
 
   // Local week of year
-  w: function(date, token, localize, options) {
-    var week = getUTCWeek(date, options)
+  w: function (date: Date, token: string, localize: Localize, options): string {
+    const week = getUTCWeek(date, options)
 
     if (token === 'wo') {
       return localize.ordinalNumber(week, { unit: 'week' })
@@ -276,8 +267,8 @@ var formatters = {
   },
 
   // ISO week of year
-  I: function(date, token, localize) {
-    var isoWeek = getUTCISOWeek(date)
+  I: function (date: Date, token: string, localize: Localize): string {
+    const isoWeek = getUTCISOWeek(date)
 
     if (token === 'Io') {
       return localize.ordinalNumber(isoWeek, { unit: 'week' })
@@ -287,7 +278,7 @@ var formatters = {
   },
 
   // Day of the month
-  d: function(date, token, localize) {
+  d: function (date: Date, token: string, localize: Localize): string {
     if (token === 'do') {
       return localize.ordinalNumber(date.getUTCDate(), { unit: 'date' })
     }
@@ -296,8 +287,8 @@ var formatters = {
   },
 
   // Day of year
-  D: function(date, token, localize) {
-    var dayOfYear = getUTCDayOfYear(date)
+  D: function (date: Date, token: string, localize: Localize): string {
+    const dayOfYear = getUTCDayOfYear(date)
 
     if (token === 'Do') {
       return localize.ordinalNumber(dayOfYear, { unit: 'dayOfYear' })
@@ -307,8 +298,8 @@ var formatters = {
   },
 
   // Day of week
-  E: function(date, token, localize) {
-    var dayOfWeek = date.getUTCDay()
+  E: function (date: Date, token: string, localize: Localize): string {
+    const dayOfWeek = date.getUTCDay() as Day
     switch (token) {
       // Tue
       case 'E':
@@ -338,9 +329,9 @@ var formatters = {
   },
 
   // Local day of week
-  e: function(date, token, localize, options) {
-    var dayOfWeek = date.getUTCDay()
-    var localDayOfWeek = (dayOfWeek - options.weekStartsOn + 8) % 7 || 7
+  e: function (date: Date, token: string, localize: Localize, options): string {
+    const dayOfWeek = date.getUTCDay() as Day
+    const localDayOfWeek = (dayOfWeek - options.weekStartsOn + 8) % 7 || 7
     switch (token) {
       // Numerical value (Nth day of week with current locale or weekStartsOn)
       case 'e':
@@ -376,9 +367,9 @@ var formatters = {
   },
 
   // Stand-alone local day of week
-  c: function(date, token, localize, options) {
-    var dayOfWeek = date.getUTCDay()
-    var localDayOfWeek = (dayOfWeek - options.weekStartsOn + 8) % 7 || 7
+  c: function (date: Date, token: string, localize: Localize, options): string {
+    const dayOfWeek = date.getUTCDay() as Day
+    const localDayOfWeek = (dayOfWeek - options.weekStartsOn + 8) % 7 || 7
     switch (token) {
       // Numerical value (same as in `e`)
       case 'c':
@@ -414,9 +405,9 @@ var formatters = {
   },
 
   // ISO day of week
-  i: function(date, token, localize) {
-    var dayOfWeek = date.getUTCDay()
-    var isoDayOfWeek = dayOfWeek === 0 ? 7 : dayOfWeek
+  i: function (date: Date, token: string, localize: Localize): string {
+    const dayOfWeek = date.getUTCDay() as Day
+    const isoDayOfWeek = dayOfWeek === 0 ? 7 : dayOfWeek
     switch (token) {
       // 2
       case 'i':
@@ -453,32 +444,32 @@ var formatters = {
   },
 
   // AM or PM
-  a: function(date, token, localize) {
-    var hours = date.getUTCHours()
-    var dayPeriodEnumValue = hours / 12 >= 1 ? 'pm' : 'am'
+  a: function (date: Date, token: string, localize: Localize): string {
+    const hours = date.getUTCHours()
+    const dayPeriod = hours / 12 >= 1 ? DayPeriod.PM : DayPeriod.AM
 
     switch (token) {
       case 'a':
       case 'aa':
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'abbreviated',
           context: 'formatting'
         })
       case 'aaa':
         return localize
-          .dayPeriod(dayPeriodEnumValue, {
+          .dayPeriod(dayPeriod, {
             width: 'abbreviated',
             context: 'formatting'
           })
           .toLowerCase()
       case 'aaaaa':
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'narrow',
           context: 'formatting'
         })
       case 'aaaa':
       default:
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'wide',
           context: 'formatting'
         })
@@ -486,39 +477,39 @@ var formatters = {
   },
 
   // AM, PM, midnight, noon
-  b: function(date, token, localize) {
-    var hours = date.getUTCHours()
-    var dayPeriodEnumValue
+  b: function (date: Date, token: string, localize: Localize): string {
+    const hours = date.getUTCHours()
+    let dayPeriod
     if (hours === 12) {
-      dayPeriodEnumValue = dayPeriodEnum.noon
+      dayPeriod = DayPeriod.NOON
     } else if (hours === 0) {
-      dayPeriodEnumValue = dayPeriodEnum.midnight
+      dayPeriod = DayPeriod.MIDNIGHT
     } else {
-      dayPeriodEnumValue = hours / 12 >= 1 ? 'pm' : 'am'
+      dayPeriod = hours / 12 >= 1 ? DayPeriod.PM : DayPeriod.AM
     }
 
     switch (token) {
       case 'b':
       case 'bb':
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'abbreviated',
           context: 'formatting'
         })
       case 'bbb':
         return localize
-          .dayPeriod(dayPeriodEnumValue, {
+          .dayPeriod(dayPeriod, {
             width: 'abbreviated',
             context: 'formatting'
           })
           .toLowerCase()
       case 'bbbbb':
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'narrow',
           context: 'formatting'
         })
       case 'bbbb':
       default:
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'wide',
           context: 'formatting'
         })
@@ -526,35 +517,35 @@ var formatters = {
   },
 
   // in the morning, in the afternoon, in the evening, at night
-  B: function(date, token, localize) {
-    var hours = date.getUTCHours()
-    var dayPeriodEnumValue
+  B: function (date: Date, token: string, localize: Localize): string {
+    const hours = date.getUTCHours()
+    let dayPeriod
     if (hours >= 17) {
-      dayPeriodEnumValue = dayPeriodEnum.evening
+      dayPeriod = DayPeriod.EVENING
     } else if (hours >= 12) {
-      dayPeriodEnumValue = dayPeriodEnum.afternoon
+      dayPeriod = DayPeriod.AFTERNOON
     } else if (hours >= 4) {
-      dayPeriodEnumValue = dayPeriodEnum.morning
+      dayPeriod = DayPeriod.MORNING
     } else {
-      dayPeriodEnumValue = dayPeriodEnum.night
+      dayPeriod = DayPeriod.NIGHT
     }
 
     switch (token) {
       case 'B':
       case 'BB':
       case 'BBB':
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'abbreviated',
           context: 'formatting'
         })
       case 'BBBBB':
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'narrow',
           context: 'formatting'
         })
       case 'BBBB':
       default:
-        return localize.dayPeriod(dayPeriodEnumValue, {
+        return localize.dayPeriod(dayPeriod, {
           width: 'wide',
           context: 'formatting'
         })
@@ -562,9 +553,9 @@ var formatters = {
   },
 
   // Hour [1-12]
-  h: function(date, token, localize) {
+  h: function (date: Date, token: string, localize: Localize): string {
     if (token === 'ho') {
-      var hours = date.getUTCHours() % 12
+      let hours = date.getUTCHours() % 12
       if (hours === 0) hours = 12
       return localize.ordinalNumber(hours, { unit: 'hour' })
     }
@@ -573,7 +564,7 @@ var formatters = {
   },
 
   // Hour [0-23]
-  H: function(date, token, localize) {
+  H: function (date: Date, token: string, localize: Localize): string {
     if (token === 'Ho') {
       return localize.ordinalNumber(date.getUTCHours(), { unit: 'hour' })
     }
@@ -582,8 +573,8 @@ var formatters = {
   },
 
   // Hour [0-11]
-  K: function(date, token, localize) {
-    var hours = date.getUTCHours() % 12
+  K: function (date: Date, token: string, localize: Localize): string {
+    const hours = date.getUTCHours() % 12
 
     if (token === 'Ko') {
       return localize.ordinalNumber(hours, { unit: 'hour' })
@@ -593,8 +584,8 @@ var formatters = {
   },
 
   // Hour [1-24]
-  k: function(date, token, localize) {
-    var hours = date.getUTCHours()
+  k: function (date: Date, token: string, localize: Localize): string {
+    let hours = date.getUTCHours()
     if (hours === 0) hours = 24
 
     if (token === 'ko') {
@@ -605,7 +596,7 @@ var formatters = {
   },
 
   // Minute
-  m: function(date, token, localize) {
+  m: function (date: Date, token: string, localize: Localize): string {
     if (token === 'mo') {
       return localize.ordinalNumber(date.getUTCMinutes(), { unit: 'minute' })
     }
@@ -614,7 +605,7 @@ var formatters = {
   },
 
   // Second
-  s: function(date, token, localize) {
+  s: function (date: Date, token: string, localize: Localize): string {
     if (token === 'so') {
       return localize.ordinalNumber(date.getUTCSeconds(), { unit: 'second' })
     }
@@ -623,14 +614,14 @@ var formatters = {
   },
 
   // Fraction of second
-  S: function(date, token) {
+  S: function (date: Date, token: string) {
     return lightFormatters.S(date, token)
   },
 
   // Timezone (ISO-8601. If offset is 0, output is always `'Z'`)
-  X: function(date, token, _localize, options) {
-    var originalDate = options._originalDate || date
-    var timezoneOffset = originalDate.getTimezoneOffset()
+  X: function (date: Date, token: string, _localize: Localize, options): string {
+    const originalDate = options._originalDate || date
+    const timezoneOffset = originalDate.getTimezoneOffset()
 
     if (timezoneOffset === 0) {
       return 'Z'
@@ -659,9 +650,9 @@ var formatters = {
   },
 
   // Timezone (ISO-8601. If offset is 0, output is `'+00:00'` or equivalent)
-  x: function(date, token, _localize, options) {
-    var originalDate = options._originalDate || date
-    var timezoneOffset = originalDate.getTimezoneOffset()
+  x: function (date: Date, token: string, _localize: Localize, options): string {
+    const originalDate = options._originalDate || date
+    const timezoneOffset = originalDate.getTimezoneOffset()
 
     switch (token) {
       // Hours and optional minutes
@@ -686,9 +677,9 @@ var formatters = {
   },
 
   // Timezone (GMT)
-  O: function(date, token, _localize, options) {
-    var originalDate = options._originalDate || date
-    var timezoneOffset = originalDate.getTimezoneOffset()
+  O: function (date: Date, token: string, _localize: Localize, options): string {
+    const originalDate = options._originalDate || date
+    const timezoneOffset = originalDate.getTimezoneOffset()
 
     switch (token) {
       // Short
@@ -704,9 +695,9 @@ var formatters = {
   },
 
   // Timezone (specific non-location)
-  z: function(date, token, _localize, options) {
-    var originalDate = options._originalDate || date
-    var timezoneOffset = originalDate.getTimezoneOffset()
+  z: function (date: Date, token: string, _localize: Localize, options): string {
+    const originalDate = options._originalDate || date
+    const timezoneOffset = originalDate.getTimezoneOffset()
 
     switch (token) {
       // Short
@@ -722,47 +713,45 @@ var formatters = {
   },
 
   // Seconds timestamp
-  t: function(date, token, _localize, options) {
-    var originalDate = options._originalDate || date
-    var timestamp = Math.floor(originalDate.getTime() / 1000)
+  t: function (date: Date, token: string, _localize: Localize, options): string {
+    const originalDate = options._originalDate || date
+    const timestamp = Math.floor(originalDate.getTime() / 1000)
     return addLeadingZeros(timestamp, token.length)
   },
 
   // Milliseconds timestamp
-  T: function(date, token, _localize, options) {
-    var originalDate = options._originalDate || date
-    var timestamp = originalDate.getTime()
+  T: function (date: Date, token: string, _localize: Localize, options): string {
+    const originalDate = options._originalDate || date
+    const timestamp = originalDate.getTime()
     return addLeadingZeros(timestamp, token.length)
   }
 }
 
-function formatTimezoneShort(offset, dirtyDelimiter) {
-  var sign = offset > 0 ? '-' : '+'
-  var absOffset = Math.abs(offset)
-  var hours = Math.floor(absOffset / 60)
-  var minutes = absOffset % 60
+function formatTimezoneShort(offset: number, delimiter: string = '') {
+  const sign = offset > 0 ? '-' : '+'
+  const absOffset = Math.abs(offset)
+  const hours = Math.floor(absOffset / 60)
+  const minutes = absOffset % 60
   if (minutes === 0) {
     return sign + String(hours)
   }
-  var delimiter = dirtyDelimiter || ''
   return sign + String(hours) + delimiter + addLeadingZeros(minutes, 2)
 }
 
-function formatTimezoneWithOptionalMinutes(offset, dirtyDelimiter) {
+function formatTimezoneWithOptionalMinutes(offset: number, delimiter: string = '') {
   if (offset % 60 === 0) {
-    var sign = offset > 0 ? '-' : '+'
+    const sign = offset > 0 ? '-' : '+'
     return sign + addLeadingZeros(Math.abs(offset) / 60, 2)
   }
-  return formatTimezone(offset, dirtyDelimiter)
+  return formatTimezone(offset, delimiter)
 }
 
-function formatTimezone(offset, dirtyDelimiter) {
-  var delimiter = dirtyDelimiter || ''
-  var sign = offset > 0 ? '-' : '+'
-  var absOffset = Math.abs(offset)
-  var hours = addLeadingZeros(Math.floor(absOffset / 60), 2)
-  var minutes = addLeadingZeros(absOffset % 60, 2)
+function formatTimezone(offset: number, delimiter: string = '') {
+  const sign = offset > 0 ? '-' : '+'
+  const absOffset = Math.abs(offset)
+  const hours = addLeadingZeros(Math.floor(absOffset / 60), 2)
+  const minutes = addLeadingZeros(absOffset % 60, 2)
   return sign + hours + delimiter + minutes
 }
 
-export default formatters
+export default FORMATTERS

--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -5,8 +5,8 @@ import getUTCISOWeekYear from '../../getUTCISOWeekYear/index'
 import getUTCWeek from '../../getUTCWeek/index'
 import getUTCWeekYear from '../../getUTCWeekYear/index'
 import addLeadingZeros from '../../addLeadingZeros/index'
-import { Localize } from '@/locale/types'
-import { Month, Quarter, DayPeriod } from '@/types'
+import { Localize } from '../../../locale/types'
+import { Month, Quarter, DayPeriod } from '../../../types'
 
 /*
  * |     | Unit                           |     | Unit                           |

--- a/src/_lib/format/lightFormatters/index.ts
+++ b/src/_lib/format/lightFormatters/index.ts
@@ -13,9 +13,9 @@ import addLeadingZeros from '../../addLeadingZeros/index'
  * Letters marked by * are not implemented but reserved by Unicode standard.
  */
 
-var formatters = {
+const FORMATTERS = {
   // Year
-  y: function(date, token) {
+  y: function (date: Date, token: string): string {
     // From http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_tokens
     // | Year     |     y | yy |   yyy |  yyyy | yyyyy |
     // |----------|-------|----|-------|-------|-------|
@@ -25,26 +25,26 @@ var formatters = {
     // | AD 1234  |  1234 | 34 |  1234 |  1234 | 01234 |
     // | AD 12345 | 12345 | 45 | 12345 | 12345 | 12345 |
 
-    var signedYear = date.getUTCFullYear()
+    const signedYear = date.getUTCFullYear()
     // Returns 1 for 1 BC (which is year 0 in JavaScript)
-    var year = signedYear > 0 ? signedYear : 1 - signedYear
+    const year = signedYear > 0 ? signedYear : 1 - signedYear
     return addLeadingZeros(token === 'yy' ? year % 100 : year, token.length)
   },
 
   // Month
-  M: function(date, token) {
-    var month = date.getUTCMonth()
+  M: function (date: Date, token: string): string {
+    const month = date.getUTCMonth()
     return token === 'M' ? String(month + 1) : addLeadingZeros(month + 1, 2)
   },
 
   // Day of the month
-  d: function(date, token) {
+  d: function (date: Date, token: string): string {
     return addLeadingZeros(date.getUTCDate(), token.length)
   },
 
   // AM or PM
-  a: function(date, token) {
-    var dayPeriodEnumValue = date.getUTCHours() / 12 >= 1 ? 'pm' : 'am'
+  a: function (date: Date, token: string): string {
+    const dayPeriodEnumValue = date.getUTCHours() / 12 >= 1 ? 'pm' : 'am'
 
     switch (token) {
       case 'a':
@@ -61,34 +61,34 @@ var formatters = {
   },
 
   // Hour [1-12]
-  h: function(date, token) {
+  h: function (date: Date, token: string): string {
     return addLeadingZeros(date.getUTCHours() % 12 || 12, token.length)
   },
 
   // Hour [0-23]
-  H: function(date, token) {
+  H: function (date: Date, token: string): string {
     return addLeadingZeros(date.getUTCHours(), token.length)
   },
 
   // Minute
-  m: function(date, token) {
+  m: function (date: Date, token: string): string {
     return addLeadingZeros(date.getUTCMinutes(), token.length)
   },
 
   // Second
-  s: function(date, token) {
+  s: function (date: Date, token: string): string {
     return addLeadingZeros(date.getUTCSeconds(), token.length)
   },
 
   // Fraction of second
-  S: function(date, token) {
-    var numberOfDigits = token.length
-    var milliseconds = date.getUTCMilliseconds()
-    var fractionalSeconds = Math.floor(
+  S: function (date: Date, token: string): string {
+    const numberOfDigits = token.length
+    const milliseconds = date.getUTCMilliseconds()
+    const fractionalSeconds = Math.floor(
       milliseconds * Math.pow(10, numberOfDigits - 3)
     )
     return addLeadingZeros(fractionalSeconds, token.length)
   }
 }
 
-export default formatters
+export default FORMATTERS

--- a/src/_lib/format/longFormatters/index.ts
+++ b/src/_lib/format/longFormatters/index.ts
@@ -1,4 +1,6 @@
-function dateLongFormatter(pattern, formatLong) {
+import { FormatLong } from '../../../locale/types'
+
+function dateLongFormatter(pattern: string, formatLong: FormatLong) {
   switch (pattern) {
     case 'P':
       return formatLong.date({ width: 'short' })
@@ -12,7 +14,7 @@ function dateLongFormatter(pattern, formatLong) {
   }
 }
 
-function timeLongFormatter(pattern, formatLong) {
+function timeLongFormatter(pattern: string, formatLong: FormatLong) {
   switch (pattern) {
     case 'p':
       return formatLong.time({ width: 'short' })
@@ -26,16 +28,20 @@ function timeLongFormatter(pattern, formatLong) {
   }
 }
 
-function dateTimeLongFormatter(pattern, formatLong) {
-  var matchResult = pattern.match(/(P+)(p+)?/)
-  var datePattern = matchResult[1]
-  var timePattern = matchResult[2]
+function dateTimeLongFormatter(pattern: string, formatLong: FormatLong) {
+  const matchResult = pattern.match(/(P+)(p+)?/)
+  if (matchResult === null) {
+    throw new Error("no match found!"); // TODO: implement proper error handling
+  }
+
+  const datePattern = matchResult[1]
+  const timePattern = matchResult[2]
 
   if (!timePattern) {
     return dateLongFormatter(pattern, formatLong)
   }
 
-  var dateTimeFormat
+  let dateTimeFormat
 
   switch (datePattern) {
     case 'P':
@@ -58,9 +64,9 @@ function dateTimeLongFormatter(pattern, formatLong) {
     .replace('{{time}}', timeLongFormatter(timePattern, formatLong))
 }
 
-var longFormatters = {
+const FORMATTERS = {
   p: timeLongFormatter,
   P: dateTimeLongFormatter
 }
 
-export default longFormatters
+export default FORMATTERS

--- a/src/locale/types.ts
+++ b/src/locale/types.ts
@@ -1,3 +1,5 @@
+import { Era, Quarter, Month, Day, DayPeriod, WeekStartOptions, FirstWeekContainsDateOptions } from '@/types'
+
 export interface Locale {
   code: string
   formatDistance: FormatDistanceFn
@@ -8,10 +10,7 @@ export interface Locale {
   options?: LocaleOptions
 }
 
-export interface LocaleOptions {
-  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
-  firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
-}
+export interface LocaleOptions extends WeekStartOptions, FirstWeekContainsDateOptions { }
 
 export type FormatDistanceFn = (
   token:
@@ -40,7 +39,7 @@ export type FormatRelativeFn = (
   token: 'lastWeek' | 'yesterday' | 'today' | 'tomorrow' | 'nextWeek' | 'other',
   date: Date | number,
   baseDate: Date | number,
-  options?: { weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 }
+  options?: WeekStartOptions
 ) => string
 
 export type LocalizeFn<TValue> = (
@@ -48,25 +47,17 @@ export type LocalizeFn<TValue> = (
   options?: {
     width?: 'narrow' | 'short' | 'abbreviated' | 'wide'
     context?: 'formatting' | 'standalone'
+    unit?: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | 'dayOfYear'
   }
 ) => string
 
 export interface Localize {
   ordinalNumber: LocalizeFn<number>
-  era: LocalizeFn<0 | 1>
-  quarter: LocalizeFn<1 | 2 | 3 | 4>
-  month: LocalizeFn<0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>
-  day: LocalizeFn<0 | 1 | 2 | 3 | 4 | 5 | 6>
-  dayPeriod: LocalizeFn<
-    | 'am'
-    | 'pm'
-    | 'midnight'
-    | 'noon'
-    | 'morning'
-    | 'afternoon'
-    | 'evening'
-    | 'night'
-  >
+  era: LocalizeFn<Era>
+  quarter: LocalizeFn<Quarter>
+  month: LocalizeFn<Month>
+  day: LocalizeFn<Day>
+  dayPeriod: LocalizeFn<DayPeriod>
 }
 
 export type FormatLongFn = (options?: {
@@ -88,18 +79,9 @@ export type MatchFn<TResult> = (
 
 export interface Match {
   ordinalNumber: MatchFn<number>
-  era: MatchFn<0 | 1>
-  quarter: MatchFn<1 | 2 | 3 | 4>
-  month: MatchFn<0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>
-  day: MatchFn<0 | 1 | 2 | 3 | 4 | 5 | 6>
-  dayPeriod: MatchFn<
-    | 'am'
-    | 'pm'
-    | 'midnight'
-    | 'noon'
-    | 'morning'
-    | 'afternoon'
-    | 'evening'
-    | 'night'
-  >
+  era: MatchFn<Era>
+  quarter: MatchFn<Quarter>
+  month: MatchFn<Month>
+  day: MatchFn<Day>
+  dayPeriod: MatchFn<DayPeriod>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,21 @@
 import { Locale } from './locale/types'
 
+export type Era = 0 | 1
+export type Quarter = 1 | 2 | 3 | 4
+export type Month = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
+export type Day = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export enum DayPeriod {
+  AM = 'am',
+  PM = 'pm',
+  MIDNIGHT = 'midnight',
+  NOON = 'noon',
+  MORNING = 'morning',
+  AFTERNOON = 'afternoon',
+  EVENING = 'evening',
+  NIGHT = 'night'
+}
+
 export interface Duration {
   years?: number
   months?: number
@@ -27,13 +43,12 @@ export interface LocaleOptions {
   locale?: Locale
 }
 
+export type FirstWeekContainsDate = 1 | 4
+
 export interface FirstWeekContainsDateOptions {
   firstWeekContainsDate?: FirstWeekContainsDate
 }
 
-export type Day = 0 | 1 | 2 | 3 | 4 | 5 | 6
-
-export type FirstWeekContainsDate = 1 | 4
 
 export interface DateValues {
   year?: number

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,6 @@
     "strictNullChecks": true,
     "importHelpers": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"],
-      "@lib/*": ["./src/_lib/*"],
-      "@fp/*": ["./src/fp/*"],
-      "@fp/lib/*": ["./src/fp/_lib*"]
-    },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "allowJs": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,12 @@
     "strictNullChecks": true,
     "importHelpers": true,
     "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@lib/*": ["./src/_lib/*"],
+      "@fp/*": ["./src/fp/*"],
+      "@fp/lib/*": ["./src/fp/_lib*"]
+    },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "allowJs": true


### PR DESCRIPTION
I started working on the migration of the `_lib/format/*` tools.

All the options objects are still not typed, since I need to track down what it might be.

I might have made some bold changes, so I wanted to push this here to have a little review, before I put too much effort in something wrong.

I'd be happy to have any pointers for some guidelines, codes styles that you folks agreed on ? For now I try to follow as much as I can the general coding conventions.