### PR TITLE
minor TypeScript type fixes

### DIFF
--- a/src/_lib/getUTCISOWeekYear/index.ts
+++ b/src/_lib/getUTCISOWeekYear/index.ts
@@ -4,7 +4,7 @@ import startOfUTCISOWeek from '../startOfUTCISOWeek/index'
 
 // This function will be a part of public API when UTC function will be implemented.
 // See issue: https://github.com/date-fns/date-fns/issues/376
-export default function getUTCISOWeekYear(dirtyDate: Date | number) {
+export default function getUTCISOWeekYear(dirtyDate: Date | number): number {
   requiredArgs(1, arguments)
 
   const date = toDate(dirtyDate)

--- a/src/_lib/getUTCWeekYear/index.ts
+++ b/src/_lib/getUTCWeekYear/index.ts
@@ -13,7 +13,7 @@ import toInteger from '../toInteger/index'
 export default function getUTCWeekYear(
   dirtyDate: Date | number,
   dirtyOptions?: LocaleOptions & FirstWeekContainsDateOptions & WeekStartOptions
-) {
+): number {
   requiredArgs(1, arguments)
 
   const date = toDate(dirtyDate)

--- a/src/_lib/requiredArgs/index.ts
+++ b/src/_lib/requiredArgs/index.ts
@@ -1,4 +1,4 @@
-export default function requiredArgs(required: number, args: IArguments) {
+export default function requiredArgs(required: number, args: IArguments): void {
   if (args.length < required) {
     throw new TypeError(
       required +

--- a/src/_lib/setUTCDay/test.ts
+++ b/src/_lib/setUTCDay/test.ts
@@ -2,8 +2,9 @@
 /* eslint-env mocha */
 
 import assert from 'assert'
-import { Locale } from '../../locale/types'
 import setUTCDay from '.'
+import { Locale } from '../../locale/types'
+import { Day } from '../../types'
 
 describe('setUTCDay', () => {
   it('sets the day of the week', () => {

--- a/src/_lib/startOfUTCWeek/index.ts
+++ b/src/_lib/startOfUTCWeek/index.ts
@@ -1,5 +1,5 @@
-import { LocaleOptions, WeekStartOptions } from '../../types'
 import toDate from '../../toDate/index'
+import { LocaleOptions, WeekStartOptions } from '../../types'
 import requiredArgs from '../requiredArgs/index'
 import toInteger from '../toInteger/index'
 
@@ -8,7 +8,7 @@ import toInteger from '../toInteger/index'
 export default function startOfUTCWeek(
   dirtyDate: Date | number,
   dirtyOptions?: LocaleOptions & WeekStartOptions
-) {
+): Date {
   requiredArgs(1, arguments)
 
   const options = dirtyOptions || {}

--- a/src/_lib/startOfUTCWeekYear/index.ts
+++ b/src/_lib/startOfUTCWeekYear/index.ts
@@ -13,7 +13,7 @@ import toInteger from '../toInteger/index'
 export default function startOfUTCWeekYear(
   dirtyDate: Date | number,
   dirtyOptions?: LocaleOptions & FirstWeekContainsDateOptions & WeekStartOptions
-) {
+): Date {
   requiredArgs(1, arguments)
 
   const options = dirtyOptions || {}

--- a/src/_lib/test/index.ts
+++ b/src/_lib/test/index.ts
@@ -1,1 +1,1 @@
-export function assertType<T>(_: T) {}
+export function assertType<T>(_: T): void {}

--- a/src/_lib/toInteger/index.ts
+++ b/src/_lib/toInteger/index.ts
@@ -1,4 +1,4 @@
-export default function toInteger(dirtyNumber: unknown) {
+export default function toInteger(dirtyNumber: unknown): number {
   if (dirtyNumber === null || dirtyNumber === true || dirtyNumber === false) {
     return NaN
   }

--- a/src/areIntervalsOverlapping/index.ts
+++ b/src/areIntervalsOverlapping/index.ts
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/clamp/index.ts
+++ b/src/clamp/index.ts
@@ -1,5 +1,6 @@
-import max from '../max'
-import min from '../min'
+import max from '../max/index'
+import min from '../min/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/clamp/test.ts
+++ b/src/clamp/test.ts
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+
 import assert from 'assert'
 import clamp from '.'
 

--- a/src/eachDayOfInterval/index.ts
+++ b/src/eachDayOfInterval/index.ts
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/eachMonthOfInterval/index.ts
+++ b/src/eachMonthOfInterval/index.ts
@@ -1,4 +1,5 @@
 import toDate from '../toDate/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
@@ -31,7 +32,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * //   Fri Aug 01 2014 00:00:00
  * // ]
  */
-export default function eachMonthOfInterval(dirtyInterval: Interval) {
+export default function eachMonthOfInterval(dirtyInterval: Interval): Date[] {
   requiredArgs(1, arguments)
 
   const interval = dirtyInterval || {}

--- a/src/eachQuarterOfInterval/index.ts
+++ b/src/eachQuarterOfInterval/index.ts
@@ -1,6 +1,7 @@
 import addQuarters from '../addQuarters/index'
 import startOfQuarter from '../startOfQuarter/index'
 import toDate from '../toDate/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/eachWeekOfInterval/index.ts
+++ b/src/eachWeekOfInterval/index.ts
@@ -1,7 +1,7 @@
-import { WeekStartOptions } from '../types'
 import addWeeks from '../addWeeks/index'
 import startOfWeek from '../startOfWeek/index'
 import toDate from '../toDate/index'
+import type { Interval, LocaleOptions, WeekStartOptions } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
@@ -45,7 +45,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  */
 export default function eachWeekOfInterval(
   dirtyInterval: Interval,
-  options?: WeekStartOptions
+  options?: LocaleOptions & WeekStartOptions
 ): Date[] {
   requiredArgs(1, arguments)
 

--- a/src/eachWeekendOfInterval/index.ts
+++ b/src/eachWeekendOfInterval/index.ts
@@ -1,6 +1,7 @@
 import eachDayOfInterval from '../eachDayOfInterval/index'
 import isSunday from '../isSunday/index'
 import isWeekend from '../isWeekend/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/eachYearOfInterval/index.ts
+++ b/src/eachYearOfInterval/index.ts
@@ -29,7 +29,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * //   Sun Jan 01 2017 00:00:00
  * // ]
  */
-export default function eachYearOfInterval(dirtyInterval: Interval) {
+export default function eachYearOfInterval(dirtyInterval: Interval): Date[] {
   requiredArgs(1, arguments)
 
   const interval = dirtyInterval || {}

--- a/src/formatDuration/index.ts
+++ b/src/formatDuration/index.ts
@@ -1,4 +1,5 @@
 import defaultLocale from '../locale/en-US/index'
+import { Locale } from '../locale/types'
 import type { Duration } from '../types'
 
 const defaultFormat: (keyof Duration)[] = [

--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -1,3 +1,4 @@
+import { Duration } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -1,14 +1,15 @@
 import compareAsc from '../compareAsc/index'
-import differenceInYears from '../differenceInYears/index'
-import differenceInMonths from '../differenceInMonths/index'
 import differenceInDays from '../differenceInDays/index'
 import differenceInHours from '../differenceInHours/index'
 import differenceInMinutes from '../differenceInMinutes/index'
+import differenceInMonths from '../differenceInMonths/index'
 import differenceInSeconds from '../differenceInSeconds/index'
+import differenceInYears from '../differenceInYears/index'
 import isValid from '../isValid/index'
-import requiredArgs from '../_lib/requiredArgs/index'
-import toDate from '../toDate/index'
 import sub from '../sub/index'
+import toDate from '../toDate/index'
+import { Duration, Interval } from '../types'
+import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
  * @name intervalToDuration

--- a/src/setWeek/index.ts
+++ b/src/setWeek/index.ts
@@ -1,12 +1,12 @@
 import getWeek from '../getWeek/index'
 import toDate from '../toDate/index'
-import toInteger from '../_lib/toInteger/index'
-import requiredArgs from '../_lib/requiredArgs/index'
 import {
+  FirstWeekContainsDateOptions,
   LocaleOptions,
   WeekStartOptions,
-  FirstWeekContainsDateOptions,
 } from '../types'
+import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
 
 /**
  * @name setWeek
@@ -55,7 +55,7 @@ import {
 export default function setWeek(
   dirtyDate: Date | number,
   dirtyWeek: number,
-  options: LocaleOptions & WeekStartOptions & FirstWeekContainsDateOptions
+  options?: LocaleOptions & WeekStartOptions & FirstWeekContainsDateOptions
 ): Date {
   requiredArgs(2, arguments)
 

--- a/src/startOfTomorrow/index.ts
+++ b/src/startOfTomorrow/index.ts
@@ -21,7 +21,7 @@
  * const result = startOfTomorrow()
  * //=> Tue Oct 7 2014 00:00:00
  */
-export default function startOfTomorrow() {
+export default function startOfTomorrow(): Date {
   const now = new Date()
   const year = now.getFullYear()
   const month = now.getMonth()

--- a/src/startOfYesterday/index.ts
+++ b/src/startOfYesterday/index.ts
@@ -21,7 +21,7 @@
  * const result = startOfYesterday()
  * //=> Sun Oct 5 2014 00:00:00
  */
-export default function startOfYesterday() {
+export default function startOfYesterday(): Date {
   const now = new Date()
   const year = now.getFullYear()
   const month = now.getMonth()

--- a/src/subDays/index.ts
+++ b/src/subDays/index.ts
@@ -1,6 +1,6 @@
-import toInteger from '../_lib/toInteger/index'
 import addDays from '../addDays/index'
 import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
 
 /**
  * @name subDays
@@ -24,7 +24,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * const result = subDays(new Date(2014, 8, 1), 10)
  * //=> Fri Aug 22 2014 00:00:00
  */
-export default function subDays(dirtyDate: Date | number, dirtyAmount: number) {
+export default function subDays(
+  dirtyDate: Date | number,
+  dirtyAmount: number
+): Date {
   requiredArgs(2, arguments)
 
   const amount = toInteger(dirtyAmount)

--- a/src/subHours/index.ts
+++ b/src/subHours/index.ts
@@ -1,6 +1,6 @@
-import toInteger from '../_lib/toInteger/index'
 import addHours from '../addHours/index'
 import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
 
 /**
  * @name subHours
@@ -24,7 +24,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * const result = subHours(new Date(2014, 6, 11, 1, 0), 2)
  * //=> Thu Jul 10 2014 23:00:00
  */
-export default function subHours(dirtyDate: Date | number, dirtyAmount: number) {
+export default function subHours(
+  dirtyDate: Date | number,
+  dirtyAmount: number
+): Date {
   requiredArgs(2, arguments)
 
   const amount = toInteger(dirtyAmount)

--- a/src/subISOWeekYears/index.ts
+++ b/src/subISOWeekYears/index.ts
@@ -1,6 +1,6 @@
-import toInteger from '../_lib/toInteger/index'
 import addISOWeekYears from '../addISOWeekYears/index'
 import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
 
 /**
  * @name subISOWeekYears
@@ -31,7 +31,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * const result = subISOWeekYears(new Date(2014, 8, 1), 5)
  * //=> Mon Aug 31 2009 00:00:00
  */
-export default function subISOWeekYears(dirtyDate: Date | number, dirtyAmount: number) {
+export default function subISOWeekYears(
+  dirtyDate: Date | number,
+  dirtyAmount: number
+): Date {
   requiredArgs(2, arguments)
 
   const amount = toInteger(dirtyAmount)

--- a/src/subMilliseconds/index.ts
+++ b/src/subMilliseconds/index.ts
@@ -1,6 +1,6 @@
-import toInteger from '../_lib/toInteger/index'
 import addMilliseconds from '../addMilliseconds/index'
 import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
 
 /**
  * @name subMilliseconds
@@ -24,7 +24,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * const result = subMilliseconds(new Date(2014, 6, 10, 12, 45, 30, 0), 750)
  * //=> Thu Jul 10 2014 12:45:29.250
  */
-export default function subMilliseconds(dirtyDate: Date | number, dirtyAmount: number) {
+export default function subMilliseconds(
+  dirtyDate: Date | number,
+  dirtyAmount: number
+): Date {
   requiredArgs(2, arguments)
 
   const amount = toInteger(dirtyAmount)

--- a/src/subMinutes/index.ts
+++ b/src/subMinutes/index.ts
@@ -1,6 +1,6 @@
-import toInteger from '../_lib/toInteger/index'
 import addMinutes from '../addMinutes/index'
 import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
 
 /**
  * @name subMinutes
@@ -24,7 +24,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * const result = subMinutes(new Date(2014, 6, 10, 12, 0), 30)
  * //=> Thu Jul 10 2014 11:30:00
  */
-export default function subMinutes(dirtyDate: Date | number, dirtyAmount: number) {
+export default function subMinutes(
+  dirtyDate: Date | number,
+  dirtyAmount: number
+): Date {
   requiredArgs(2, arguments)
 
   const amount = toInteger(dirtyAmount)


### PR DESCRIPTION
This fixes some missing type imports and adds explicit return types where they were missing.

It also fixes two additional issues I stumbled upon:
- `setWeek` options wasn't optional in the function definition (missing a `?`)
- `eachWeekOfInterval` was missing `LocaleOptions` as a type definition to its options argument. This options argument gets passed down to `startOfWeek` which accepts `LocaleOptions`.