### PR TITLE
Make contributors mentioned in releases

### DIFF
--- a/scripts/release/buildChangelog.ts
+++ b/scripts/release/buildChangelog.ts
@@ -221,7 +221,7 @@ function renderAuthors(authors: Author[]) {
 }
 
 function renderAuthor(author: Author) {
-  return `[${author.name}](http://github.com/${author.login})`
+  return `@${author.login}`
 }
 
 function renderItem(item: ChangelogItem) {


### PR DESCRIPTION
GitHub recently added the ability to mention contributors in releases. This PR changes the changelog script to enable that.