### PR TITLE
fix: returned type of parseISO function should returns a Date or the string Invalid Date.

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -10050,7 +10050,7 @@ declare module 'date-fns/esm' {
     options?: {
       additionalDigits?: 0 | 1 | 2
     }
-  ): Date
+  ): Date | string
   namespace parseISO {}
 
   function parseJSON(argument: string | number | Date): Date


### PR DESCRIPTION
Fix #2622 