### PR TITLE
`intervalToDuration` fix for end of month calculations

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -1,14 +1,13 @@
-import compareAsc from '../compareAsc/index'
-import differenceInYears from '../differenceInYears/index'
-import differenceInMonths from '../differenceInMonths/index'
+import add from '../add/index'
 import differenceInDays from '../differenceInDays/index'
 import differenceInHours from '../differenceInHours/index'
 import differenceInMinutes from '../differenceInMinutes/index'
+import differenceInMonths from '../differenceInMonths/index'
 import differenceInSeconds from '../differenceInSeconds/index'
-import isValid from '../isValid/index'
-import requiredArgs from '../_lib/requiredArgs/index'
+import differenceInYears from '../differenceInYears/index'
 import toDate from '../toDate/index'
-import sub from '../sub/index'
+import { Duration, Interval } from '../types'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name intervalToDuration
@@ -24,6 +23,7 @@ import sub from '../sub/index'
  * @throws {TypeError} Requires 2 arguments
  * @throws {RangeError} `start` must not be Invalid Date
  * @throws {RangeError} `end` must not be Invalid Date
+ * @throws {RangeError} The start of an interval cannot be after its end
  *
  * @example
  * // Get the duration between January 15, 1929 and April 4, 1968.
@@ -33,49 +33,36 @@ import sub from '../sub/index'
  * })
  * // => { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
  */
