### PR TITLE
Make `isValid` a type predicate

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -785,7 +785,7 @@ declare module 'date-fns' {
   function isTuesday(date: Date | number): boolean
   namespace isTuesday {}
 
-  function isValid(date: any): boolean
+  function isValid(date: any): date is Date
   namespace isValid {}
 
   function isWednesday(date: Date | number): boolean
@@ -9885,7 +9885,7 @@ declare module 'date-fns/esm' {
   function isTuesday(date: Date | number): boolean
   namespace isTuesday {}
 
-  function isValid(date: any): boolean
+  function isValid(date: any): date is Date
   namespace isValid {}
 
   function isWednesday(date: Date | number): boolean
@@ -21755,7 +21755,7 @@ interface dateFns {
 
   isTuesday(date: Date | number): boolean
 
-  isValid(date: any): boolean
+  isValid(date: any): date is Date
 
   isWednesday(date: Date | number): boolean
 


### PR DESCRIPTION
Simple change to help TS know the typing on the supplied argument in conditionals