### PR TITLE
Lower tsc error count

### DIFF
--- a/src/areIntervalsOverlapping/test.ts
+++ b/src/areIntervalsOverlapping/test.ts
@@ -3,7 +3,6 @@
 
 import assert from 'assert'
 import areIntervalsOverlapping from '.'
-import context from 'assert'
 
 describe('areIntervalsOverlapping', function () {
   const initialIntervalStart = new Date(2016, 10, 10, 13, 0, 0)

--- a/src/eachDayOfInterval/test.ts
+++ b/src/eachDayOfInterval/test.ts
@@ -8,7 +8,7 @@ describe('eachDayOfInterval', () => {
   it('returns an array with starts of days from the day of the start date to the day of the end date', () => {
     const result = eachDayOfInterval({
       start: new Date(2014, 9 /* Oct */, 6),
-      end: new Date(2014, 9 /* Oct */, 12)
+      end: new Date(2014, 9 /* Oct */, 12),
     })
     assert.deepStrictEqual(result, [
       new Date(2014, 9 /* Oct */, 6),
@@ -17,14 +17,14 @@ describe('eachDayOfInterval', () => {
       new Date(2014, 9 /* Oct */, 9),
       new Date(2014, 9 /* Oct */, 10),
       new Date(2014, 9 /* Oct */, 11),
-      new Date(2014, 9 /* Oct */, 12)
+      new Date(2014, 9 /* Oct */, 12),
     ])
   })
 
   it('accepts timestamps', () => {
     const result = eachDayOfInterval({
       start: new Date(2014, 9 /* Oct */, 6).getTime(),
-      end: new Date(2014, 9 /* Oct */, 12).getTime()
+      end: new Date(2014, 9 /* Oct */, 12).getTime(),
     })
     assert.deepStrictEqual(result, [
       new Date(2014, 9 /* Oct */, 6),
@@ -33,14 +33,14 @@ describe('eachDayOfInterval', () => {
       new Date(2014, 9 /* Oct */, 9),
       new Date(2014, 9 /* Oct */, 10),
       new Date(2014, 9 /* Oct */, 11),
-      new Date(2014, 9 /* Oct */, 12)
+      new Date(2014, 9 /* Oct */, 12),
     ])
   })
 
   it('handles the dates that are not starts of days', () => {
     const result = eachDayOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 6, 35),
-      end: new Date(2014, 9 /* Oct */, 12, 22, 15)
+      end: new Date(2014, 9 /* Oct */, 12, 22, 15),
     })
     assert.deepStrictEqual(result, [
       new Date(2014, 9 /* Oct */, 6),
@@ -49,14 +49,14 @@ describe('eachDayOfInterval', () => {
       new Date(2014, 9 /* Oct */, 9),
       new Date(2014, 9 /* Oct */, 10),
       new Date(2014, 9 /* Oct */, 11),
-      new Date(2014, 9 /* Oct */, 12)
+      new Date(2014, 9 /* Oct */, 12),
     ])
   })
 
   it('returns one day if the both arguments are on the same day', () => {
     const result = eachDayOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 6, 15)
+      end: new Date(2014, 9 /* Oct */, 6, 15),
     })
     assert.deepStrictEqual(result, [new Date(2014, 9 /* Oct */, 6)])
   })
@@ -64,7 +64,7 @@ describe('eachDayOfInterval', () => {
   it('returns one day if the both arguments are the same', () => {
     const result = eachDayOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 6, 14)
+      end: new Date(2014, 9 /* Oct */, 6, 14),
     })
     assert.deepStrictEqual(result, [new Date(2014, 9 /* Oct */, 6)])
   })
@@ -72,7 +72,7 @@ describe('eachDayOfInterval', () => {
   it('throws an exception if the start date is after the end date', () => {
     const block = eachDayOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
@@ -80,7 +80,7 @@ describe('eachDayOfInterval', () => {
   it('throws an exception if the start date is `Invalid Date`', () => {
     var block = eachDayOfInterval.bind(null, {
       start: new Date(NaN),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
@@ -88,28 +88,26 @@ describe('eachDayOfInterval', () => {
   it('throws an exception if the end date is `Invalid Date`', () => {
     var block = eachDayOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(NaN)
+      end: new Date(NaN),
     })
     assert.throws(block, RangeError)
   })
 
   it('throws an exception if the interval is undefined', () => {
-    var block = eachDayOfInterval.bind(
-      null,
-      //@ts-expect-error
-      undefined
-    )
+    //@ts-expect-error
+    var block = eachDayOfInterval.bind(null, undefined)
     assert.throws(block, RangeError)
   })
 
   it('throws TypeError exception if passed less than 1 argument', () => {
+    // @ts-expect-error
     assert.throws(eachDayOfInterval.bind(null), TypeError)
   })
 
   describe('options.step', () => {
     const interval = {
       start: new Date(2014, 9 /* Oct */, 6),
-      end: new Date(2014, 9 /* Oct */, 13)
+      end: new Date(2014, 9 /* Oct */, 13),
     }
 
     const stepError = /^RangeError: `options.step` must be a number greater than 1$/
@@ -119,7 +117,7 @@ describe('eachDayOfInterval', () => {
       assert.deepStrictEqual(result, [
         new Date(2014, 9 /* Oct */, 6),
         new Date(2014, 9 /* Oct */, 9),
-        new Date(2014, 9 /* Oct */, 12)
+        new Date(2014, 9 /* Oct */, 12),
       ])
     })
 

--- a/src/eachHourOfInterval/test.ts
+++ b/src/eachHourOfInterval/test.ts
@@ -8,46 +8,46 @@ describe('eachHourOfInterval', () => {
   it('returns an array with starts of hours from the hour of the start date to the hour of the end date', () => {
     const result = eachHourOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 12),
-      end: new Date(2014, 9 /* Oct */, 6, 15)
+      end: new Date(2014, 9 /* Oct */, 6, 15),
     })
     assert.deepEqual(result, [
       new Date(2014, 9 /* Oct */, 6, 12),
       new Date(2014, 9 /* Oct */, 6, 13),
       new Date(2014, 9 /* Oct */, 6, 14),
-      new Date(2014, 9 /* Oct */, 6, 15)
+      new Date(2014, 9 /* Oct */, 6, 15),
     ])
   })
 
   it('accepts timestamps', () => {
     const result = eachHourOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 12).getTime(),
-      end: new Date(2014, 9 /* Oct */, 6, 15).getTime()
+      end: new Date(2014, 9 /* Oct */, 6, 15).getTime(),
     })
     assert.deepEqual(result, [
       new Date(2014, 9 /* Oct */, 6, 12),
       new Date(2014, 9 /* Oct */, 6, 13),
       new Date(2014, 9 /* Oct */, 6, 14),
-      new Date(2014, 9 /* Oct */, 6, 15)
+      new Date(2014, 9 /* Oct */, 6, 15),
     ])
   })
 
   it('handles the hours that are not starts of hours', () => {
     const result = eachHourOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 12, 59, 59, 999),
-      end: new Date(2014, 9 /* Oct */, 6, 15, 59, 59, 999)
+      end: new Date(2014, 9 /* Oct */, 6, 15, 59, 59, 999),
     })
     assert.deepEqual(result, [
       new Date(2014, 9 /* Oct */, 6, 12),
       new Date(2014, 9 /* Oct */, 6, 13),
       new Date(2014, 9 /* Oct */, 6, 14),
-      new Date(2014, 9 /* Oct */, 6, 15)
+      new Date(2014, 9 /* Oct */, 6, 15),
     ])
   })
 
   it('returns one hour if the both arguments are on the same hour', () => {
     const result = eachHourOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 12, 35),
-      end: new Date(2014, 9 /* Oct */, 6, 12, 47)
+      end: new Date(2014, 9 /* Oct */, 6, 12, 47),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 6, 12)])
   })
@@ -55,7 +55,7 @@ describe('eachHourOfInterval', () => {
   it('returns one hour if the both arguments are the same', () => {
     const result = eachHourOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 12, 35),
-      end: new Date(2014, 9 /* Oct */, 6, 12, 35)
+      end: new Date(2014, 9 /* Oct */, 6, 12, 35),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 6, 12)])
   })
@@ -63,7 +63,7 @@ describe('eachHourOfInterval', () => {
   it('throws an exception if the start date is after the end date', () => {
     const block = eachHourOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12, 35, 0, 0, 1),
-      end: new Date(2014, 9 /* Oct */, 12, 35, 0, 0, 0)
+      end: new Date(2014, 9 /* Oct */, 12, 35, 0, 0, 0),
     })
     assert.throws(block, RangeError)
   })
@@ -71,7 +71,7 @@ describe('eachHourOfInterval', () => {
   it('throws an exception if the start date is `Invalid Date`', () => {
     const block = eachHourOfInterval.bind(null, {
       start: new Date(NaN),
-      end: new Date(2014, 9 /* Oct */, 6, 12)
+      end: new Date(2014, 9 /* Oct */, 6, 12),
     })
     assert.throws(block, RangeError)
   })
@@ -79,28 +79,26 @@ describe('eachHourOfInterval', () => {
   it('throws an exception if the end date is `Invalid Date`', () => {
     const block = eachHourOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12, 12),
-      end: new Date(NaN)
+      end: new Date(NaN),
     })
     assert.throws(block, RangeError)
   })
 
   it('throws an exception if the interval is undefined', () => {
-    const block = eachHourOfInterval.bind(
-      null,
-      // $ExpectedMistake
-      undefined
-    )
+    // @ts-expect-error
+    const block = eachHourOfInterval.bind(null, undefined)
     assert.throws(block, RangeError)
   })
 
   it('throws TypeError exception if passed less than 1 argument', () => {
+    // @ts-expect-error
     assert.throws(eachHourOfInterval.bind(null), TypeError)
   })
 
   describe('options.step', () => {
     const interval = {
       start: new Date(2014, 9 /* Oct */, 6, 12),
-      end: new Date(2014, 9 /* Oct */, 6, 18)
+      end: new Date(2014, 9 /* Oct */, 6, 18),
     }
 
     const stepError = /^RangeError: `options.step` must be a number greater than 1$/
@@ -110,7 +108,7 @@ describe('eachHourOfInterval', () => {
       assert.deepEqual(result, [
         new Date(2014, 9 /* Oct */, 6, 12),
         new Date(2014, 9 /* Oct */, 6, 15),
-        new Date(2014, 9 /* Oct */, 6, 18)
+        new Date(2014, 9 /* Oct */, 6, 18),
       ])
     })
 
@@ -120,8 +118,8 @@ describe('eachHourOfInterval', () => {
     })
 
     it('throws TypeError error if `options.step` is NaN', () => {
-      // $ExpectedMistake
       assert.throws(
+        // @ts-expect-error
         () => eachHourOfInterval(interval, { step: 'w' }),
         stepError
       )

--- a/src/eachMinuteOfInterval/test.ts
+++ b/src/eachMinuteOfInterval/test.ts
@@ -2,14 +2,13 @@
 /* eslint-env mocha */
 
 import assert from 'power-assert'
-
 import eachMinuteOfInterval from '.'
 
 describe('eachMinuteOfInterval', () => {
   it('should return an array of Date objects containing a Date for each minute between the interval', () => {
     const result = eachMinuteOfInterval({
       start: new Date(2020, 10, 14, 13, 0),
-      end: new Date(2020, 10, 14, 13, 5)
+      end: new Date(2020, 10, 14, 13, 5),
     })
 
     assert.deepEqual(result, [
@@ -18,14 +17,14 @@ describe('eachMinuteOfInterval', () => {
       new Date(2020, 10, 14, 13, 2),
       new Date(2020, 10, 14, 13, 3),
       new Date(2020, 10, 14, 13, 4),
-      new Date(2020, 10, 14, 13, 5)
+      new Date(2020, 10, 14, 13, 5),
     ])
   })
 
   it('should handle all the minutes that are not in the begining', () => {
     const result = eachMinuteOfInterval({
       start: new Date(2020, 10, 14, 13, 0, 33),
-      end: new Date(2020, 10, 14, 13, 2)
+      end: new Date(2020, 10, 14, 13, 2),
     })
 
     assert.deepEqual(result[0], new Date(2020, 10, 14, 13))
@@ -38,20 +37,20 @@ describe('eachMinuteOfInterval', () => {
 
     const result = eachMinuteOfInterval({
       start,
-      end
+      end,
     })
 
     assert.deepEqual(result, [
       new Date(2020, 10, 14, 13, 0),
       new Date(2020, 10, 14, 13, 1),
-      new Date(2020, 10, 14, 13, 2)
+      new Date(2020, 10, 14, 13, 2),
     ])
   })
 
   it('throws an exception if the start date is after the end date', () => {
     const block = eachMinuteOfInterval.bind(null, {
       start: new Date(2014, 10, 14, 10),
-      end: new Date(2014, 10, 14, 5)
+      end: new Date(2014, 10, 14, 5),
     })
     assert.throws(block, RangeError)
   })
@@ -59,7 +58,7 @@ describe('eachMinuteOfInterval', () => {
   describe('options.step', () => {
     const interval = {
       start: new Date(2020, 9, 14, 13, 1),
-      end: new Date(2020, 9, 14, 13, 7)
+      end: new Date(2020, 9, 14, 13, 7),
     }
 
     const stepError = /^RangeError: `options.step` must be a number equal or greater than 1$/
@@ -69,7 +68,7 @@ describe('eachMinuteOfInterval', () => {
       assert.deepEqual(result, [
         new Date(2020, 9, 14, 13, 1),
         new Date(2020, 9, 14, 13, 4),
-        new Date(2020, 9, 14, 13, 7)
+        new Date(2020, 9, 14, 13, 7),
       ])
     })
 
@@ -85,8 +84,8 @@ describe('eachMinuteOfInterval', () => {
     })
 
     it('throws TypeError error if `options.step` is NaN', () => {
-      // $ExpectedMistake
       assert.throws(
+        // @ts-expect-error
         () => eachMinuteOfInterval(interval, { step: 'w' }),
         stepError
       )

--- a/src/eachMonthOfInterval/test.ts
+++ b/src/eachMonthOfInterval/test.ts
@@ -4,11 +4,11 @@
 import assert from 'assert'
 import eachMonthOfInterval from '.'
 
-describe('eachMonthOfInterval', function() {
-  it('returns an array with starts of months from the month of the start date to the month of the end date', function() {
+describe('eachMonthOfInterval', function () {
+  it('returns an array with starts of months from the month of the start date to the month of the end date', function () {
     const result = eachMonthOfInterval({
       start: new Date(2014, 2 /* Mar */, 6),
-      end: new Date(2014, 7 /* Aug */, 12)
+      end: new Date(2014, 7 /* Aug */, 12),
     })
     assert.deepEqual(result, [
       new Date(2014, 2 /* Mar */, 1),
@@ -16,14 +16,14 @@ describe('eachMonthOfInterval', function() {
       new Date(2014, 4 /* May */, 1),
       new Date(2014, 5 /* Jun */, 1),
       new Date(2014, 6 /* Jul */, 1),
-      new Date(2014, 7 /* Aug */, 1)
+      new Date(2014, 7 /* Aug */, 1),
     ])
   })
 
-  it('accepts timestamps', function() {
+  it('accepts timestamps', function () {
     const result = eachMonthOfInterval({
       start: new Date(2014, 2 /* Mar */, 6).getTime(),
-      end: new Date(2014, 7 /* Aug */, 12).getTime()
+      end: new Date(2014, 7 /* Aug */, 12).getTime(),
     })
     assert.deepEqual(result, [
       new Date(2014, 2 /* Mar */, 1),
@@ -31,14 +31,14 @@ describe('eachMonthOfInterval', function() {
       new Date(2014, 4 /* May */, 1),
       new Date(2014, 5 /* Jun */, 1),
       new Date(2014, 6 /* Jul */, 1),
-      new Date(2014, 7 /* Aug */, 1)
+      new Date(2014, 7 /* Aug */, 1),
     ])
   })
 
-  it('handles the dates that are not starts of days', function() {
+  it('handles the dates that are not starts of days', function () {
     const result = eachMonthOfInterval({
       start: new Date(2014, 2 /* Mar */, 6, 6, 35),
-      end: new Date(2014, 7 /* Aug */, 12, 22, 15)
+      end: new Date(2014, 7 /* Aug */, 12, 22, 15),
     })
     assert.deepEqual(result, [
       new Date(2014, 2 /* Mar */, 1),
@@ -46,14 +46,14 @@ describe('eachMonthOfInterval', function() {
       new Date(2014, 4 /* May */, 1),
       new Date(2014, 5 /* Jun */, 1),
       new Date(2014, 6 /* Jul */, 1),
-      new Date(2014, 7 /* Aug */, 1)
+      new Date(2014, 7 /* Aug */, 1),
     ])
   })
 
-  it('handles the dates that are not containing days', function() {
+  it('handles the dates that are not containing days', function () {
     const result = eachMonthOfInterval({
       start: new Date(2014, 2 /* Mar */),
-      end: new Date(2014, 7 /* Aug */)
+      end: new Date(2014, 7 /* Aug */),
     })
     assert.deepEqual(result, [
       new Date(2014, 2 /* Mar */, 1),
@@ -61,60 +61,61 @@ describe('eachMonthOfInterval', function() {
       new Date(2014, 4 /* May */, 1),
       new Date(2014, 5 /* Jun */, 1),
       new Date(2014, 6 /* Jul */, 1),
-      new Date(2014, 7 /* Aug */, 1)
+      new Date(2014, 7 /* Aug */, 1),
     ])
   })
 
-  it('returns one month if the both arguments are on the same month', function() {
+  it('returns one month if the both arguments are on the same month', function () {
     const result = eachMonthOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 9, 15)
+      end: new Date(2014, 9 /* Oct */, 9, 15),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 1)])
   })
 
-  it('returns one month if the both arguments are the same', function() {
+  it('returns one month if the both arguments are the same', function () {
     const result = eachMonthOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 6, 14)
+      end: new Date(2014, 9 /* Oct */, 6, 14),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 1)])
   })
 
-  it('throws an exception if the start date is after the end date', function() {
+  it('throws an exception if the start date is after the end date', function () {
     const block = eachMonthOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the start date is `Invalid Date`', function() {
+  it('throws an exception if the start date is `Invalid Date`', function () {
     const block = eachMonthOfInterval.bind(null, {
       start: new Date(NaN),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the end date is `Invalid Date`', function() {
+  it('throws an exception if the end date is `Invalid Date`', function () {
     const block = eachMonthOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(NaN)
+      end: new Date(NaN),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the interval is undefined', function() {
+  it('throws an exception if the interval is undefined', function () {
     const block = eachMonthOfInterval.bind(
       null,
-      // $ExpectedMistake
+      // @ts-expect-error
       undefined
     )
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 1 argument', function() {
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    // @ts-expect-error
     assert.throws(eachMonthOfInterval.bind(null), TypeError)
   })
 })

--- a/src/eachQuarterOfInterval/test.ts
+++ b/src/eachQuarterOfInterval/test.ts
@@ -4,105 +4,106 @@
 import assert from 'assert'
 import eachQuarterOfInterval from '.'
 
-describe('eachQuarterOfInterval', function() {
-  it('returns an array with starts of quarters from the quarter of the start date to the quarter of the end date', function() {
+describe('eachQuarterOfInterval', function () {
+  it('returns an array with starts of quarters from the quarter of the start date to the quarter of the end date', function () {
     const result = eachQuarterOfInterval({
       start: new Date(2014, 2 /* Mar */, 6),
-      end: new Date(2014, 7 /* Aug */, 12)
+      end: new Date(2014, 7 /* Aug */, 12),
     })
     assert.deepEqual(result, [
       new Date(2014, 0 /* Jan */, 1),
       new Date(2014, 3 /* Apr */, 1),
-      new Date(2014, 6 /* Jul */, 1)
+      new Date(2014, 6 /* Jul */, 1),
     ])
   })
 
-  it('accepts timestamps', function() {
+  it('accepts timestamps', function () {
     const result = eachQuarterOfInterval({
       start: new Date(2014, 2 /* Mar */, 6).getTime(),
-      end: new Date(2014, 7 /* Aug */, 12).getTime()
+      end: new Date(2014, 7 /* Aug */, 12).getTime(),
     })
     assert.deepEqual(result, [
       new Date(2014, 0 /* Jan */, 1),
       new Date(2014, 3 /* Apr */, 1),
-      new Date(2014, 6 /* Jul */, 1)
+      new Date(2014, 6 /* Jul */, 1),
     ])
   })
 
-  it('handles the dates that are not starts of days', function() {
+  it('handles the dates that are not starts of days', function () {
     const result = eachQuarterOfInterval({
       start: new Date(2014, 2 /* Mar */, 6, 6, 35),
-      end: new Date(2014, 7 /* Aug */, 12, 22, 15)
+      end: new Date(2014, 7 /* Aug */, 12, 22, 15),
     })
     assert.deepEqual(result, [
       new Date(2014, 0 /* Jan */, 1),
       new Date(2014, 3 /* Apr */, 1),
-      new Date(2014, 6 /* Jul */, 1)
+      new Date(2014, 6 /* Jul */, 1),
     ])
   })
 
-  it('handles the dates that are not containing days', function() {
+  it('handles the dates that are not containing days', function () {
     const result = eachQuarterOfInterval({
       start: new Date(2014, 2 /* Mar */),
-      end: new Date(2014, 7 /* Oct */)
+      end: new Date(2014, 7 /* Oct */),
     })
     assert.deepEqual(result, [
       new Date(2014, 0 /* Jan */, 1),
       new Date(2014, 3 /* Apr */, 1),
-      new Date(2014, 6 /* Jul */, 1)
+      new Date(2014, 6 /* Jul */, 1),
     ])
   })
 
-  it('returns one quarter if the both arguments are on the same quarter', function() {
+  it('returns one quarter if the both arguments are on the same quarter', function () {
     const result = eachQuarterOfInterval({
       start: new Date(2014, 0 /* Jan */, 6, 14),
-      end: new Date(2014, 2 /* Feb */, 9, 15)
+      end: new Date(2014, 2 /* Feb */, 9, 15),
     })
     assert.deepEqual(result, [new Date(2014, 0 /* Jan */, 1)])
   })
 
-  it('returns one quarter if the both arguments are the same', function() {
+  it('returns one quarter if the both arguments are the same', function () {
     const result = eachQuarterOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 6, 14)
+      end: new Date(2014, 9 /* Oct */, 6, 14),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 1)])
   })
 
-  it('throws an exception if the start date is after the end date', function() {
+  it('throws an exception if the start date is after the end date', function () {
     const block = eachQuarterOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the start date is `Invalid Date`', function() {
+  it('throws an exception if the start date is `Invalid Date`', function () {
     const block = eachQuarterOfInterval.bind(null, {
       start: new Date(NaN),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the end date is `Invalid Date`', function() {
+  it('throws an exception if the end date is `Invalid Date`', function () {
     const block = eachQuarterOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(NaN)
+      end: new Date(NaN),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the interval is undefined', function() {
+  it('throws an exception if the interval is undefined', function () {
     const block = eachQuarterOfInterval.bind(
       null,
-      // $ExpectedMistake
+      // @ts-expect-error
       undefined
     )
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 1 argument', function() {
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    // @ts-expect-error
     assert.throws(eachQuarterOfInterval.bind(null), TypeError)
   })
 })

--- a/src/eachWeekOfInterval/test.ts
+++ b/src/eachWeekOfInterval/test.ts
@@ -4,11 +4,11 @@
 import assert from 'assert'
 import eachWeekOfInterval from '.'
 
-describe('eachWeekOfInterval', function() {
-  it('returns an array with starts of weeks from the week of the start date to the week of the end date', function() {
+describe('eachWeekOfInterval', function () {
+  it('returns an array with starts of weeks from the week of the start date to the week of the end date', function () {
     const result = eachWeekOfInterval({
       start: new Date(2014, 9 /* Oct */, 6),
-      end: new Date(2014, 10 /* Nov */, 23)
+      end: new Date(2014, 10 /* Nov */, 23),
     })
     assert.deepEqual(result, [
       new Date(2014, 9 /* Oct */, 5),
@@ -18,14 +18,14 @@ describe('eachWeekOfInterval', function() {
       new Date(2014, 10 /* Nov */, 2),
       new Date(2014, 10 /* Nov */, 9),
       new Date(2014, 10 /* Nov */, 16),
-      new Date(2014, 10 /* Nov */, 23)
+      new Date(2014, 10 /* Nov */, 23),
     ])
   })
 
-  it('accepts timestamps', function() {
+  it('accepts timestamps', function () {
     const result = eachWeekOfInterval({
       start: new Date(2014, 9 /* Oct */, 6).getTime(),
-      end: new Date(2014, 10 /* Nov */, 23).getTime()
+      end: new Date(2014, 10 /* Nov */, 23).getTime(),
     })
     assert.deepEqual(result, [
       new Date(2014, 9 /* Oct */, 5),
@@ -35,14 +35,14 @@ describe('eachWeekOfInterval', function() {
       new Date(2014, 10 /* Nov */, 2),
       new Date(2014, 10 /* Nov */, 9),
       new Date(2014, 10 /* Nov */, 16),
-      new Date(2014, 10 /* Nov */, 23)
+      new Date(2014, 10 /* Nov */, 23),
     ])
   })
 
-  it('handles the dates that are not starts/ends of days and weeks', function() {
+  it('handles the dates that are not starts/ends of days and weeks', function () {
     const result = eachWeekOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 6, 35),
-      end: new Date(2014, 10 /* Nov */, 25, 22, 16)
+      end: new Date(2014, 10 /* Nov */, 25, 22, 16),
     })
     assert.deepEqual(result, [
       new Date(2014, 9 /* Oct */, 5),
@@ -52,15 +52,15 @@ describe('eachWeekOfInterval', function() {
       new Date(2014, 10 /* Nov */, 2),
       new Date(2014, 10 /* Nov */, 9),
       new Date(2014, 10 /* Nov */, 16),
-      new Date(2014, 10 /* Nov */, 23)
+      new Date(2014, 10 /* Nov */, 23),
     ])
   })
 
-  it('considers the weekStartsOn option', function() {
+  it('considers the weekStartsOn option', function () {
     const result = eachWeekOfInterval(
       {
         start: new Date(2014, 9 /* Oct */, 6, 6, 35),
-        end: new Date(2014, 10 /* Nov */, 25, 22, 15)
+        end: new Date(2014, 10 /* Nov */, 25, 22, 15),
       },
       { weekStartsOn: 2 }
     )
@@ -73,73 +73,71 @@ describe('eachWeekOfInterval', function() {
       new Date(2014, 10 /* Nov */, 4),
       new Date(2014, 10 /* Nov */, 11),
       new Date(2014, 10 /* Nov */, 18),
-      new Date(2014, 10 /* Nov */, 25)
+      new Date(2014, 10 /* Nov */, 25),
     ])
   })
 
-  it('returns one week if the both arguments are on the same week', function() {
+  it('returns one week if the both arguments are on the same week', function () {
     const result = eachWeekOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 8, 15)
+      end: new Date(2014, 9 /* Oct */, 8, 15),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 5)])
   })
 
-  it('returns one day if the both arguments are the same', function() {
+  it('returns one day if the both arguments are the same', function () {
     const result = eachWeekOfInterval({
       start: new Date(2014, 9 /* Oct */, 6, 14),
-      end: new Date(2014, 9 /* Oct */, 6, 14)
+      end: new Date(2014, 9 /* Oct */, 6, 14),
     })
     assert.deepEqual(result, [new Date(2014, 9 /* Oct */, 5)])
   })
 
-  it('throws an exception if the start date is after the end date', function() {
+  it('throws an exception if the start date is after the end date', function () {
     const block = eachWeekOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the start date is `Invalid Date`', function() {
+  it('throws an exception if the start date is `Invalid Date`', function () {
     const block = eachWeekOfInterval.bind(null, {
       start: new Date(NaN),
-      end: new Date(2014, 9 /* Oct */, 6)
+      end: new Date(2014, 9 /* Oct */, 6),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the end date is `Invalid Date`', function() {
+  it('throws an exception if the end date is `Invalid Date`', function () {
     const block = eachWeekOfInterval.bind(null, {
       start: new Date(2014, 9 /* Oct */, 12),
-      end: new Date(NaN)
+      end: new Date(NaN),
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws an exception if the interval is undefined', function() {
-    const block = eachWeekOfInterval.bind(
-      null,
-      // $ExpectedMistake
-      undefined
-    )
+  it('throws an exception if the interval is undefined', function () {
+    // @ts-expect-error
+    const block = eachWeekOfInterval.bind(null, undefined)
     assert.throws(block, RangeError)
   })
 
-  it('throws `RangeError` if `options.weekStartsOn` is not convertible to 0, 1, ..., 6 or undefined', function() {
+  it('throws `RangeError` if `options.weekStartsOn` is not convertible to 0, 1, ..., 6 or undefined', function () {
+    // @ts-expect-error
     const block = eachWeekOfInterval.bind(
       null,
       {
         start: new Date(2014, 9 /* Oct */, 6, 6, 35),
-        end: new Date(2014, 10 /* Nov */, 25, 22, 15)
+        end: new Date(2014, 10 /* Nov */, 25, 22, 15),
       },
-      // $ExpectedMistake
       { weekStartsOn: NaN }
     )
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 1 argument', function() {
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    // @ts-expect-error
     assert.throws(eachWeekOfInterval.bind(null), TypeError)
   })
 })

--- a/src/eachWeekendOfInterval/test.ts
+++ b/src/eachWeekendOfInterval/test.ts
@@ -8,26 +8,26 @@ describe('eachWeekendOfInterval', function () {
   it('returns all weekends within the interval', function () {
     const result = eachWeekendOfInterval({
       start: new Date(2018, 8 /* Sept */, 17),
-      end: new Date(2018, 8 /* Sept */, 30)
+      end: new Date(2018, 8 /* Sept */, 30),
     })
     assert.deepEqual(result, [
       new Date(2018, 8 /* Sept */, 22),
       new Date(2018, 8 /* Sept */, 23),
       new Date(2018, 8 /* Sept */, 29),
-      new Date(2018, 8 /* Sept */, 30)
+      new Date(2018, 8 /* Sept */, 30),
     ])
   })
 
   it('returns all weekends within the interval when starting on a weekend', function () {
     const result = eachWeekendOfInterval({
       start: new Date(2018, 8 /* Sept */, 22),
-      end: new Date(2018, 8 /* Sept */, 30)
+      end: new Date(2018, 8 /* Sept */, 30),
     })
     assert.deepEqual(result, [
       new Date(2018, 8 /* Sept */, 22),
       new Date(2018, 8 /* Sept */, 23),
       new Date(2018, 8 /* Sept */, 29),
-      new Date(2018, 8 /* Sept */, 30)
+      new Date(2018, 8 /* Sept */, 30),
     ])
   })
 
@@ -35,7 +35,7 @@ describe('eachWeekendOfInterval', function () {
     // $ExpectedMistake
     const block = eachWeekendOfInterval.bind(null, {
       start: new Date(NaN),
-      end: new Date(2019, 11 /* Dec */, 31)
+      end: new Date(2019, 11 /* Dec */, 31),
     })
     assert.throws(block, RangeError)
   })
@@ -44,12 +44,13 @@ describe('eachWeekendOfInterval', function () {
     // $ExpectedMistake
     const block = eachWeekendOfInterval.bind(null, {
       start: new Date(2019, 0 /* Jan */, 1),
-      end: new Date(NaN)
+      end: new Date(NaN),
     })
     assert.throws(block, RangeError)
   })
 
   it('throws TypeError exception if passed less than 1 argument', function () {
+    // @ts-expect-error
     assert.throws(eachWeekendOfInterval, TypeError)
   })
 
@@ -59,7 +60,7 @@ describe('eachWeekendOfInterval', function () {
       // $ExpectedMistake
       {
         start: new Date(2018, 8 /* Sept */, 25),
-        end: new Date(2018, 8 /* Sept */, 6)
+        end: new Date(2018, 8 /* Sept */, 6),
       }
     )
     assert.throws(block, RangeError)

--- a/src/formatDistance/test.ts
+++ b/src/formatDistance/test.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import assert from 'assert'
+import { Locale } from 'src/locale/types'
 import formatDistance from '.'
 
 describe('formatDistance', function () {
@@ -236,22 +237,24 @@ describe('formatDistance', function () {
 
   describe('custom locale', function () {
     it('can be passed to the function', function () {
-      function localizeDistance(token, count, options) {
-        assert(token === 'lessThanXSeconds')
-        assert(count === 5)
-        assert(options.addSuffix === true)
-        assert(options.comparison > 0)
-        return 'It works!'
-      }
-
-      const customLocale = {
-        formatDistance: localizeDistance,
+      const customLocale: Locale = {
+        formatDistance: (token, count, options) => {
+          assert(token === 'lessThanXSeconds')
+          assert(count === 5)
+          assert(options?.addSuffix === true)
+          assert(options.comparison && options.comparison > 0)
+          return 'It works!'
+        },
       }
 
       const result = formatDistance(
         new Date(1986, 3, 4, 10, 32, 3),
         new Date(1986, 3, 4, 10, 32, 0),
-        { includeSeconds: true, addSuffix: true, locale: customLocale }
+        {
+          includeSeconds: true,
+          addSuffix: true,
+          locale: customLocale,
+        }
       )
 
       assert(result === 'It works!')
@@ -260,6 +263,8 @@ describe('formatDistance', function () {
     describe('does not contain `formatDistance` property', function () {
       it('throws `RangeError`', function () {
         const customLocale = {}
+
+        // @ts-expect-error
         const block = formatDistance.bind(
           null,
           new Date(1986, 3, 4, 10, 32, 0),
@@ -293,7 +298,10 @@ describe('formatDistance', function () {
   })
 
   it('throws TypeError exception if passed less than 2 arguments', function () {
+    // @ts-expect-error
     assert.throws(formatDistance.bind(null), TypeError)
+
+    // @ts-expect-error
     assert.throws(formatDistance.bind(null, 1), TypeError)
   })
 })

--- a/src/getWeek/test.ts
+++ b/src/getWeek/test.ts
@@ -29,11 +29,11 @@ describe('getWeek', function () {
 
   it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in locale', function () {
     const date = new Date(2005, 0 /* Jan */, 2)
-    // @ts-expect-error
     const result = getWeek(date, {
+      // @ts-expect-error
       locale: {
-        options: { weekStartsOn: 1, firstWeekContainsDate: 4 }
-      }
+        options: { weekStartsOn: 1, firstWeekContainsDate: 4 },
+      },
     })
     assert(result === 53)
   })
@@ -43,10 +43,10 @@ describe('getWeek', function () {
     const result = getWeek(date, {
       weekStartsOn: 1,
       firstWeekContainsDate: 4,
-      // $ExpectedMistake
+      // @ts-expect-error
       locale: {
-        options: { weekStartsOn: 0, firstWeekContainsDate: 1 }
-      }
+        options: { weekStartsOn: 0, firstWeekContainsDate: 1 },
+      },
     })
     assert(result === 53)
   })
@@ -54,7 +54,7 @@ describe('getWeek', function () {
   it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
     // @ts-expect-error
     const block = getWeek.bind(null, new Date(2007, 11 /* Dec */, 31), {
-      weekStartsOn: NaN
+      weekStartsOn: NaN,
     })
     assert.throws(block, RangeError)
   })
@@ -62,7 +62,7 @@ describe('getWeek', function () {
   it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function () {
     // @ts-expect-error
     const block = getWeek.bind(null, new Date(2007, 11 /* Dec */, 31), {
-      firstWeekContainsDate: NaN
+      firstWeekContainsDate: NaN,
     })
     assert.throws(block, RangeError)
   })

--- a/src/getWeeksInMonth/test.ts
+++ b/src/getWeeksInMonth/test.ts
@@ -3,59 +3,60 @@
 import assert from 'assert'
 import getWeeksInMonth from '.'
 
-describe('getWeeksInMonth', function() {
-  it('returns the number of calendar weeks the month in the given date spans', function() {
+describe('getWeeksInMonth', function () {
+  it('returns the number of calendar weeks the month in the given date spans', function () {
     const result = getWeeksInMonth(new Date(2015, 1 /* Feb */, 8, 18, 0))
     assert(result === 4)
   })
 
-  it('allows to specify which day is the first day of the week', function() {
+  it('allows to specify which day is the first day of the week', function () {
     const result = getWeeksInMonth(new Date(2015, 1 /* Feb */, 8, 18, 0), {
-      weekStartsOn: 1
+      weekStartsOn: 1,
     })
     assert(result === 5)
   })
 
-  it('allows to specify which day is the first day of the week in locale', function() {
+  it('allows to specify which day is the first day of the week in locale', function () {
     const result = getWeeksInMonth(new Date(2015, 1 /* Feb */, 8, 18, 0), {
       // @ts-expect-error
       locale: {
-        options: { weekStartsOn: 1 }
-      }
+        options: { weekStartsOn: 1 },
+      },
     })
     assert(result === 5)
   })
 
-  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function() {
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
     const result = getWeeksInMonth(new Date(2015, 1 /* Feb */, 8, 18, 0), {
       weekStartsOn: 1,
       // @ts-expect-error
       locale: {
-        options: { weekStartsOn: 0 }
-      }
+        options: { weekStartsOn: 0 },
+      },
     })
     assert(result === 5)
   })
 
-  it('accepts timestamps', function() {
+  it('accepts timestamps', function () {
     const result = getWeeksInMonth(
       new Date(2017, 3 /* Apr */, 8, 18, 0).getTime()
     )
     assert(result === 6)
   })
 
-  it('does not mutate the original date', function() {
+  it('does not mutate the original date', function () {
     const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0)
     getWeeksInMonth(date)
     assert.deepStrictEqual(date, new Date(2014, 8 /* Sep */, 2, 11, 55, 0))
   })
 
-  it('returns NaN if the date is `Invalid Date`', function() {
+  it('returns NaN if the date is `Invalid Date`', function () {
     const result = getWeeksInMonth(new Date(NaN))
     assert(isNaN(result))
   })
 
-  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // @ts-expect-error
     const block = getWeeksInMonth.bind(
       null,
       new Date(2014, 6 /* Jul */, 8, 18, 0),
@@ -64,7 +65,7 @@ describe('getWeeksInMonth', function() {
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 1 argument', function() {
+  it('throws TypeError exception if passed less than 1 argument', function () {
     // @ts-expect-error
     assert.throws(getWeeksInMonth.bind(null), TypeError)
   })

--- a/src/intlFormat/test.ts
+++ b/src/intlFormat/test.ts
@@ -49,7 +49,7 @@ describe('intlFormat', () => {
 
     fullICUOnly("should work with only format's options", function () {
       const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
-      const formatOptions = {
+      const formatOptions: Intl.DateTimeFormatOptions = {
         year: 'numeric',
         month: 'numeric',
         day: 'numeric',
@@ -84,7 +84,7 @@ describe('intlFormat', () => {
       "should work with format's options and locale's options",
       function () {
         const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
-        const formatOptions = {
+        const formatOptions: Intl.DateTimeFormatOptions = {
           weekday: 'long',
           year: 'numeric',
           month: 'long',

--- a/src/isSameWeek/test.ts
+++ b/src/isSameWeek/test.ts
@@ -4,8 +4,8 @@
 import assert from 'power-assert'
 import isSameWeek from '.'
 
-describe('isSameWeek', function() {
-  it('returns true if the given dates have the same week', function() {
+describe('isSameWeek', function () {
+  it('returns true if the given dates have the same week', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 31),
       new Date(2014, 8 /* Sep */, 4)
@@ -13,7 +13,7 @@ describe('isSameWeek', function() {
     assert(result === true)
   })
 
-  it('returns false if the given dates have different weeks', function() {
+  it('returns false if the given dates have different weeks', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 30),
       new Date(2014, 8 /* Sep */, 4)
@@ -21,7 +21,7 @@ describe('isSameWeek', function() {
     assert(result === false)
   })
 
-  it('allows to specify which day is the first day of the week', function() {
+  it('allows to specify which day is the first day of the week', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 31),
       new Date(2014, 8 /* Sep */, 4),
@@ -30,21 +30,21 @@ describe('isSameWeek', function() {
     assert(result === false)
   })
 
-  it('allows to specify which day is the first day of the week in locale', function() {
+  it('allows to specify which day is the first day of the week in locale', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 31),
       new Date(2014, 8 /* Sep */, 4),
       {
         // @ts-expect-error
         locale: {
-          options: { weekStartsOn: 1 }
-        }
+          options: { weekStartsOn: 1 },
+        },
       }
     )
     assert(result === false)
   })
 
-  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function() {
+  it('`options.weekStartsOn` overwrites the first day of the week specified in locale', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 31),
       new Date(2014, 8 /* Sep */, 4),
@@ -52,14 +52,14 @@ describe('isSameWeek', function() {
         weekStartsOn: 1,
         // @ts-expect-error
         locale: {
-          options: { weekStartsOn: 0 }
-        }
+          options: { weekStartsOn: 0 },
+        },
       }
     )
     assert(result === false)
   })
 
-  it('implicitly converts options', function() {
+  it('implicitly converts options', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 31),
       new Date(2014, 8 /* Sep */, 4),
@@ -69,7 +69,7 @@ describe('isSameWeek', function() {
     assert(result === false)
   })
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     const result = isSameWeek(
       new Date(2014, 7 /* Aug */, 31).getTime(),
       new Date(2014, 8 /* Sep */, 4).getTime()
@@ -77,22 +77,23 @@ describe('isSameWeek', function() {
     assert(result === true)
   })
 
-  it('returns false if the first date is `Invalid Date`', function() {
+  it('returns false if the first date is `Invalid Date`', function () {
     const result = isSameWeek(new Date(NaN), new Date(1989, 6 /* Jul */, 10))
     assert(result === false)
   })
 
-  it('returns false if the second date is `Invalid Date`', function() {
+  it('returns false if the second date is `Invalid Date`', function () {
     const result = isSameWeek(new Date(1987, 1 /* Feb */, 11), new Date(NaN))
     assert(result === false)
   })
 
-  it('returns false if the both dates are `Invalid Date`', function() {
+  it('returns false if the both dates are `Invalid Date`', function () {
     const result = isSameWeek(new Date(NaN), new Date(NaN))
     assert(result === false)
   })
 
-  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // @ts-expect-error
     const block = isSameWeek.bind(
       null,
       new Date(2014, 7 /* Aug */, 31),
@@ -102,7 +103,7 @@ describe('isSameWeek', function() {
     assert.throws(block, RangeError)
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(isSameWeek.bind(null), TypeError)
     assert.throws(isSameWeek.bind(null, 1), TypeError)
   })

--- a/src/isThisISOWeek/test.ts
+++ b/src/isThisISOWeek/test.ts
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import isThisISOWeek from '.'
 
 describe('isSameISOWeek', () => {
-  let clock
+  let clock: sinon.SinonFakeTimers
   beforeEach(() => {
     clock = sinon.useFakeTimers(new Date(2014, 8 /* Sep */, 25).getTime())
   })
@@ -30,7 +30,8 @@ describe('isSameISOWeek', () => {
     assert(isThisISOWeek(date) === false)
   })
 
-  it('throws TypeError exception if passed less than 1 argument', function() {
+  it('throws TypeError exception if passed less than 1 argument', function () {
+    // @ts-expect-error
     assert.throws(isThisISOWeek.bind(null), TypeError)
   })
 })

--- a/src/lastDayOfWeek/test.ts
+++ b/src/lastDayOfWeek/test.ts
@@ -97,6 +97,7 @@ describe('lastDayOfWeek', function () {
   })
 
   it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
+    // @ts-expect-error
     const block = lastDayOfWeek.bind(
       null,
       new Date(2014, 8 /* Sep */, 2, 11, 55, 0),

--- a/src/setDayOfYear/test.ts
+++ b/src/setDayOfYear/test.ts
@@ -4,46 +4,48 @@
 import assert from 'power-assert'
 import setDayOfYear from '.'
 
-describe('setDayOfYear', function() {
-  it('sets the day of the year', function() {
+describe('setDayOfYear', function () {
+  it('sets the day of the year', function () {
     const result = setDayOfYear(new Date(2014, 6 /* Jul */, 2), 2)
     assert.deepEqual(result, new Date(2014, 0 /* Jan */, 2))
   })
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     const result = setDayOfYear(new Date(2014, 6 /* Jul */, 2).getTime(), 60)
     assert.deepEqual(result, new Date(2014, 2 /* Mar */, 1))
   })
 
-  it('converts a fractional number to an integer', function() {
+  it('converts a fractional number to an integer', function () {
     const result = setDayOfYear(new Date(2014, 6 /* Jul */, 2), 2.75)
     assert.deepEqual(result, new Date(2014, 0 /* Jan */, 2))
   })
 
-  it('implicitly converts number arguments', function() {
+  it('implicitly converts number arguments', function () {
     // $ExpectedMistake
     // @ts-expect-error
     const result = setDayOfYear(new Date(2014, 6 /* Jul */, 2), '2')
     assert.deepEqual(result, new Date(2014, 0 /* Jan */, 2))
   })
 
-  it('does not mutate the original date', function() {
+  it('does not mutate the original date', function () {
     const date = new Date(2014, 6 /* Jul */, 2)
     setDayOfYear(date, 365)
     assert.deepEqual(date, new Date(2014, 6 /* Jul */, 2))
   })
 
-  it('returns `Invalid Date` if the given date is invalid', function() {
+  it('returns `Invalid Date` if the given date is invalid', function () {
     const result = setDayOfYear(new Date(NaN), 2)
+    // @ts-expect-error
     assert(result instanceof Date && isNaN(result))
   })
 
-  it('returns `Invalid Date` if the given amount is NaN', function() {
+  it('returns `Invalid Date` if the given amount is NaN', function () {
     const result = setDayOfYear(new Date(2014, 6 /* Jul */, 2), NaN)
+    // @ts-expect-error
     assert(result instanceof Date && isNaN(result))
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(setDayOfYear.bind(null), TypeError)
     assert.throws(setDayOfYear.bind(null, 1), TypeError)
   })

--- a/src/startOfToday/test.ts
+++ b/src/startOfToday/test.ts
@@ -5,19 +5,19 @@ import assert from 'power-assert'
 import sinon from 'sinon'
 import startOfToday from '.'
 
-describe('startOfToday', function() {
-  let clock
-  beforeEach(function() {
+describe('startOfToday', function () {
+  let clock: sinon.SinonFakeTimers
+  beforeEach(function () {
     clock = sinon.useFakeTimers(
       new Date(2014, 8 /* Sep */, 25, 14, 30, 45, 500).getTime()
     )
   })
 
-  afterEach(function() {
+  afterEach(function () {
     clock.restore()
   })
 
-  it('returns the current date with the time setted to 00:00:00', function() {
+  it('returns the current date with the time setted to 00:00:00', function () {
     var result = startOfToday()
     assert.deepEqual(result, new Date(2014, 8 /* Sep */, 25))
   })

--- a/src/subISOWeekYears/test.ts
+++ b/src/subISOWeekYears/test.ts
@@ -4,35 +4,35 @@
 import assert from 'power-assert'
 import subISOWeekYears from '.'
 
-describe('subISOWeekYears', function() {
-  it('subtracts the given number of ISO week-numbering years', function() {
+describe('subISOWeekYears', function () {
+  it('subtracts the given number of ISO week-numbering years', function () {
     const result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1), 5)
     assert.deepEqual(result, new Date(2009, 7 /* Aug */, 31))
   })
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     const result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1).getTime(), 12)
     assert.deepEqual(result, new Date(2002, 8 /* Sep */, 2))
   })
 
-  it('converts a fractional number to an integer', function() {
+  it('converts a fractional number to an integer', function () {
     const result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1), 5.555)
     assert.deepEqual(result, new Date(2009, 7 /* Aug */, 31))
   })
 
-  it('implicitly converts number arguments', function() {
-    // $ExpectedMistake
+  it('implicitly converts number arguments', function () {
+    // @ts-expect-error
     const result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1), '5')
     assert.deepEqual(result, new Date(2009, 7 /* Aug */, 31))
   })
 
-  it('does not mutate the original date', function() {
+  it('does not mutate the original date', function () {
     const date = new Date(2014, 8 /* Sep */, 1)
     subISOWeekYears(date, 12)
     assert.deepEqual(date, new Date(2014, 8 /* Sep */, 1))
   })
 
-  it('handles dates before 100 AD', function() {
+  it('handles dates before 100 AD', function () {
     const initialDate = new Date(0)
     initialDate.setFullYear(15, 5 /* Jun */, 26)
     initialDate.setHours(0, 0, 0, 0)
@@ -43,19 +43,19 @@ describe('subISOWeekYears', function() {
     assert.deepEqual(result, expectedResult)
   })
 
-  it('returns `Invalid Date` if the given date is invalid', function() {
+  it('returns `Invalid Date` if the given date is invalid', function () {
     const result = subISOWeekYears(new Date(NaN), 5)
     // @ts-expect-error
     assert(result instanceof Date && isNaN(result))
   })
 
-  it('returns `Invalid Date` if the given amount is NaN', function() {
+  it('returns `Invalid Date` if the given amount is NaN', function () {
     const result = subISOWeekYears(new Date(2014, 8 /* Sep */, 1), NaN)
     // @ts-expect-error
     assert(result instanceof Date && isNaN(result))
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(subISOWeekYears.bind(null), TypeError)
     assert.throws(subISOWeekYears.bind(null, 1), TypeError)
   })

--- a/src/subMinutes/test.ts
+++ b/src/subMinutes/test.ts
@@ -4,13 +4,13 @@
 import assert from 'power-assert'
 import subMinutes from '.'
 
-describe('subMinutes', function() {
-  it('subtracts the given number of minutes', function() {
+describe('subMinutes', function () {
+  it('subtracts the given number of minutes', function () {
     const result = subMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), 30)
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 11, 30))
   })
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     const result = subMinutes(
       new Date(2014, 6 /* Jul */, 10, 12, 0).getTime(),
       20
@@ -18,36 +18,36 @@ describe('subMinutes', function() {
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 11, 40))
   })
 
-  it('converts a fractional number to an integer', function() {
+  it('converts a fractional number to an integer', function () {
     const result = subMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), 30.4)
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 11, 30))
   })
 
-  it('implicitly converts number arguments', function() {
-    // $ExpectedMistake
+  it('implicitly converts number arguments', function () {
+    // @ts-expect-error
     const result = subMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), '30')
     assert.deepEqual(result, new Date(2014, 6 /* Jul */, 10, 11, 30))
   })
 
-  it('does not mutate the original date', function() {
+  it('does not mutate the original date', function () {
     const date = new Date(2014, 6 /* Jul */, 10, 12, 0)
     subMinutes(date, 25)
     assert.deepEqual(date, new Date(2014, 6 /* Jul */, 10, 12, 0))
   })
 
-  it('returns `Invalid Date` if the given date is invalid', function() {
+  it('returns `Invalid Date` if the given date is invalid', function () {
     const result = subMinutes(new Date(NaN), 30)
     // @ts-expect-error
     assert(result instanceof Date && isNaN(result))
   })
 
-  it('returns `Invalid Date` if the given amount is NaN', function() {
+  it('returns `Invalid Date` if the given amount is NaN', function () {
     const result = subMinutes(new Date(2014, 6 /* Jul */, 10, 12, 0), NaN)
     // @ts-expect-error
     assert(result instanceof Date && isNaN(result))
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(subMinutes.bind(null), TypeError)
     assert.throws(subMinutes.bind(null, 1), TypeError)
   })

--- a/src/toDate/test.ts
+++ b/src/toDate/test.ts
@@ -42,8 +42,8 @@ describe('toDate', () => {
       // @ts-expect-error
       toDate('1987-02-11')
       assert(
-        // eslint-disable-next-line no-console
         // @ts-expect-error
+        // eslint-disable-next-line no-console
         console.warn.calledWith(
           "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
         )
@@ -120,7 +120,7 @@ describe('toDate', () => {
 })
 
 function mockConsoleWarn() {
-  let originalWarn
+  let originalWarn: any
 
   beforeEach(() => {
     originalWarn = console.warn // eslint-disable-line no-console
@@ -129,8 +129,6 @@ function mockConsoleWarn() {
   })
 
   afterEach(() => {
-    // $ExpectedMistake
-    // @ts-expect-error
     console.warn = originalWarn // eslint-disable-line no-console
   })
 }


### PR DESCRIPTION
This PR lowers the error count of the `yarn tsc --noEmit` command from 54 to 16 (all from test.ts files).

14 of the remaining 16 errors are caused by `lint-staged v7`'s dependency tree bringing in `date-fns` itself: `lint-staged -> listr -> listr-verbose-renderer -> date-fns:"^1.27.2"`. The duplicate type definitions clash with the project's `typings.d.ts`. Could that also be potentially dangerous? (ex: accidental wrong import path in a unit test might silently run against an older version of the library)

I can think of two approaches to resolve this, would love to get feedback so I can put together a follow-up PR. I tend to prefer the first one.

1. Bump `lint-staged` to the latest version, which would get rid of that `date-fns` nested dependency altogether
2. Add `skipLibCheck` to `tsconfig.json`. This could be suppressing important type feedback though, see https://www.typescriptlang.org/tsconfig#skipLibCheck