-
-export default function intervalToDuration({ start, end }: Interval): Duration {
+export default function intervalToDuration(interval: Interval): Duration {
   requiredArgs(1, arguments)
 
-  const dateLeft = toDate(start)
-  const dateRight = toDate(end)
+  let start = toDate(interval.start)
+  let end = toDate(interval.end)
 
-  if (!isValid(dateLeft)) {
-    throw new RangeError('Start Date is invalid')
-  }
-  if (!isValid(dateRight)) {
-    throw new RangeError('End Date is invalid')
-  }
-
-  const duration = {
-    years: 0,
-    months: 0,
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
+  if (isNaN(start.getTime())) throw new RangeError('Start Date is invalid')
+  if (isNaN(end.getTime())) throw new RangeError('End Date is invalid')
+  if (start > end) {
+    throw new RangeError('The start of an interval cannot be after its end')
   }
 
-  const sign = compareAsc(dateLeft, dateRight)
+  const duration: Duration = {
+    years: differenceInYears(end, start),
+  }
 
-  duration.years = Math.abs(differenceInYears(dateLeft, dateRight))
+  const remainingMonths = add(start, { years: duration.years })
+  duration.months = differenceInMonths(end, remainingMonths)
 
-  const remainingMonths = sub(dateLeft, { years: sign * duration.years })
-  duration.months = Math.abs(differenceInMonths(remainingMonths, dateRight))
+  const remainingDays = add(remainingMonths, { months: duration.months })
+  duration.days = differenceInDays(end, remainingDays)
 
-  const remainingDays = sub(remainingMonths, { months: sign * duration.months })
-  duration.days = Math.abs(differenceInDays(remainingDays, dateRight))
+  const remainingHours = add(remainingDays, { days: duration.days })
+  duration.hours = differenceInHours(end, remainingHours)
 
-  const remainingHours = sub(remainingDays, { days: sign * duration.days })
-  duration.hours = Math.abs(differenceInHours(remainingHours, dateRight))
+  const remainingMinutes = add(remainingHours, { hours: duration.hours })
+  duration.minutes = differenceInMinutes(end, remainingMinutes)
 
-  const remainingMinutes = sub(remainingHours, { hours: sign * duration.hours })
-  duration.minutes = Math.abs(differenceInMinutes(remainingMinutes, dateRight))
-
-  const remainingSeconds = sub(remainingMinutes, {
-    minutes: sign * duration.minutes,
-  })
-  duration.seconds = Math.abs(differenceInSeconds(remainingSeconds, dateRight))
+  const remainingSeconds = add(remainingMinutes, { minutes: duration.minutes })
+  duration.seconds = differenceInSeconds(end, remainingSeconds)
 
   return duration
 }

--- a/src/intervalToDuration/test.ts
+++ b/src/intervalToDuration/test.ts
@@ -1,15 +1,16 @@
 /* eslint-env mocha */
 
-import assert from 'power-assert'
+import assert from 'assert'
 import intervalToDuration from '.'
+import addMonths from '../addMonths/index'
 
-describe('intervalToDuration', function () {
-  it('returns correct duration for arbitrary dates', function () {
+describe('intervalToDuration', () => {
+  it('returns correct duration for arbitrary dates', () => {
     const start = new Date(1929, 0, 15, 12, 0, 0)
     const end = new Date(1968, 3, 4, 19, 5, 0)
     const result = intervalToDuration({ start, end })
 
-    assert.deepEqual(result, {
+    assert.deepStrictEqual(result, {
       years: 39,
       months: 2,
       days: 20,
@@ -19,12 +20,12 @@ describe('intervalToDuration', function () {
     })
   })
 
-  it('returns correct duration (1 of everything)', function () {
+  it('returns correct duration (1 of everything)', () => {
     const start = new Date(2020, 2, 1, 12, 0, 0)
     const end = new Date(2021, 3, 2, 13, 1, 1)
     const result = intervalToDuration({ start, end })
 
-    assert.deepEqual(result, {
+    assert.deepStrictEqual(result, {
       years: 1,
       months: 1,
       days: 1,
@@ -34,12 +35,12 @@ describe('intervalToDuration', function () {
     })
   })
 
-  it('returns duration of 0 when the dates are the same', function () {
+  it('returns duration of 0 when the dates are the same', () => {
     const start = new Date(2020, 2, 1, 12, 0, 0)
     const end = new Date(2020, 2, 1, 12, 0, 0)
     const result = intervalToDuration({ start, end })
 
-    assert.deepEqual(result, {
+    assert.deepStrictEqual(result, {
       years: 0,
       months: 0,
       days: 0,
@@ -49,9 +50,36 @@ describe('intervalToDuration', function () {
     })
   })
 
-  describe('edge cases', function () {
-    it('returns correct duration for dates in the end of Feb - issue 2255', function () {
-      assert.deepEqual(
+  it("throws a RangeError if interval's start date is greater than its end date", () => {
+    const interval = {
+      start: new Date(2020, 3, 1),
+      end: new Date(2020, 2, 1),
+    }
+
+    assert.throws(intervalToDuration.bind(null, interval), RangeError)
+  })
+
+  it("throws a RangeError if interval's start date invalid", () => {
+    const interval = {
+      start: new Date(NaN),
+      end: new Date(2020, 0, 1),
+    }
+
+    assert.throws(intervalToDuration.bind(null, interval), RangeError)
+  })
+
+  it("throws a RangeError if interval's end date invalid", () => {
+    const interval = {
+      start: new Date(2020, 0, 1),
+      end: new Date(NaN),
+    }
+
+    assert.throws(intervalToDuration.bind(null, interval), RangeError)
+  })
+
+  describe('edge cases', () => {
+    it('returns correct duration for dates in the end of Feb - issue 2255', () => {
+      assert.deepStrictEqual(
         intervalToDuration({
           start: new Date(2012, 1 /* Feb */, 28, 9, 0, 0),
           end: new Date(2012, 1 /* Feb */, 29, 10, 0, 0),
@@ -66,7 +94,7 @@ describe('intervalToDuration', function () {
         }
       )
 
-      assert.deepEqual(
+      assert.deepStrictEqual(
         intervalToDuration({
           start: new Date(2012, 1 /* Feb */, 29, 9, 0, 0),
           end: new Date(2012, 1 /* Feb */, 29, 10, 0, 0),
@@ -81,7 +109,7 @@ describe('intervalToDuration', function () {
         }
       )
 
-      assert.deepEqual(
+      assert.deepStrictEqual(
         intervalToDuration({
           start: new Date(2012, 1 /* Feb */, 28, 9, 0, 0),
           end: new Date(2012, 1 /* Feb */, 28, 10, 0, 0),
@@ -97,7 +125,7 @@ describe('intervalToDuration', function () {
       )
 
       // Issue 2261
-      assert.deepEqual(
+      assert.deepStrictEqual(
         intervalToDuration({
           start: new Date(2021, 1 /* Feb */, 28, 7, 23, 7),
           end: new Date(2021, 1 /* Feb */, 28, 7, 38, 18),
@@ -111,6 +139,148 @@ describe('intervalToDuration', function () {
           seconds: 11,
         }
       )
+    })
+
+    it('returns correct duration for end of month start dates - issue 2611', () => {
+      const start = new Date(2021, 7, 31)
+      const end = addMonths(start, 1)
+
+      assert.deepStrictEqual(end, new Date(2021, 8, 30))
+
+      const duration = intervalToDuration({ start, end })
+      const expectedDuration = {
+        years: 0,
+        months: 1,
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      }
+
+      assert.deepStrictEqual(duration, expectedDuration)
+    })
+
+    it('returns correct duration for Feb 29 on leap year + 1 month - issue 1778', () => {
+      const duration = intervalToDuration({
+        start: new Date(2020, 1, 29),
+        end: new Date(2020, 2, 29),
+      })
+      const expectedDuration = {
+        years: 0,
+        months: 1,
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      }
+
+      assert.deepStrictEqual(duration, expectedDuration)
+    })
+
+    describe('issue 2470', () => {
+      it('returns correct duration for Feb 28 to Aug 31 interval', () => {
+        const duration = intervalToDuration({
+          start: new Date(2021, 1, 28),
+          end: new Date(2021, 7, 31),
+        })
+        const expectedDuration = {
+          years: 0,
+          months: 6,
+          days: 3,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        }
+
+        assert.deepStrictEqual(duration, expectedDuration)
+      })
+
+      it('returns correct duration for Feb 28 to Aug 30 interval', () => {
+        const duration = intervalToDuration({
+          start: new Date(2021, 1, 28),
+          end: new Date(2021, 7, 30),
+        })
+        const expectedDuration = {
+          years: 0,
+          months: 6,
+          days: 2,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        }
+
+        assert.deepStrictEqual(duration, expectedDuration)
+      })
+
+      it('returns correct duration for Feb 28 to Aug 29 interval', () => {
+        const duration = intervalToDuration({
+          start: new Date(2021, 1, 28),
+          end: new Date(2021, 7, 29),
+        })
+        const expectedDuration = {
+          years: 0,
+          months: 6,
+          days: 1,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        }
+
+        assert.deepStrictEqual(duration, expectedDuration)
+      })
+
+      it('returns correct duration for Feb 28 to Aug 28 interval', () => {
+        const duration = intervalToDuration({
+          start: new Date(2021, 1, 28),
+          end: new Date(2021, 7, 28),
+        })
+        const expectedDuration = {
+          years: 0,
+          months: 6,
+          days: 0,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        }
+
+        assert.deepStrictEqual(duration, expectedDuration)
+      })
+
+      it('returns correct duration for Feb 28 to Aug 27 interval', () => {
+        // Feb 28 to July 28 is 5 months, July 28 to Aug 27 is 30 days
+
+        const duration = intervalToDuration({
+          start: new Date(2021, 1, 28),
+          end: new Date(2021, 7, 27),
+        })
+        const expectedDuration = {
+          years: 0,
+          months: 5,
+          days: 30,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        }
+
+        assert.deepStrictEqual(duration, expectedDuration)
+      })
+
+      it('returns correct duration for Apr 30 to May 31 interval', () => {
+        const duration = intervalToDuration({
+          start: new Date(2021, 3, 30),
+          end: new Date(2021, 4, 31),
+        })
+        const expectedDuration = {
+          years: 0,
+          months: 1,
+          days: 1,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        }
+
+        assert.deepStrictEqual(duration, expectedDuration)
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #2611, #1778, #2470

By using `add` internally instead of `sub`, the `intervalToDuration` function gives better results for end of month interval start dates while still passing all existing unit tests. It also means better interop with `add`, as discussed in #2611.

Before:
```js
intervalToDuration({start: new Date(2021, 7, 31), end: new Date(2021, 8, 30)})
// {years: 0, months: 0, days: 30, hours: 0, minutes: 0, seconds: 0}
```

With this PR:
```js
intervalToDuration({start: new Date(2021, 7, 31), end: new Date(2021, 8, 30)})
// {years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0}
```

This also brings a few improvements:
- new RangeError thrown if interval start date is greater than end date. This is standard in all other functions handling intervals and per https://date-fns.org/docs/Interval
- additional unit tests covering new edge cases and thrown exceptions
- leaner implementation: removed dependencies to `compareAsc` and `isValid`, removed sign and Math.abs operations that were not required.