### PR TITLE
Monday as first day of the week for korean

### DIFF
--- a/src/locale/ko/index.js
+++ b/src/locale/ko/index.js
@@ -22,7 +22,7 @@ var locale = {
   localize: localize,
   match: match,
   options: {
-    weekStartsOn: 0 /* Sunday */,
+    weekStartsOn: 1 /* Monday */,
     firstWeekContainsDate: 1
   }
 }


### PR DESCRIPTION
We call Saturday and Sunday as 주말(週末). 주(週) means "week" and 말(末) means "end".
So you can see that Sunday is the last day of a week in Korean language.