### PR TITLE
Fix path when deleting the esm version of outdated locales during build

### DIFF
--- a/scripts/build/removeOutdatedLocales.js
+++ b/scripts/build/removeOutdatedLocales.js
@@ -14,7 +14,7 @@ const packageDir = process.argv[2]
 if (!packageDir) throw new Error('Package dir should be passed as an argument')
 
 const locales = require('../../outdatedLocales.json')
-locales.forEach(locale => {
+locales.forEach((locale) => {
   rimraf.sync(path.resolve(packageDir, `locale/${locale}`))
-  rimraf.sync(path.resolve(packageDir, `locale/esm/${locale}`))
+  rimraf.sync(path.resolve(packageDir, `esm/locale/${locale}`))
 })


### PR DESCRIPTION
Fairly self-explanatory, but it the esm version of the broken/outdated locales were not getting removed correctly during the build step.