### PR TITLE
remove unnecessary `toDate` call in next week day functions (`nextMonday`, etc)

### DIFF
--- a/src/nextFriday/index.ts
+++ b/src/nextFriday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextFriday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextFriday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 5)
+  return nextDay(date, 5)
 }

--- a/src/nextMonday/index.ts
+++ b/src/nextMonday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextMonday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextMonday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 1)
+  return nextDay(date, 1)
 }

--- a/src/nextSaturday/index.ts
+++ b/src/nextSaturday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextSaturday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextSaturday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 6)
+  return nextDay(date, 6)
 }

--- a/src/nextSunday/index.ts
+++ b/src/nextSunday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextSunday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextSunday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 0)
+  return nextDay(date, 0)
 }

--- a/src/nextThursday/index.ts
+++ b/src/nextThursday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextThursday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextThursday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 4)
+  return nextDay(date, 4)
 }

--- a/src/nextTuesday/index.ts
+++ b/src/nextTuesday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextTuesday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextTuesday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 2)
+  return nextDay(date, 2)
 }

--- a/src/nextWednesday/index.ts
+++ b/src/nextWednesday/index.ts
@@ -1,6 +1,5 @@
-import requiredArgs from '../_lib/requiredArgs/index'
 import nextDay from '../nextDay/index'
-import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name nextWednesday
@@ -21,5 +20,5 @@ import toDate from '../toDate/index'
  */
 export default function nextWednesday(date: Date | number): Date {
   requiredArgs(1, arguments)
-  return nextDay(toDate(date), 3)
+  return nextDay(date, 3)
 }


### PR DESCRIPTION
As discussed https://github.com/date-fns/date-fns/pull/2522#issuecomment-890246854