### PR TITLE
Updated Swedish short date format

### DIFF
--- a/src/locale/sv/_lib/formatLong/index.js
+++ b/src/locale/sv/_lib/formatLong/index.js
@@ -4,7 +4,7 @@ var dateFormats = {
   full: 'EEEE d MMMM y',
   long: 'd MMMM y',
   medium: 'd MMM y',
-  short: 'y-MM-dd'
+  short: 'yyyy-MM-dd'
 }
 
 var timeFormats = {


### PR DESCRIPTION
Changed Swedish short date format from `y-MM-dd` to `yyyy-MM-dd`, which is the correct Swedish official date format.
Sweden basically follows ISO-8601 as official date format.