### PR TITLE
ja i18n: use ヶ not か for month counts

### DIFF
--- a/src/locale/ja/_lib/formatDistance/index.js
+++ b/src/locale/ja/_lib/formatDistance/index.js
@@ -51,13 +51,13 @@ var formatDistanceLocale = {
   },
 
   aboutXMonths: {
-    one: '約1か月',
-    other: '約{{count}}か月'
+    one: '約1ヶ月',
+    other: '約{{count}}ヶ月'
   },
 
   xMonths: {
-    one: '1か月',
-    other: '{{count}}か月'
+    one: '1ヶ月',
+    other: '{{count}}ヶ月'
   },
 
   aboutXYears: {


### PR DESCRIPTION
While they're pronounced the same, when written Japanese month counts usually are written with the ヶ character, not the hiragana か. I checked with my native Japanese speaking wife, she says that while か isn't strictly wrong it's not what she would use naturally, and i've never seen it not written with ヶ in my time living in Japan.

https://en.wikipedia.org/wiki/Small_ke