### PR TITLE
fix `hi` locale type issues

### DIFF
--- a/src/locale/hi/_lib/formatDistance/index.ts
+++ b/src/locale/hi/_lib/formatDistance/index.ts
@@ -1,6 +1,5 @@
-import type { FormatDistanceLocale, FormatDistanceToken } from '../../../types'
-import { FormatDistanceFnOptions } from '../../../types'
-import localize from '../localize/index'
+import type { FormatDistanceFn, FormatDistanceLocale } from '../../../types'
+import { numberToLocale } from '../localize/index'
 
 // Source: https://www.unicode.org/cldr/charts/32/summary/hi.html
 
@@ -92,30 +91,20 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceLocaleValue> = {
   },
 }
 
-export default function formatDistance(
-  token: FormatDistanceToken,
-  count: number,
-  options: FormatDistanceFnOptions
-) {
-  const newOptions = options || {}
-
+const formatDistance: FormatDistanceFn = (token, count, options) => {
   let result
-  if (typeof formatDistanceLocale[token] === 'string') {
-    result = formatDistanceLocale[token]
+
+  const tokenValue = formatDistanceLocale[token]
+  if (typeof tokenValue === 'string') {
+    result = tokenValue
   } else if (count === 1) {
-    result = (formatDistanceLocale[token] as FormatDistanceTokanRelativeValue)
-      .one
+    result = tokenValue.one
   } else {
-    result = (formatDistanceLocale[
-      token
-    ] as FormatDistanceTokanRelativeValue).other.replace(
-      '{{count}}',
-      localize.numberToLocale(count)
-    )
+    result = tokenValue.other.replace('{{count}}', numberToLocale(count))
   }
 
-  if (newOptions.addSuffix) {
-    if (newOptions.comparison! > 0) {
+  if (options?.addSuffix) {
+    if (options.comparison && options.comparison > 0) {
       return result + 'मे '
     } else {
       return result + ' पहले'
@@ -124,3 +113,5 @@ export default function formatDistance(
 
   return result
 }
+
+export default formatDistance

--- a/src/locale/hi/_lib/formatRelative/index.ts
+++ b/src/locale/hi/_lib/formatRelative/index.ts
@@ -1,5 +1,4 @@
-import type { FormatRelativeToken } from '../../../types'
-import { FormatRelativeFnOptions } from '../../../types'
+import type { FormatRelativeFn } from '../../../types'
 
 const formatRelativeLocale = {
   lastWeek: "'पिछले' eeee p",
@@ -10,11 +9,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-export default function formatRelative(
-  token: FormatRelativeToken,
-  _date: Date | number,
-  _baseDate: Date | number,
-  _options: FormatRelativeFnOptions
-) {
-  return formatRelativeLocale[token]
-}
+const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
+  formatRelativeLocale[token]
+
+export default formatRelative

--- a/src/locale/hi/_lib/localize/index.ts
+++ b/src/locale/hi/_lib/localize/index.ts
@@ -1,10 +1,10 @@
-import type { Day, Era, Month, Quarter } from '../../../../types'
-import type { LocaleDayPeriod, QuarterIndex } from '../../../types'
+import type { Era, Quarter } from '../../../../types'
+import type { Localize, LocalizeFn, QuarterIndex } from '../../../types'
 import buildLocalizeFn, {
   LocalizePeriodValuesMap,
 } from '../../../_lib/buildLocalizeFn/index'
 
-export type hiLocaleNumberType =
+type hiLocaleNumberType =
   | '\u0967'
   | '\u0968'
   | '\u0969'
@@ -16,7 +16,7 @@ export type hiLocaleNumberType =
   | '\u096F'
   | '\u0966'
 
-export type enLocaleNumberType =
+type enLocaleNumberType =
   | '1'
   | '2'
   | '3'
@@ -28,11 +28,13 @@ export type enLocaleNumberType =
   | '9'
   | '0'
 
-export type enHiLocaleNumberType = {
+type enHiLocaleNumberType = {
+  // eslint-disable-next-line no-unused-vars
   [enNumber in enLocaleNumberType]: hiLocaleNumberType
 }
 
-export type hiLocaleEnNumberType = {
+type hiLocaleEnNumberType = {
+  // eslint-disable-next-line no-unused-vars
   [hiNumber in hiLocaleNumberType]: enLocaleNumberType
 }
 
@@ -88,7 +90,7 @@ const quarterValues: LocalizePeriodValuesMap<Quarter> = {
 // e.g. in Spanish language the weekdays and months should be in the lowercase.
 // https://www.unicode.org/cldr/charts/32/summary/hi.html
 // CLDR #1617 - #1688
-const monthValues: LocalizePeriodValuesMap<Month> = {
+const monthValues = {
   narrow: [
     'ज',
     'फ़',
@@ -102,7 +104,7 @@ const monthValues: LocalizePeriodValuesMap<Month> = {
     'अक्टू',
     'न',
     'दि',
-  ],
+  ] as const,
   abbreviated: [
     'जन',
     'फ़र',
@@ -116,7 +118,7 @@ const monthValues: LocalizePeriodValuesMap<Month> = {
     'अक्टू',
     'नव',
     'दिस',
-  ],
+  ] as const,
   wide: [
     'जनवरी',
     'फ़रवरी',
@@ -130,14 +132,14 @@ const monthValues: LocalizePeriodValuesMap<Month> = {
     'अक्टूबर',
     'नवंबर',
     'दिसंबर',
-  ],
+  ] as const,
 }
 
 // CLDR #1689 - #1744
-const dayValues: LocalizePeriodValuesMap<Day> = {
-  narrow: ['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श'],
-  short: ['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श'],
-  abbreviated: ['रवि', 'सोम', 'मंगल', 'बुध', 'गुरु', 'शुक्र', 'शनि'],
+const dayValues = {
+  narrow: ['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श'] as const,
+  short: ['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श'] as const,
+  abbreviated: ['रवि', 'सोम', 'मंगल', 'बुध', 'गुरु', 'शुक्र', 'शनि'] as const,
   wide: [
     'रविवार',
     'सोमवार',
@@ -146,10 +148,10 @@ const dayValues: LocalizePeriodValuesMap<Day> = {
     'गुरुवार',
     'शुक्रवार',
     'शनिवार',
-  ],
+  ] as const,
 }
 
-const dayPeriodValues: LocalizePeriodValuesMap<LocaleDayPeriod> = {
+const dayPeriodValues = {
   narrow: {
     am: 'पूर्वाह्न',
     pm: 'अपराह्न',
@@ -215,11 +217,14 @@ const formattingDayPeriodValues = {
   },
 }
 
-function ordinalNumber(dirtyNumber: string) {
-  var number = localize.localeToNumber(dirtyNumber)
-  var localeNumber = localize.numberToLocale(number)
+const ordinalNumber: LocalizeFn<number, undefined> = (
+  dirtyNumber,
+  _options
+) => {
+  const number = localeToNumber(dirtyNumber)
+  const localeNumber = numberToLocale(number)
 
-  var rem10 = number % 10
+  const rem10 = number % 10
   switch (rem10) {
     case 2:
     case 3:
@@ -248,12 +253,10 @@ export function numberToLocale(enNumber: number) {
   })
 }
 
-const localize = {
-  localeToNumber: localeToNumber,
-  numberToLocale: numberToLocale,
-  ordinalNumber: ordinalNumber,
+const localize: Localize = {
+  ordinalNumber,
 
-  era: buildLocalizeFn<Era, undefined>({
+  era: buildLocalizeFn({
     values: eraValues,
     defaultWidth: 'wide',
   }),
@@ -261,22 +264,20 @@ const localize = {
   quarter: buildLocalizeFn({
     values: quarterValues,
     defaultWidth: 'wide',
-    argumentCallback: function (quarter: Quarter) {
-      return (Number(quarter) - 1) as QuarterIndex
-    },
+    argumentCallback: (quarter) => (quarter - 1) as QuarterIndex,
   }),
 
-  month: buildLocalizeFn<Month, undefined>({
+  month: buildLocalizeFn({
     values: monthValues,
     defaultWidth: 'wide',
   }),
 
-  day: buildLocalizeFn<Day, undefined>({
+  day: buildLocalizeFn({
     values: dayValues,
     defaultWidth: 'wide',
   }),
 
-  dayPeriod: buildLocalizeFn<LocaleDayPeriod, undefined>({
+  dayPeriod: buildLocalizeFn({
     values: dayPeriodValues,
     defaultWidth: 'wide',
     formattingValues: formattingDayPeriodValues,

--- a/src/locale/hi/_lib/localize/index.ts
+++ b/src/locale/hi/_lib/localize/index.ts
@@ -242,7 +242,7 @@ function localeToNumber(locale: string): number {
   return Number(enNumber)
 }
 
-function numberToLocale(enNumber: number) {
+export function numberToLocale(enNumber: number) {
   return enNumber.toString().replace(/\d/g, function (match) {
     return numberValues.locale[match as enLocaleNumberType]
   })

--- a/src/locale/hi/_lib/localize/index.ts
+++ b/src/locale/hi/_lib/localize/index.ts
@@ -221,23 +221,8 @@ const ordinalNumber: LocalizeFn<number, undefined> = (
   dirtyNumber,
   _options
 ) => {
-  const number = localeToNumber(dirtyNumber)
-  const localeNumber = numberToLocale(number)
-
-  const rem10 = number % 10
-  switch (rem10) {
-    case 2:
-    case 3:
-    case 4:
-    case 6:
-    case 1:
-    case 5:
-    case 7:
-    case 8:
-    case 9:
-    case 0:
-      return localeNumber
-  }
+  const number = Number(dirtyNumber)
+  return numberToLocale(number)
 }
 
 export function localeToNumber(locale: string): number {

--- a/src/locale/hi/_lib/localize/index.ts
+++ b/src/locale/hi/_lib/localize/index.ts
@@ -235,7 +235,7 @@ function ordinalNumber(dirtyNumber: string) {
   }
 }
 
-function localeToNumber(locale: string): number {
+export function localeToNumber(locale: string): number {
   const enNumber = locale.toString().replace(/[१२३४५६७८९०]/g, function (match) {
     return numberValues.number[match as hiLocaleNumberType]
   })

--- a/src/locale/hi/_lib/match/index.ts
+++ b/src/locale/hi/_lib/match/index.ts
@@ -1,8 +1,8 @@
-import { Day, Era, Month, Quarter } from '../../../../types'
-import type { ParsePatterns } from '../../../types'
+import type { Quarter } from '../../../../types'
+import type { Match } from '../../../types'
 import buildMatchFn from '../../../_lib/buildMatchFn/index'
 import buildMatchPatternFn from '../../../_lib/buildMatchPatternFn/index'
-import localize from '../localize/index'
+import { localeToNumber } from '../localize/index'
 
 const matchOrdinalNumberPattern = /^[०१२३४५६७८९]+/i
 const parseOrdinalNumberPattern = /^[०१२३४५६७८९]+/i
@@ -13,8 +13,8 @@ const matchEraPatterns = {
   wide: /^(ईसा-पूर्व|ईसवी पूर्व|ईसवी सन|ईसवी)/i,
 }
 
-const parseEraPatterns: ParsePatterns<Era, 'any'> = {
-  any: [/^b/i, /^(a|c)/i],
+const parseEraPatterns = {
+  any: [/^b/i, /^(a|c)/i] as const,
 }
 
 const matchQuarterPatterns = {
@@ -22,8 +22,8 @@ const matchQuarterPatterns = {
   abbreviated: /^ति[1234]/i,
   wide: /^[1234](पहली|दूसरी|तीसरी|चौथी)? तिमाही/i,
 }
-const parseQuarterPatterns: ParsePatterns<Quarter, 'any'> = {
-  any: [/1/i, /2/i, /3/i, /4/i],
+const parseQuarterPatterns = {
+  any: [/1/i, /2/i, /3/i, /4/i] as const,
 }
 
 const matchMonthPatterns = {
@@ -32,7 +32,7 @@ const matchMonthPatterns = {
   abbreviated: /^(जन|फ़र|मार्च|अप्|मई|जून|जुल|अग|सित|अक्तू|नव|दिस)/i,
   wide: /^(जनवरी|फ़रवरी|मार्च|अप्रैल|मई|जून|जुलाई|अगस्त|सितंबर|अक्तूबर|नवंबर|दिसंबर)/i,
 }
-const parseMonthPatterns: ParsePatterns<Month, 'narrow' | 'any'> = {
+const parseMonthPatterns = {
   narrow: [
     /^ज/i,
     /^फ़/i,
@@ -46,7 +46,7 @@ const parseMonthPatterns: ParsePatterns<Month, 'narrow' | 'any'> = {
     /^अक्तू/i,
     /^न/i,
     /^दि/i,
-  ],
+  ] as const,
   any: [
     /^जन/i,
     /^फ़/i,
@@ -60,7 +60,7 @@ const parseMonthPatterns: ParsePatterns<Month, 'narrow' | 'any'> = {
     /^अक्तू/i,
     /^नव/i,
     /^दिस/i,
-  ],
+  ] as const,
 }
 
 const matchDayPatterns = {
@@ -70,9 +70,25 @@ const matchDayPatterns = {
   abbreviated: /^(रवि|सोम|मंगल|बुध|गुरु|शुक्र|शनि)/i,
   wide: /^(रविवार|सोमवार|मंगलवार|बुधवार|गुरुवार|शुक्रवार|शनिवार)/i,
 }
-const parseDayPatterns: ParsePatterns<Day, 'narrow' | 'any'> = {
-  narrow: [/^रवि/i, /^सोम/i, /^मंगल/i, /^बुध/i, /^गुरु/i, /^शुक्र/i, /^शनि/i],
-  any: [/^रवि/i, /^सोम/i, /^मंगल/i, /^बुध/i, /^गुरु/i, /^शुक्र/i, /^शनि/i],
+const parseDayPatterns = {
+  narrow: [
+    /^रवि/i,
+    /^सोम/i,
+    /^मंगल/i,
+    /^बुध/i,
+    /^गुरु/i,
+    /^शुक्र/i,
+    /^शनि/i,
+  ] as const,
+  any: [
+    /^रवि/i,
+    /^सोम/i,
+    /^मंगल/i,
+    /^बुध/i,
+    /^गुरु/i,
+    /^शुक्र/i,
+    /^शनि/i,
+  ] as const,
 }
 
 const matchDayPeriodPatterns = {
@@ -92,11 +108,11 @@ const parseDayPeriodPatterns = {
   },
 }
 
-const match = {
-  ordinalNumber: buildMatchPatternFn<number>({
+const match: Match = {
+  ordinalNumber: buildMatchPatternFn({
     matchPattern: matchOrdinalNumberPattern,
     parsePattern: parseOrdinalNumberPattern,
-    valueCallback: localize.localeToNumber,
+    valueCallback: localeToNumber,
   }),
 
   era: buildMatchFn({
@@ -111,9 +127,7 @@ const match = {
     defaultMatchWidth: 'wide',
     parsePatterns: parseQuarterPatterns,
     defaultParseWidth: 'any',
-    valueCallback: function (index: string | number) {
-      return (Number(index) + 1) as Quarter
-    },
+    valueCallback: (index) => (index + 1) as Quarter,
   }),
 
   month: buildMatchFn({

--- a/src/locale/hi/index.ts
+++ b/src/locale/hi/index.ts
@@ -1,3 +1,4 @@
+import type { Locale } from '../types'
 import formatDistance from './_lib/formatDistance/index'
 import formatLong from './_lib/formatLong/index'
 import formatRelative from './_lib/formatRelative/index'

--- a/src/locale/types.ts
+++ b/src/locale/types.ts
@@ -74,8 +74,8 @@ export interface FormatRelativeFnOptions {
 
 export type FormatRelativeFn = (
   token: FormatRelativeToken,
-  date: Date | number,
-  baseDate: Date | number,
+  date: Date,
+  baseDate: Date,
   options?: FormatRelativeFnOptions
 ) => string
 


### PR DESCRIPTION
See my comment on the merged PR for `hi`: [#2669](https://github.com/date-fns/date-fns/pull/2669#issuecomment-992592632)

~The ordinalNumber function in localize still has issues, so this is in draft mode.~

Out of draft mode, but would still like a review / confirmation that the `ordinalNumber` function is OK @minitesh 