### PR TITLE
Fix unescaped formating string in sk locale

### DIFF
--- a/src/locale/sk/_lib/formatRelative/index.js
+++ b/src/locale/sk/_lib/formatRelative/index.js
@@ -41,7 +41,7 @@ function nextWeek(day) {
     case 0: /* Sun */
     case 4: /* Wed */
     case 6 /* Sat */:
-      return "'budúcu' " + weekday + " 'o' p"
+      return "'budúcu " + weekday + " o' p"
     default:
       return "'budúci' eeee 'o' p"
   }


### PR DESCRIPTION
See #2083, there is an edge case formatting in the sk locale that can return an improperly escaped string and cause a runtime error.