### PR TITLE
Fix eachMinuteOfInterval interval validation

### DIFF
--- a/src/eachMinuteOfInterval/index.ts
+++ b/src/eachMinuteOfInterval/index.ts
@@ -42,7 +42,7 @@ export default function eachMinuteOfInterval(
   requiredArgs(1, arguments)
 
   const startDate = startOfMinute(toDate(interval.start))
-  const endDate = startOfMinute(toDate(interval.end))
+  const endDate = toDate(interval.end)
 
   const startTime = startDate.getTime()
   const endTime = endDate.getTime()

--- a/src/eachMinuteOfInterval/test.ts
+++ b/src/eachMinuteOfInterval/test.ts
@@ -56,6 +56,14 @@ describe('eachMinuteOfInterval', () => {
     assert.throws(block, RangeError)
   })
 
+  it('treats intervals shorter than a minute as valid', () => {
+    const block = eachMinuteOfInterval.bind(null, {
+      start: new Date(2014, 10, 14, 10, 1, 0),
+      end: new Date(2014, 10, 14, 10, 1, 1),
+    })
+    assert.doesNotThrow(block, RangeError)
+  })
+
   describe('options.step', () => {
     const interval = {
       start: new Date(2020, 9, 14, 13, 1),


### PR DESCRIPTION
Allows eachMinuteOfInterval to use intervals shorter than a minute. Currently throws an `RangeError` if a one second long interval is given.