### PR TITLE
Fix timezone support in isSameMonth

### DIFF
--- a/src/isSameMonth/index.ts
+++ b/src/isSameMonth/index.ts
@@ -29,7 +29,7 @@ export default function isSameMonth(dirtyDateLeft: Date | number, dirtyDateRight
   const dateLeft = toDate(dirtyDateLeft)
   const dateRight = toDate(dirtyDateRight)
   return (
-    dateLeft.getFullYear() === dateRight.getFullYear() &&
-    dateLeft.getMonth() === dateRight.getMonth()
+    dateLeft.getUTCFullYear() === dateRight.getUTCFullYear() &&
+    dateLeft.getUTCMonth() === dateRight.getUTCMonth()
   )
 }

--- a/src/isSameMonth/test.ts
+++ b/src/isSameMonth/test.ts
@@ -13,10 +13,26 @@ describe('isSameMonth', function() {
     assert(result === true)
   })
 
+  it('returns true if the given dates use a different timezone', function() {
+    const result = isSameMonth(
+      new Date('2015-02-01T00:00:00.000+01:00'),
+      new Date('2015-01-31T23:00:00.000Z')
+    )
+    assert(result === true)
+  })
+
   it('returns false if the given dates have different months', function() {
     const result = isSameMonth(
       new Date(2014, 8 /* Sep */, 2),
       new Date(2013, 8 /* Sep */, 25)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the given dates differ with a timezone', function() {
+    const result = isSameMonth(
+      new Date('2015-02-01T00:00:00.000+01:00'),
+      new Date('2015-02-01T00:00:00.000Z')
     )
     assert(result === false)
   })


### PR DESCRIPTION
Related Issues:
- https://github.com/date-fns/date-fns/issues/376
- https://github.com/date-fns/date-fns/issues/2484
- https://github.com/date-fns/date-fns/issues/2151
- https://github.com/date-fns/date-fns/issues/1604

The current implementation of `isSameMonth` didn't respect the timezones.

```js
const january = new Date('2015-02-01T00:00:00.000+01:00')
const february = new Date('2015-02-01T00:00:00.000Z')

// Current behavior 
_.isSameMonth(january, february)
true

// Expected behavior
_.isSameMonth(january, february)
false
```