### PR TITLE
Increase test code coverage for _lib/format/formatters/*

### DIFF
--- a/src/_lib/format/formatters/index.js
+++ b/src/_lib/format/formatters/index.js
@@ -14,7 +14,7 @@ var dayPeriodEnum = {
   morning: 'morning',
   afternoon: 'afternoon',
   evening: 'evening',
-  night: 'night'
+  night: 'night',
 }
 
 /*
@@ -65,7 +65,7 @@ var dayPeriodEnum = {
 
 var formatters = {
   // Era
-  G: function(date, token, localize) {
+  G: function (date, token, localize) {
     var era = date.getUTCFullYear() > 0 ? 1 : 0
     switch (token) {
       // AD, BC
@@ -84,7 +84,7 @@ var formatters = {
   },
 
   // Year
-  y: function(date, token, localize) {
+  y: function (date, token, localize) {
     // Ordinal number
     if (token === 'yo') {
       var signedYear = date.getUTCFullYear()
@@ -97,7 +97,7 @@ var formatters = {
   },
 
   // Local week-numbering year
-  Y: function(date, token, localize, options) {
+  Y: function (date, token, localize, options) {
     var signedWeekYear = getUTCWeekYear(date, options)
     // Returns 1 for 1 BC (which is year 0 in JavaScript)
     var weekYear = signedWeekYear > 0 ? signedWeekYear : 1 - signedWeekYear
@@ -118,7 +118,7 @@ var formatters = {
   },
 
   // ISO week-numbering year
-  R: function(date, token) {
+  R: function (date, token) {
     var isoWeekYear = getUTCISOWeekYear(date)
 
     // Padding
@@ -134,13 +134,13 @@ var formatters = {
   // | BC 2 |   2 |  -1 |
   // Also `yy` always returns the last two digits of a year,
   // while `uu` pads single digit years to 2 characters and returns other years unchanged.
-  u: function(date, token) {
+  u: function (date, token) {
     var year = date.getUTCFullYear()
     return addLeadingZeros(year, token.length)
   },
 
   // Quarter
-  Q: function(date, token, localize) {
+  Q: function (date, token, localize) {
     var quarter = Math.ceil((date.getUTCMonth() + 1) / 3)
     switch (token) {
       // 1, 2, 3, 4
@@ -156,26 +156,26 @@ var formatters = {
       case 'QQQ':
         return localize.quarter(quarter, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       // 1, 2, 3, 4 (narrow quarter; could be not numerical)
       case 'QQQQQ':
         return localize.quarter(quarter, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       // 1st quarter, 2nd quarter, ...
       case 'QQQQ':
       default:
         return localize.quarter(quarter, {
           width: 'wide',
-          context: 'formatting'
+          context: 'formatting',
         })
     }
   },
 
   // Stand-alone quarter
-  q: function(date, token, localize) {
+  q: function (date, token, localize) {
     var quarter = Math.ceil((date.getUTCMonth() + 1) / 3)
     switch (token) {
       // 1, 2, 3, 4
@@ -191,26 +191,26 @@ var formatters = {
       case 'qqq':
         return localize.quarter(quarter, {
           width: 'abbreviated',
-          context: 'standalone'
+          context: 'standalone',
         })
       // 1, 2, 3, 4 (narrow quarter; could be not numerical)
       case 'qqqqq':
         return localize.quarter(quarter, {
           width: 'narrow',
-          context: 'standalone'
+          context: 'standalone',
         })
       // 1st quarter, 2nd quarter, ...
       case 'qqqq':
       default:
         return localize.quarter(quarter, {
           width: 'wide',
-          context: 'standalone'
+          context: 'standalone',
         })
     }
   },
 
   // Month
-  M: function(date, token, localize) {
+  M: function (date, token, localize) {
     var month = date.getUTCMonth()
     switch (token) {
       case 'M':
@@ -223,7 +223,7 @@ var formatters = {
       case 'MMM':
         return localize.month(month, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       // J, F, ..., D
       case 'MMMMM':
@@ -236,7 +236,7 @@ var formatters = {
   },
 
   // Stand-alone month
-  L: function(date, token, localize) {
+  L: function (date, token, localize) {
     var month = date.getUTCMonth()
     switch (token) {
       // 1, 2, ..., 12
@@ -252,7 +252,7 @@ var formatters = {
       case 'LLL':
         return localize.month(month, {
           width: 'abbreviated',
-          context: 'standalone'
+          context: 'standalone',
         })
       // J, F, ..., D
       case 'LLLLL':
@@ -265,7 +265,7 @@ var formatters = {
   },
 
   // Local week of year
-  w: function(date, token, localize, options) {
+  w: function (date, token, localize, options) {
     var week = getUTCWeek(date, options)
 
     if (token === 'wo') {
@@ -276,7 +276,7 @@ var formatters = {
   },
 
   // ISO week of year
-  I: function(date, token, localize) {
+  I: function (date, token, localize) {
     var isoWeek = getUTCISOWeek(date)
 
     if (token === 'Io') {
@@ -287,7 +287,7 @@ var formatters = {
   },
 
   // Day of the month
-  d: function(date, token, localize) {
+  d: function (date, token, localize) {
     if (token === 'do') {
       return localize.ordinalNumber(date.getUTCDate(), { unit: 'date' })
     }
@@ -296,7 +296,7 @@ var formatters = {
   },
 
   // Day of year
-  D: function(date, token, localize) {
+  D: function (date, token, localize) {
     var dayOfYear = getUTCDayOfYear(date)
 
     if (token === 'Do') {
@@ -307,7 +307,7 @@ var formatters = {
   },
 
   // Day of week
-  E: function(date, token, localize) {
+  E: function (date, token, localize) {
     var dayOfWeek = date.getUTCDay()
     switch (token) {
       // Tue
@@ -316,19 +316,19 @@ var formatters = {
       case 'EEE':
         return localize.day(dayOfWeek, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       // T
       case 'EEEEE':
         return localize.day(dayOfWeek, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       // Tu
       case 'EEEEEE':
         return localize.day(dayOfWeek, {
           width: 'short',
-          context: 'formatting'
+          context: 'formatting',
         })
       // Tuesday
       case 'EEEE':
@@ -338,7 +338,7 @@ var formatters = {
   },
 
   // Local day of week
-  e: function(date, token, localize, options) {
+  e: function (date, token, localize, options) {
     var dayOfWeek = date.getUTCDay()
     var localDayOfWeek = (dayOfWeek - options.weekStartsOn + 8) % 7 || 7
     switch (token) {
@@ -354,19 +354,19 @@ var formatters = {
       case 'eee':
         return localize.day(dayOfWeek, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       // T
       case 'eeeee':
         return localize.day(dayOfWeek, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       // Tu
       case 'eeeeee':
         return localize.day(dayOfWeek, {
           width: 'short',
-          context: 'formatting'
+          context: 'formatting',
         })
       // Tuesday
       case 'eeee':
@@ -376,7 +376,7 @@ var formatters = {
   },
 
   // Stand-alone local day of week
-  c: function(date, token, localize, options) {
+  c: function (date, token, localize, options) {
     var dayOfWeek = date.getUTCDay()
     var localDayOfWeek = (dayOfWeek - options.weekStartsOn + 8) % 7 || 7
     switch (token) {
@@ -392,19 +392,19 @@ var formatters = {
       case 'ccc':
         return localize.day(dayOfWeek, {
           width: 'abbreviated',
-          context: 'standalone'
+          context: 'standalone',
         })
       // T
       case 'ccccc':
         return localize.day(dayOfWeek, {
           width: 'narrow',
-          context: 'standalone'
+          context: 'standalone',
         })
       // Tu
       case 'cccccc':
         return localize.day(dayOfWeek, {
           width: 'short',
-          context: 'standalone'
+          context: 'standalone',
         })
       // Tuesday
       case 'cccc':
@@ -414,7 +414,7 @@ var formatters = {
   },
 
   // ISO day of week
-  i: function(date, token, localize) {
+  i: function (date, token, localize) {
     var dayOfWeek = date.getUTCDay()
     var isoDayOfWeek = dayOfWeek === 0 ? 7 : dayOfWeek
     switch (token) {
@@ -431,19 +431,19 @@ var formatters = {
       case 'iii':
         return localize.day(dayOfWeek, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       // T
       case 'iiiii':
         return localize.day(dayOfWeek, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       // Tu
       case 'iiiiii':
         return localize.day(dayOfWeek, {
           width: 'short',
-          context: 'formatting'
+          context: 'formatting',
         })
       // Tuesday
       case 'iiii':
@@ -453,7 +453,7 @@ var formatters = {
   },
 
   // AM or PM
-  a: function(date, token, localize) {
+  a: function (date, token, localize) {
     var hours = date.getUTCHours()
     var dayPeriodEnumValue = hours / 12 >= 1 ? 'pm' : 'am'
 
@@ -462,31 +462,31 @@ var formatters = {
       case 'aa':
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       case 'aaa':
         return localize
           .dayPeriod(dayPeriodEnumValue, {
             width: 'abbreviated',
-            context: 'formatting'
+            context: 'formatting',
           })
           .toLowerCase()
       case 'aaaaa':
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       case 'aaaa':
       default:
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'wide',
-          context: 'formatting'
+          context: 'formatting',
         })
     }
   },
 
   // AM, PM, midnight, noon
-  b: function(date, token, localize) {
+  b: function (date, token, localize) {
     var hours = date.getUTCHours()
     var dayPeriodEnumValue
     if (hours === 12) {
@@ -502,31 +502,31 @@ var formatters = {
       case 'bb':
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       case 'bbb':
         return localize
           .dayPeriod(dayPeriodEnumValue, {
             width: 'abbreviated',
-            context: 'formatting'
+            context: 'formatting',
           })
           .toLowerCase()
       case 'bbbbb':
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       case 'bbbb':
       default:
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'wide',
-          context: 'formatting'
+          context: 'formatting',
         })
     }
   },
 
   // in the morning, in the afternoon, in the evening, at night
-  B: function(date, token, localize) {
+  B: function (date, token, localize) {
     var hours = date.getUTCHours()
     var dayPeriodEnumValue
     if (hours >= 17) {
@@ -545,24 +545,24 @@ var formatters = {
       case 'BBB':
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'abbreviated',
-          context: 'formatting'
+          context: 'formatting',
         })
       case 'BBBBB':
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'narrow',
-          context: 'formatting'
+          context: 'formatting',
         })
       case 'BBBB':
       default:
         return localize.dayPeriod(dayPeriodEnumValue, {
           width: 'wide',
-          context: 'formatting'
+          context: 'formatting',
         })
     }
   },
 
   // Hour [1-12]
-  h: function(date, token, localize) {
+  h: function (date, token, localize) {
     if (token === 'ho') {
       var hours = date.getUTCHours() % 12
       if (hours === 0) hours = 12
@@ -573,7 +573,7 @@ var formatters = {
   },
 
   // Hour [0-23]
-  H: function(date, token, localize) {
+  H: function (date, token, localize) {
     if (token === 'Ho') {
       return localize.ordinalNumber(date.getUTCHours(), { unit: 'hour' })
     }
@@ -582,7 +582,7 @@ var formatters = {
   },
 
   // Hour [0-11]
-  K: function(date, token, localize) {
+  K: function (date, token, localize) {
     var hours = date.getUTCHours() % 12
 
     if (token === 'Ko') {
@@ -593,7 +593,7 @@ var formatters = {
   },
 
   // Hour [1-24]
-  k: function(date, token, localize) {
+  k: function (date, token, localize) {
     var hours = date.getUTCHours()
     if (hours === 0) hours = 24
 
@@ -605,7 +605,7 @@ var formatters = {
   },
 
   // Minute
-  m: function(date, token, localize) {
+  m: function (date, token, localize) {
     if (token === 'mo') {
       return localize.ordinalNumber(date.getUTCMinutes(), { unit: 'minute' })
     }
@@ -614,7 +614,7 @@ var formatters = {
   },
 
   // Second
-  s: function(date, token, localize) {
+  s: function (date, token, localize) {
     if (token === 'so') {
       return localize.ordinalNumber(date.getUTCSeconds(), { unit: 'second' })
     }
@@ -623,12 +623,12 @@ var formatters = {
   },
 
   // Fraction of second
-  S: function(date, token) {
+  S: function (date, token) {
     return lightFormatters.S(date, token)
   },
 
   // Timezone (ISO-8601. If offset is 0, output is always `'Z'`)
-  X: function(date, token, _localize, options) {
+  X: function (date, token, _localize, options) {
     var originalDate = options._originalDate || date
     var timezoneOffset = originalDate.getTimezoneOffset()
 
@@ -659,7 +659,7 @@ var formatters = {
   },
 
   // Timezone (ISO-8601. If offset is 0, output is `'+00:00'` or equivalent)
-  x: function(date, token, _localize, options) {
+  x: function (date, token, _localize, options) {
     var originalDate = options._originalDate || date
     var timezoneOffset = originalDate.getTimezoneOffset()
 
@@ -686,7 +686,7 @@ var formatters = {
   },
 
   // Timezone (GMT)
-  O: function(date, token, _localize, options) {
+  O: function (date, token, _localize, options) {
     var originalDate = options._originalDate || date
     var timezoneOffset = originalDate.getTimezoneOffset()
 
@@ -704,7 +704,7 @@ var formatters = {
   },
 
   // Timezone (specific non-location)
-  z: function(date, token, _localize, options) {
+  z: function (date, token, _localize, options) {
     var originalDate = options._originalDate || date
     var timezoneOffset = originalDate.getTimezoneOffset()
 
@@ -722,21 +722,21 @@ var formatters = {
   },
 
   // Seconds timestamp
-  t: function(date, token, _localize, options) {
+  t: function (date, token, _localize, options) {
     var originalDate = options._originalDate || date
     var timestamp = Math.floor(originalDate.getTime() / 1000)
     return addLeadingZeros(timestamp, token.length)
   },
 
   // Milliseconds timestamp
-  T: function(date, token, _localize, options) {
+  T: function (date, token, _localize, options) {
     var originalDate = options._originalDate || date
     var timestamp = originalDate.getTime()
     return addLeadingZeros(timestamp, token.length)
-  }
+  },
 }
 
-function formatTimezoneShort(offset, dirtyDelimiter) {
+function formatTimezoneShort(offset, delimiter) {
   var sign = offset > 0 ? '-' : '+'
   var absOffset = Math.abs(offset)
   var hours = Math.floor(absOffset / 60)
@@ -744,7 +744,6 @@ function formatTimezoneShort(offset, dirtyDelimiter) {
   if (minutes === 0) {
     return sign + String(hours)
   }
-  var delimiter = dirtyDelimiter || ''
   return sign + String(hours) + delimiter + addLeadingZeros(minutes, 2)
 }
 

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 
 import assert from 'power-assert'
+import sinon from 'sinon'
 import format from '.'
 
 describe('format', function () {
@@ -554,6 +555,24 @@ describe('format', function () {
         timezoneWithZ,
       ].join(' ')
       assert(result === expectedResult)
+
+      var getTimezoneOffsetStub = sinon.stub(
+        Date.prototype,
+        'getTimezoneOffset'
+      )
+      getTimezoneOffsetStub.returns(0)
+      var resultZeroOffset = format(date, 'X XX XXX XXXX XXXXX')
+      assert(resultZeroOffset === 'Z Z Z Z Z')
+
+      getTimezoneOffsetStub.returns(480)
+      var resultNegativeOffset = format(date, 'X XX XXX XXXX XXXXX')
+      assert(resultNegativeOffset === '-08 -0800 -08:00 -0800 -08:00')
+
+      getTimezoneOffsetStub.returns(450)
+      var resultNegative30Offset = format(date, 'X XX XXX XXXX XXXXX')
+      assert(resultNegative30Offset === '-0730 -0730 -07:30 -0730 -07:30')
+
+      getTimezoneOffsetStub.restore()
     })
 
     it('ISO-8601 without Z', function () {
@@ -577,6 +596,20 @@ describe('format', function () {
         timezoneGMT,
       ].join(' ')
       assert(result === expectedResult)
+
+      var getTimezoneOffsetStub = sinon.stub(
+        Date.prototype,
+        'getTimezoneOffset'
+      )
+      getTimezoneOffsetStub.returns(480)
+      var resultNegativeOffset = format(date, 'O OO OOO OOOO')
+      assert(resultNegativeOffset === 'GMT-8 GMT-8 GMT-8 GMT-08:00')
+
+      getTimezoneOffsetStub.returns(450)
+      var resultNegative30Offset = format(date, 'O OO OOO OOOO')
+      assert(resultNegative30Offset === 'GMT-7:30 GMT-7:30 GMT-7:30 GMT-07:30')
+
+      getTimezoneOffsetStub.restore()
     })
 
     it('Specific non-location', function () {

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -106,6 +106,11 @@ describe('format', function () {
   it('era', function () {
     var result = format(date, 'G GG GGG GGGG GGGGG')
     assert(result === 'AD AD AD Anno Domini A')
+
+    var bcDate = new Date()
+    bcDate.setFullYear(-1, 0 /* Jan */, 1)
+    var bcResult = format(bcDate, 'G GG GGG GGGG GGGGG')
+    assert(bcResult === 'BC BC BC Before Christ B')
   })
 
   describe('year', function () {
@@ -129,6 +134,14 @@ describe('format', function () {
         date.setHours(0, 0, 0, 0)
         var result = format(date, 'y')
         assert(result === '2')
+      })
+
+      it('2 BC formats as 2nd', function () {
+        var date = new Date()
+        date.setFullYear(-1, 0 /* Jan */, 1)
+        date.setHours(0, 0, 0, 0)
+        var result = format(date, 'yo')
+        assert(result === '2nd')
       })
     })
 
