### PR TITLE
CS locale now using time seconds, not arc seconds

### DIFF
--- a/src/locale/cs/_lib/formatDistance/index.js
+++ b/src/locale/cs/_lib/formatDistance/index.js
@@ -1,289 +1,289 @@
 var formatDistanceLocale = {
   lessThanXSeconds: {
     one: {
-      regular: 'méně než vteřina',
-      past: 'před méně než vteřinou',
-      future: 'za méně než vteřinu'
+      regular: 'méně než sekunda',
+      past: 'před méně než sekundou',
+      future: 'za méně než sekundu',
     },
     few: {
-      regular: 'méně než {{count}} vteřiny',
-      past: 'před méně než {{count}} vteřinami',
-      future: 'za méně než {{count}} vteřiny'
+      regular: 'méně než {{count}} sekundy',
+      past: 'před méně než {{count}} sekundami',
+      future: 'za méně než {{count}} sekund',
     },
     many: {
-      regular: 'méně než {{count}} vteřin',
-      past: 'před méně než {{count}} vteřinami',
-      future: 'za méně než {{count}} vteřin'
-    }
+      regular: 'méně než {{count}} sekund',
+      past: 'před méně než {{count}} sekundami',
+      future: 'za méně než {{count}} sekund',
+    },
   },
 
   xSeconds: {
     one: {
-      regular: 'vteřina',
-      past: 'před vteřinou',
-      future: 'za vteřinu'
+      regular: 'sekunda',
+      past: 'před sekundou',
+      future: 'za sekundu',
     },
     few: {
-      regular: '{{count}} vteřiny',
-      past: 'před {{count}} vteřinami',
-      future: 'za {{count}} vteřiny'
+      regular: '{{count}} sekundy',
+      past: 'před {{count}} sekundami',
+      future: 'za {{count}} sekund',
     },
     many: {
-      regular: '{{count}} vteřin',
-      past: 'před {{count}} vteřinami',
-      future: 'za {{count}} vteřin'
-    }
+      regular: '{{count}} sekund',
+      past: 'před {{count}} sekundami',
+      future: 'za {{count}} sekund',
+    },
   },
 
   halfAMinute: {
     other: {
       regular: 'půl minuty',
       past: 'před půl minutou',
-      future: 'za půl minuty'
-    }
+      future: 'za půl minuty',
+    },
   },
 
   lessThanXMinutes: {
     one: {
       regular: 'méně než minuta',
       past: 'před méně než minutou',
-      future: 'za méně než minutu'
+      future: 'za méně než minutu',
     },
     few: {
       regular: 'méně než {{count}} minuty',
       past: 'před méně než {{count}} minutami',
-      future: 'za méně než {{count}} minuty'
+      future: 'za méně než {{count}} minuty',
     },
     many: {
       regular: 'méně než {{count}} minut',
       past: 'před méně než {{count}} minutami',
-      future: 'za méně než {{count}} minut'
-    }
+      future: 'za méně než {{count}} minut',
+    },
   },
 
   xMinutes: {
     one: {
       regular: 'minuta',
       past: 'před minutou',
-      future: 'za minutu'
+      future: 'za minutu',
     },
     few: {
       regular: '{{count}} minuty',
       past: 'před {{count}} minutami',
-      future: 'za {{count}} minuty'
+      future: 'za {{count}} minuty',
     },
     many: {
       regular: '{{count}} minut',
       past: 'před {{count}} minutami',
-      future: 'za {{count}} minut'
-    }
+      future: 'za {{count}} minut',
+    },
   },
 
   aboutXHours: {
     one: {
       regular: 'přibližně hodina',
       past: 'přibližně před hodinou',
-      future: 'přibližně za hodinu'
+      future: 'přibližně za hodinu',
     },
     few: {
       regular: 'přibližně {{count}} hodiny',
       past: 'přibližně před {{count}} hodinami',
-      future: 'přibližně za {{count}} hodiny'
+      future: 'přibližně za {{count}} hodiny',
     },
     many: {
       regular: 'přibližně {{count}} hodin',
       past: 'přibližně před {{count}} hodinami',
-      future: 'přibližně za {{count}} hodin'
-    }
+      future: 'přibližně za {{count}} hodin',
+    },
   },
 
   xHours: {
     one: {
       regular: 'hodina',
       past: 'před hodinou',
-      future: 'za hodinu'
+      future: 'za hodinu',
     },
     few: {
       regular: '{{count}} hodiny',
       past: 'před {{count}} hodinami',
-      future: 'za {{count}} hodiny'
+      future: 'za {{count}} hodiny',
     },
     many: {
       regular: '{{count}} hodin',
       past: 'před {{count}} hodinami',
-      future: 'za {{count}} hodin'
-    }
+      future: 'za {{count}} hodin',
+    },
   },
 
   xDays: {
     one: {
       regular: 'den',
       past: 'před dnem',
-      future: 'za den'
+      future: 'za den',
     },
     few: {
       regular: '{{count}} dny',
       past: 'před {{count}} dny',
-      future: 'za {{count}} dny'
+      future: 'za {{count}} dny',
     },
     many: {
       regular: '{{count}} dní',
       past: 'před {{count}} dny',
-      future: 'za {{count}} dní'
-    }
+      future: 'za {{count}} dní',
+    },
   },
 
   aboutXWeeks: {
     one: {
       regular: 'přibližně týden',
       past: 'přibližně před týdnem',
-      future: 'přibližně za týden'
+      future: 'přibližně za týden',
     },
 
     few: {
       regular: 'přibližně {{count}} týdny',
       past: 'přibližně před {{count}} týdny',
-      future: 'přibližně za {{count}} týdny'
+      future: 'přibližně za {{count}} týdny',
     },
 
     many: {
       regular: 'přibližně {{count}} týdnů',
       past: 'přibližně před {{count}} týdny',
-      future: 'přibližně za {{count}} týdnů'
-    }
+      future: 'přibližně za {{count}} týdnů',
+    },
   },
 
   xWeeks: {
     one: {
       regular: 'týden',
       past: 'před týdnem',
-      future: 'za týden'
+      future: 'za týden',
     },
 
     few: {
       regular: '{{count}} týdny',
       past: 'před {{count}} týdny',
-      future: 'za {{count}} týdny'
+      future: 'za {{count}} týdny',
     },
 
     many: {
       regular: '{{count}} týdnů',
       past: 'před {{count}} týdny',
-      future: 'za {{count}} týdnů'
-    }
+      future: 'za {{count}} týdnů',
+    },
   },
 
   aboutXMonths: {
     one: {
       regular: 'přibližně měsíc',
       past: 'přibližně před měsícem',
-      future: 'přibližně za měsíc'
+      future: 'přibližně za měsíc',
     },
 
     few: {
       regular: 'přibližně {{count}} měsíce',
       past: 'přibližně před {{count}} měsíci',
-      future: 'přibližně za {{count}} měsíce'
+      future: 'přibližně za {{count}} měsíce',
     },
 
     many: {
       regular: 'přibližně {{count}} měsíců',
       past: 'přibližně před {{count}} měsíci',
-      future: 'přibližně za {{count}} měsíců'
-    }
+      future: 'přibližně za {{count}} měsíců',
+    },
   },
 
   xMonths: {
     one: {
       regular: 'měsíc',
       past: 'před měsícem',
-      future: 'za měsíc'
+      future: 'za měsíc',
     },
 
     few: {
       regular: '{{count}} měsíce',
       past: 'před {{count}} měsíci',
-      future: 'za {{count}} měsíce'
+      future: 'za {{count}} měsíce',
     },
 
     many: {
       regular: '{{count}} měsíců',
       past: 'před {{count}} měsíci',
-      future: 'za {{count}} měsíců'
-    }
+      future: 'za {{count}} měsíců',
+    },
   },
 
   aboutXYears: {
     one: {
       regular: 'přibližně rok',
       past: 'přibližně před rokem',
-      future: 'přibližně za rok'
+      future: 'přibližně za rok',
     },
     few: {
       regular: 'přibližně {{count}} roky',
       past: 'přibližně před {{count}} roky',
-      future: 'přibližně za {{count}} roky'
+      future: 'přibližně za {{count}} roky',
     },
     many: {
       regular: 'přibližně {{count}} roků',
       past: 'přibližně před {{count}} roky',
-      future: 'přibližně za {{count}} roků'
-    }
+      future: 'přibližně za {{count}} roků',
+    },
   },
 
   xYears: {
     one: {
       regular: 'rok',
       past: 'před rokem',
-      future: 'za rok'
+      future: 'za rok',
     },
     few: {
       regular: '{{count}} roky',
       past: 'před {{count}} roky',
-      future: 'za {{count}} roky'
+      future: 'za {{count}} roky',
     },
     many: {
       regular: '{{count}} roků',
       past: 'před {{count}} roky',
-      future: 'za {{count}} roků'
-    }
+      future: 'za {{count}} roků',
+    },
   },
 
   overXYears: {
     one: {
       regular: 'více než rok',
       past: 'před více než rokem',
-      future: 'za více než rok'
+      future: 'za více než rok',
     },
     few: {
       regular: 'více než {{count}} roky',
       past: 'před více než {{count}} roky',
-      future: 'za více než {{count}} roky'
+      future: 'za více než {{count}} roky',
     },
     many: {
       regular: 'více než {{count}} roků',
       past: 'před více než {{count}} roky',
-      future: 'za více než {{count}} roků'
-    }
+      future: 'za více než {{count}} roků',
+    },
   },
 
   almostXYears: {
     one: {
       regular: 'skoro rok',
       past: 'skoro před rokem',
-      future: 'skoro za rok'
+      future: 'skoro za rok',
     },
     few: {
       regular: 'skoro {{count}} roky',
       past: 'skoro před {{count}} roky',
-      future: 'skoro za {{count}} roky'
+      future: 'skoro za {{count}} roky',
     },
     many: {
       regular: 'skoro {{count}} roků',
       past: 'skoro před {{count}} roky',
-      future: 'skoro za {{count}} roků'
-    }
-  }
+      future: 'skoro za {{count}} roků',
+    },
+  },
 }
 
 export default function formatDistance(token, count, options) {

--- a/src/locale/cs/_lib/formatDistance/index.js
+++ b/src/locale/cs/_lib/formatDistance/index.js
@@ -8,7 +8,7 @@ var formatDistanceLocale = {
     few: {
       regular: 'méně než {{count}} sekundy',
       past: 'před méně než {{count}} sekundami',
-      future: 'za méně než {{count}} sekund',
+      future: 'za méně než {{count}} sekundy',
     },
     many: {
       regular: 'méně než {{count}} sekund',
@@ -26,7 +26,7 @@ var formatDistanceLocale = {
     few: {
       regular: '{{count}} sekundy',
       past: 'před {{count}} sekundami',
-      future: 'za {{count}} sekund',
+      future: 'za {{count}} sekundy',
     },
     many: {
       regular: '{{count}} sekund',

--- a/src/locale/cs/snapshot.md
+++ b/src/locale/cs/snapshot.md
@@ -211,11 +211,11 @@ If now is January 1st, 2000, 00:00.
 | 2000-01-01T00:15:00.000Z | 15 minut          | 15 minut               | za 15 minut               |
 | 2000-01-01T00:01:00.000Z | minuta            | minuta                 | za minutu                 |
 | 2000-01-01T00:00:25.000Z | méně než minuta   | půl minuty             | za méně než minutu        |
-| 2000-01-01T00:00:15.000Z | méně než minuta   | méně než 20 vteřin     | za méně než minutu        |
-| 2000-01-01T00:00:05.000Z | méně než minuta   | méně než 10 vteřin     | za méně než minutu        |
-| 2000-01-01T00:00:00.000Z | méně než minuta   | méně než 5 vteřin      | méně než minuta           |
-| 1999-12-31T23:59:55.000Z | méně než minuta   | méně než 10 vteřin     | před méně než minutou     |
-| 1999-12-31T23:59:45.000Z | méně než minuta   | méně než 20 vteřin     | před méně než minutou     |
+| 2000-01-01T00:00:15.000Z | méně než minuta   | méně než 20 sekund     | za méně než minutu        |
+| 2000-01-01T00:00:05.000Z | méně než minuta   | méně než 10 sekund     | za méně než minutu        |
+| 2000-01-01T00:00:00.000Z | méně než minuta   | méně než 5 sekund      | méně než minuta           |
+| 1999-12-31T23:59:55.000Z | méně než minuta   | méně než 10 sekund     | před méně než minutou     |
+| 1999-12-31T23:59:45.000Z | méně než minuta   | méně než 20 sekund     | před méně než minutou     |
 | 1999-12-31T23:59:35.000Z | méně než minuta   | půl minuty             | před méně než minutou     |
 | 1999-12-31T23:59:00.000Z | minuta            | minuta                 | před minutou              |
 | 1999-12-31T23:45:00.000Z | 15 minut          | 15 minut               | před 15 minutami          |
@@ -262,13 +262,13 @@ If now is January 1st, 2000, 00:00.
 | 2000-01-01T00:30:00.000Z | 30 minut  | za 30 minut       | hodina                         |
 | 2000-01-01T00:15:00.000Z | 15 minut  | za 15 minut       | 0 hodiny                       |
 | 2000-01-01T00:01:00.000Z | minuta    | za minutu         | 0 hodiny                       |
-| 2000-01-01T00:00:25.000Z | 25 vteřin | za 25 vteřin      | 0 hodiny                       |
-| 2000-01-01T00:00:15.000Z | 15 vteřin | za 15 vteřin      | 0 hodiny                       |
-| 2000-01-01T00:00:05.000Z | 5 vteřin  | za 5 vteřin       | 0 hodiny                       |
-| 2000-01-01T00:00:00.000Z | 0 vteřiny | 0 vteřiny         | 0 hodiny                       |
-| 1999-12-31T23:59:55.000Z | 5 vteřin  | před 5 vteřinami  | 0 hodiny                       |
-| 1999-12-31T23:59:45.000Z | 15 vteřin | před 15 vteřinami | 0 hodiny                       |
-| 1999-12-31T23:59:35.000Z | 25 vteřin | před 25 vteřinami | 0 hodiny                       |
+| 2000-01-01T00:00:25.000Z | 25 sekund | za 25 sekund      | 0 hodiny                       |
+| 2000-01-01T00:00:15.000Z | 15 sekund | za 15 sekund      | 0 hodiny                       |
+| 2000-01-01T00:00:05.000Z | 5 sekund  | za 5 sekund       | 0 hodiny                       |
+| 2000-01-01T00:00:00.000Z | 0 sekundy | 0 sekundy         | 0 hodiny                       |
+| 1999-12-31T23:59:55.000Z | 5 sekund  | před 5 sekundami  | 0 hodiny                       |
+| 1999-12-31T23:59:45.000Z | 15 sekund | před 15 sekundami | 0 hodiny                       |
+| 1999-12-31T23:59:35.000Z | 25 sekund | před 25 sekundami | 0 hodiny                       |
 | 1999-12-31T23:59:00.000Z | minuta    | před minutou      | 0 hodiny                       |
 | 1999-12-31T23:45:00.000Z | 15 minut  | před 15 minutami  | 0 hodiny                       |
 | 1999-12-31T23:30:00.000Z | 30 minut  | před 30 minutami  | hodina                         |


### PR DESCRIPTION
Hey guys, just noticed there is bad wording used for CS locale

Currently word `vteřina` is being used, HOWEVER. Vteřina is a word for arc second, not time second.
For time second, `sekunda` is the correct word to use

See: https://cs.wikipedia.org/wiki/Vte%C5%99ina

edit:
resolves #1488