@@ -460,6 +473,12 @@ describe('format', function () {
           'b bb bbb bbbb bbbbb'
         )
         assert(result === 'AM AM am a.m. a')
+
+        var pmResult = format(
+          new Date(1986, 3 /* Apr */, 6, 13, 0, 0, 900),
+          'b bb bbb bbbb bbbbb'
+        )
+        assert(pmResult === 'PM PM pm p.m. p')
       })
 
       it('12 PM', function () {

--- a/src/lightFormat/test.ts
+++ b/src/lightFormat/test.ts
@@ -93,6 +93,12 @@ describe('lightFormat', () => {
           'a aa aaa aaaa aaaaa'
         )
         assert(result === 'AM AM am a.m. a')
+
+        const pmResult = lightFormat(
+          new Date(2018, 0 /* Jan */, 1, 13, 0, 0, 0),
+          'a aa aaa aaaa aaaaa'
+        )
+        assert(pmResult === 'PM PM pm p.m. p')
       })
 
       it('12 PM', () => {


### PR DESCRIPTION
|                                                     Before                                                      |                                                     After                                                      |
| :-------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------: |
| ![Before](https://user-images.githubusercontent.com/2569355/137174784-2ab853e0-3676-4b93-9b15-ececd8c4b482.png) | ![Screen Shot 2021-10-14 at 19 54 42](https://user-images.githubusercontent.com/2569355/137312460-f2c1c249-9660-4f6b-abe2-905cfe5e68b4.png)|


Hi, as much as I want to make 100% code coverage for the following APIs in `src/_lib/format/formatters/index.js`, I'm blocked with this scenario wherein I'm not sure how to create a `Date` calling `getTimezoneOffset()` resulting to `0`. 

I'm willing to update the PR if anyone can guide me. Thanks!

Below are some of the uncovered code regions related to `getTimezoneOffset()`
![image](https://user-images.githubusercontent.com/2569355/137175483-1fc94987-52a7-479e-abef-e6b402aa3ccd.png)
