### PR TITLE
Allow setting global locale via `setLocale`

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -1,7 +1,14 @@
 import isValid from '../isValid/index'
-import defaultLocale from '../locale/en-US/index'
+import { getLocale } from '../setLocale/index'
 import subMilliseconds from '../subMilliseconds/index'
 import toDate from '../toDate/index'
+import type {
+  Day,
+  FirstWeekContainsDate,
+  FirstWeekContainsDateOptions,
+  LocaleOptions,
+  WeekStartOptions,
+} from '../types'
 import formatters from '../_lib/format/formatters/index'
 import longFormatters from '../_lib/format/longFormatters/index'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index'
@@ -10,15 +17,8 @@ import {
   isProtectedWeekYearToken,
   throwProtectedError,
 } from '../_lib/protectedTokens/index'
-import toInteger from '../_lib/toInteger/index'
 import requiredArgs from '../_lib/requiredArgs/index'
-import type {
-  FirstWeekContainsDateOptions,
-  LocaleOptions,
-  WeekStartOptions,
-  Day,
-  FirstWeekContainsDate,
-} from '../types'
+import toInteger from '../_lib/toInteger/index'
 
 // This RegExp consists of three parts separated by `|`:
 // - [yYQqMLwIdDecihHKkms]o matches any available ordinal number token
@@ -316,21 +316,31 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *
  * @example
  * // Represent 11 February 2014 in middle-endian format:
- * const result = format(new Date(2014, 1, 11), 'MM/dd/yyyy')
- * //=> '02/11/2014'
+ * format(new Date(2014, 1, 11), 'MM/dd/yyyy')
+ * //=> "02/11/2014"
  *
  * @example
+ * import eo from 'date-fns/locale/eo'
+ *
  * // Represent 2 July 2014 in Esperanto:
- * import { eoLocale } from 'date-fns/locale/eo'
- * const result = format(new Date(2014, 6, 2), "do 'de' MMMM yyyy", {
- *   locale: eoLocale
+ * format(new Date(2014, 6, 2), "do 'de' MMMM yyyy", {
+ *   locale: eo
  * })
- * //=> '2-a de julio 2014'
+ * //=> "2-a de julio 2014"
  *
  * @example
  * // Escape string by single quote characters:
- * const result = format(new Date(2014, 6, 2, 15), "h 'o''clock'")
+ * format(new Date(2014, 6, 2, 15), "h 'o''clock'")
  * //=> "3 o'clock"
+ *
+ * @example
+ * import { setLocale } from 'date-fns'
+ * import eo from 'date-fns/locale/eo'
+ *
+ * // Set and use the global locale
+ * setLocale(eo)
+ * format(new Date(2014, 6, 2), "do 'de' MMMM yyyy")
+ * //=> "2-a de julio 2014"
  */
 
 export default function format(
@@ -348,7 +358,7 @@ export default function format(
   const formatStr = String(dirtyFormatStr)
   const options = dirtyOptions || {}
 
-  const locale = options.locale || defaultLocale
+  const locale = options.locale || getLocale()
 
   const localeFirstWeekContainsDate =
     locale.options && locale.options.firstWeekContainsDate

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -3,6 +3,9 @@
 import assert from 'assert'
 import sinon from 'sinon'
 import format from '.'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+import setLocale from '../setLocale'
 
 describe('format', () => {
   const date = new Date(1986, 3 /* Apr */, 4, 10, 32, 55, 123)
@@ -746,6 +749,19 @@ describe('format', () => {
         formatString
       ) === '2014-04-04'
     )
+  })
+
+  describe('global locale', () => {
+    afterEach(() => {
+      setLocale(enUS)
+    })
+
+    it('uses the global locale', () => {
+      const date = new Date(2014, 6, 2)
+      assert(format(date, 'PPpp') === 'Jul 2, 2014, 12:00:00 AM')
+      setLocale(ru)
+      assert(format(date, 'PPpp') === '2 июл. 2014 г., 0:00:00')
+    })
   })
 
   describe('custom locale', () => {

--- a/src/formatDistance/index.ts
+++ b/src/formatDistance/index.ts
@@ -1,13 +1,13 @@
 import compareAsc from '../compareAsc/index'
 import differenceInMonths from '../differenceInMonths/index'
 import differenceInSeconds from '../differenceInSeconds/index'
-import defaultLocale from '../locale/en-US/index'
+import { getLocale } from '../setLocale/index'
 import toDate from '../toDate/index'
-import cloneObject from '../_lib/cloneObject/index'
+import type { LocaleOptions } from '../types'
 import assign from '../_lib/assign'
+import cloneObject from '../_lib/cloneObject/index'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index'
 import requiredArgs from '../_lib/requiredArgs/index'
-import type { LocaleOptions } from '../types'
 
 const MINUTES_IN_DAY = 1440
 const MINUTES_IN_ALMOST_TWO_DAYS = 2520
@@ -65,34 +65,44 @@ const MINUTES_IN_TWO_MONTHS = 86400
  *
  * @example
  * // What is the distance between 2 July 2014 and 1 January 2015?
- * const result = formatDistance(new Date(2014, 6, 2), new Date(2015, 0, 1))
- * //=> '6 months'
+ * formatDistance(new Date(2014, 6, 2), new Date(2015, 0, 1))
+ * //=> "6 months"
  *
  * @example
  * // What is the distance between 1 January 2015 00:00:15
  * // and 1 January 2015 00:00:00, including seconds?
- * const result = formatDistance(
+ * formatDistance(
  *   new Date(2015, 0, 1, 0, 0, 15),
  *   new Date(2015, 0, 1, 0, 0, 0),
  *   { includeSeconds: true }
  * )
- * //=> 'less than 20 seconds'
+ * //=> "less than 20 seconds"
  *
  * @example
  * // What is the distance from 1 January 2016
  * // to 1 January 2015, with a suffix?
- * const result = formatDistance(new Date(2015, 0, 1), new Date(2016, 0, 1), {
+ * formatDistance(new Date(2015, 0, 1), new Date(2016, 0, 1), {
  *   addSuffix: true
  * })
- * //=> 'about 1 year ago'
+ * //=> "about 1 year ago"
  *
  * @example
+ * import eo from 'date-fns/locale/eo'
+ *
  * // What is the distance between 1 August 2016 and 1 January 2015 in Esperanto?
- * import { eoLocale } from 'date-fns/locale/eo'
- * const result = formatDistance(new Date(2016, 7, 1), new Date(2015, 0, 1), {
+ * formatDistance(new Date(2016, 7, 1), new Date(2015, 0, 1), {
  *   locale: eoLocale
  * })
- * //=> 'pli ol 1 jaro'
+ * //=> "pli ol 1 jaro"
+ *
+ * @example
+ * import { setLocale } from 'date-fns'
+ * import eo from 'date-fns/locale/eo'
+ *
+ * // Set and use the global locale
+ * setLocale(eo)
+ * formatDistance(new Date(2016, 7, 1), new Date(2015, 0, 1))
+ * //=> "pli ol 1 jaro"
  */
 
 export default function formatDistance(
@@ -105,7 +115,7 @@ export default function formatDistance(
 ): string {
   requiredArgs(2, arguments)
 
-  const locale = options.locale || defaultLocale
+  const locale = options.locale || getLocale()
 
   if (!locale.formatDistance) {
     throw new RangeError('locale must contain formatDistance property')

--- a/src/formatDistance/test.ts
+++ b/src/formatDistance/test.ts
@@ -1,8 +1,11 @@
 /* eslint-env mocha */
 
 import assert from 'assert'
-import type { FormatDistanceFn } from '../locale/types'
 import formatDistance from '.'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+import type { FormatDistanceFn } from '../locale/types'
+import setLocale from '../setLocale'
 
 describe('formatDistance', () => {
   describe('seconds', () => {
@@ -236,6 +239,20 @@ describe('formatDistance', () => {
         }
       )
       assert(result === 'in about 1 hour')
+    })
+  })
+
+  describe('global locale', () => {
+    afterEach(() => {
+      setLocale(enUS)
+    })
+
+    it('uses the global locale', () => {
+      const dateA = new Date(1986, 3, 4, 11, 32, 0)
+      const dateB = new Date(1986, 3, 4, 10, 32, 0)
+      assert(formatDistance(dateA, dateB) === 'about 1 hour')
+      setLocale(ru)
+      assert(formatDistance(dateA, dateB) === 'около 1 часа')
     })
   })
 

--- a/src/formatDistanceStrict/index.ts
+++ b/src/formatDistanceStrict/index.ts
@@ -3,9 +3,9 @@ import compareAsc from '../compareAsc/index'
 import toDate from '../toDate/index'
 import cloneObject from '../_lib/cloneObject/index'
 import assign from '../_lib/assign/index'
-import defaultLocale from '../locale/en-US/index'
 import requiredArgs from '../_lib/requiredArgs/index'
 import type { LocaleOptions, Unit } from '../types'
+import { getLocale } from '../setLocale/index'
 
 const MILLISECONDS_IN_MINUTE = 1000 * 60
 const MINUTES_IN_DAY = 60 * 24
@@ -48,50 +48,60 @@ const MINUTES_IN_YEAR = MINUTES_IN_DAY * 365
  *
  * @example
  * // What is the distance between 2 July 2014 and 1 January 2015?
- * const result = formatDistanceStrict(new Date(2014, 6, 2), new Date(2015, 0, 2))
- * //=> '6 months'
+ * formatDistanceStrict(new Date(2014, 6, 2), new Date(2015, 0, 2))
+ * //=> "6 months"
  *
  * @example
  * // What is the distance between 1 January 2015 00:00:15
  * // and 1 January 2015 00:00:00?
- * const result = formatDistanceStrict(
+ * formatDistanceStrict(
  *   new Date(2015, 0, 1, 0, 0, 15),
  *   new Date(2015, 0, 1, 0, 0, 0)
  * )
- * //=> '15 seconds'
+ * //=> "15 seconds"
  *
  * @example
  * // What is the distance from 1 January 2016
  * // to 1 January 2015, with a suffix?
- * const result = formatDistanceStrict(new Date(2015, 0, 1), new Date(2016, 0, 1), {
+ * formatDistanceStrict(new Date(2015, 0, 1), new Date(2016, 0, 1), {
  *   addSuffix: true
  * })
- * //=> '1 year ago'
+ * //=> "1 year ago"
  *
  * @example
  * // What is the distance from 1 January 2016
  * // to 1 January 2015, in minutes?
- * const result = formatDistanceStrict(new Date(2016, 0, 1), new Date(2015, 0, 1), {
+ * formatDistanceStrict(new Date(2016, 0, 1), new Date(2015, 0, 1), {
  *   unit: 'minute'
  * })
- * //=> '525600 minutes'
+ * //=> "525600 minutes"
  *
  * @example
  * // What is the distance from 1 January 2015
  * // to 28 January 2015, in months, rounded up?
- * const result = formatDistanceStrict(new Date(2015, 0, 28), new Date(2015, 0, 1), {
+ * formatDistanceStrict(new Date(2015, 0, 28), new Date(2015, 0, 1), {
  *   unit: 'month',
  *   roundingMethod: 'ceil'
  * })
- * //=> '1 month'
+ * //=> "1 month"
  *
  * @example
+ * import eo from 'date-fns/locale/eo'
+ *
  * // What is the distance between 1 August 2016 and 1 January 2015 in Esperanto?
- * import { eoLocale } from 'date-fns/locale/eo'
- * const result = formatDistanceStrict(new Date(2016, 7, 1), new Date(2015, 0, 1), {
- *   locale: eoLocale
+ * formatDistanceStrict(new Date(2016, 7, 1), new Date(2015, 0, 1), {
+ *   locale: eo
  * })
- * //=> '1 jaro'
+ * //=> "1 jaro"
+ *
+ * @example
+ * import { setLocale } from 'date-fns'
+ * import eo from 'date-fns/locale/eo'
+ *
+ * // Set and use the global locale
+ * setLocale(eo)
+ * formatDistanceStrict(new Date(2016, 7, 1), new Date(2015, 0, 1))
+ * //=> "1 jaro"
  */
 
 export default function formatDistanceStrict(
@@ -105,7 +115,7 @@ export default function formatDistanceStrict(
 ): string {
   requiredArgs(2, arguments)
 
-  const locale = options.locale || defaultLocale
+  const locale = options.locale || getLocale()
 
   if (!locale.formatDistance) {
     throw new RangeError('locale must contain localize.formatDistance property')

--- a/src/formatDistanceStrict/test.ts
+++ b/src/formatDistanceStrict/test.ts
@@ -3,6 +3,9 @@
 import assert from 'assert'
 import type { FormatDistanceFn } from '../locale/types'
 import formatDistanceStrict from '.'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+import setLocale from '../setLocale'
 
 describe('formatDistanceStrict', () => {
   describe('seconds', () => {
@@ -421,6 +424,20 @@ describe('formatDistanceStrict', () => {
         }
       )
       assert(result === '2 minutes')
+    })
+  })
+
+  describe('global locale', () => {
+    afterEach(() => {
+      setLocale(enUS)
+    })
+
+    it('uses the global locale', () => {
+      const dateA = new Date(1986, 3, 4, 10, 32, 0)
+      const dateB = new Date(1986, 3, 4, 10, 33, 1)
+      assert(formatDistanceStrict(dateA, dateB) === '1 minute')
+      setLocale(ru)
+      assert(formatDistanceStrict(dateA, dateB) === '1 минута')
     })
   })
 

--- a/src/formatDuration/index.ts
+++ b/src/formatDuration/index.ts
@@ -1,6 +1,6 @@
-import defaultLocale from '../locale/en-US/index'
 import type { FormatDistanceToken, Locale } from '../locale/types'
 import type { Duration } from '../types'
+import { getLocale } from '../setLocale/index'
 
 const defaultFormat: (keyof Duration)[] = [
   'years',
@@ -47,12 +47,12 @@ interface Options {
  *   minutes: 9,
  *   seconds: 30
  * })
- * //=> '2 years 9 months 1 week 7 days 5 hours 9 minutes 30 seconds'
+ * //=> "2 years 9 months 1 week 7 days 5 hours 9 minutes 30 seconds"
  *
  * @example
  * // Format partial duration
  * formatDuration({ months: 9, days: 2 })
- * //=> '9 months 2 days'
+ * //=> "9 months 2 days"
  *
  * @example
  * // Customize the format
@@ -67,19 +67,28 @@ interface Options {
  *     seconds: 30
  *   },
  *   { format: ['months', 'weeks'] }
- * ) === '9 months 1 week'
+ * ) === "9 months 1 week"
  *
  * @example
  * // Customize the zeros presence
  * formatDuration({ years: 0, months: 9 })
- * //=> '9 months'
+ * //=> "9 months"
  * formatDuration({ years: 0, months: 9 }, { zero: true })
- * //=> '0 years 9 months'
+ * //=> "0 years 9 months"
  *
  * @example
  * // Customize the delimiter
  * formatDuration({ years: 2, months: 9, weeks: 3 }, { delimiter: ', ' })
- * //=> '2 years, 9 months, 3 weeks'
+ * //=> "2 years, 9 months, 3 weeks"
+ *
+ * @example
+ * import { setLocale } from 'date-fns'
+ * import eo from 'date-fns/locale/eo'
+ *
+ * // Set and use the global locale
+ * setLocale(eo)
+ * formatDuration({ months: 9, days: 2 })
+ * //=> "9 monatoj 2 tagoj"
  */
 export default function formatDuration(
   duration: Duration,
@@ -92,7 +101,7 @@ export default function formatDuration(
   }
 
   const format = options?.format || defaultFormat
-  const locale = options?.locale || defaultLocale
+  const locale = options?.locale || getLocale()
   const zero = options?.zero || false
   const delimiter = options?.delimiter || ' '
 

--- a/src/formatDuration/test.ts
+++ b/src/formatDuration/test.ts
@@ -2,6 +2,9 @@
 
 import assert from 'assert'
 import formatDuration from '.'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+import setLocale from '../setLocale'
 
 describe('formatDuration', () => {
   it('formats full duration', () => {
@@ -75,6 +78,19 @@ describe('formatDuration', () => {
       formatDuration({ months: 9, days: 2 }, { delimiter: ', ' }) ===
         '9 months, 2 days'
     )
+  })
+
+  describe('global locale', () => {
+    afterEach(() => {
+      setLocale(enUS)
+    })
+
+    it('uses the global locale', () => {
+      const duration = { months: 9, days: 2 }
+      assert(formatDuration(duration) === '9 months 2 days')
+      setLocale(ru)
+      assert(formatDuration(duration) === '9 месяцев 2 дня')
+    })
   })
 
   it('throws TypeError exception if passed less than 1 argument', () => {

--- a/src/formatRelative/index.ts
+++ b/src/formatRelative/index.ts
@@ -1,12 +1,12 @@
 import differenceInCalendarDays from '../differenceInCalendarDays/index'
 import format from '../format/index'
-import defaultLocale from '../locale/en-US/index'
 import subMilliseconds from '../subMilliseconds/index'
 import toDate from '../toDate/index'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index'
 import requiredArgs from '../_lib/requiredArgs/index'
 import type { LocaleOptions, WeekStartOptions } from '../types'
 import type { FormatRelativeToken } from '../locale/types'
+import { getLocale } from '../setLocale/index'
 
 /**
  * @name formatRelative
@@ -41,8 +41,17 @@ import type { FormatRelativeToken } from '../locale/types'
  *
  * @example
  * // Represent the date of 6 days ago in words relative to the given base date. In this example, today is Wednesday
- * const result = formatRelative(addDays(new Date(), -6), new Date())
+ * formatRelative(addDays(new Date(), -6), new Date())
  * //=> "last Thursday at 12:45 AM"
+ *
+ * @example
+ * import { setLocale } from 'date-fns'
+ * import eo from 'date-fns/locale/eo'
+ *
+ * // Set and use the global locale
+ * setLocale(eo)
+ * formatRelative(addDays(new Date(), -6), new Date())
+ * //=> "pasinta vendredo je 12:45"
  */
 export default function formatRelative(
   dirtyDate: Date | number,
@@ -54,7 +63,7 @@ export default function formatRelative(
   const date = toDate(dirtyDate)
   const baseDate = toDate(dirtyBaseDate)
 
-  const { locale = defaultLocale, weekStartsOn = 0 } = dirtyOptions || {}
+  const { locale = getLocale(), weekStartsOn = 0 } = dirtyOptions || {}
 
   if (!locale.localize) {
     throw new RangeError('locale must contain localize property')

--- a/src/formatRelative/test.ts
+++ b/src/formatRelative/test.ts
@@ -2,6 +2,9 @@
 
 import assert from 'assert'
 import formatRelative from '.'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+import setLocale from '../setLocale'
 
 describe('formatRelative', () => {
   const baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900)
@@ -95,6 +98,19 @@ describe('formatRelative', () => {
       date.setFullYear(7, 11 /* Dec */, 31)
       date.setHours(0, 0, 0, 0)
       assert(formatRelative(date, baseDate) === '12/31/0007')
+    })
+  })
+
+  describe('global locale', () => {
+    afterEach(() => {
+      setLocale(enUS)
+    })
+
+    it('uses the global locale', () => {
+      const date = new Date(1986, 3 /* Apr */, 1)
+      assert(formatRelative(date, baseDate) === 'last Tuesday at 12:00 AM')
+      setLocale(ru)
+      assert(formatRelative(date, baseDate) === 'во вторник в 0:00')
     })
   })
 

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -1,4 +1,4 @@
-import defaultLocale from '../locale/en-US/index'
+import { getLocale } from '../setLocale/index'
 import subMilliseconds from '../subMilliseconds/index'
 import toDate from '../toDate/index'
 import assign from '../_lib/assign/index'
@@ -9,9 +9,9 @@ import {
   isProtectedWeekYearToken,
   throwProtectedError,
 } from '../_lib/protectedTokens/index'
+import requiredArgs from '../_lib/requiredArgs/index'
 import toInteger from '../_lib/toInteger/index'
 import parsers from './_lib/parsers/index'
-import requiredArgs from '../_lib/requiredArgs/index'
 
 var TIMEZONE_UNIT_PRIORITY = 10
 
@@ -328,15 +328,25 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *
  * @example
  * // Parse 11 February 2014 from middle-endian format:
- * var result = parse('02/11/2014', 'MM/dd/yyyy', new Date())
+ * parse('02/11/2014', 'MM/dd/yyyy', new Date())
  * //=> Tue Feb 11 2014 00:00:00
  *
  * @example
- * // Parse 28th of February in Esperanto locale in the context of 2010 year:
  * import eo from 'date-fns/locale/eo'
- * var result = parse('28-a de februaro', "do 'de' MMMM", new Date(2010, 0, 1), {
+ *
+ * // Parse 28th of February in Esperanto locale in the context of 2010 year:
+ * parse('28-a de februaro', "do 'de' MMMM", new Date(2010, 0, 1), {
  *   locale: eo
  * })
+ * //=> Sun Feb 28 2010 00:00:00
+ *
+ * @example
+ * import { setLocale } from 'date-fns'
+ * import eo from 'date-fns/locale/eo'
+ *
+ * // Set and use the global locale
+ * setLocale(eo)
+ * parse('28-a de februaro', "do 'de' MMMM")
  * //=> Sun Feb 28 2010 00:00:00
  */
 export default function parse(
@@ -351,7 +361,7 @@ export default function parse(
   var formatString = String(dirtyFormatString)
   var options = dirtyOptions || {}
 
-  var locale = options.locale || defaultLocale
+  var locale = options.locale || getLocale()
 
   if (!locale.match) {
     throw new RangeError('locale must contain match property')

--- a/src/parse/test.ts
+++ b/src/parse/test.ts
@@ -2,6 +2,9 @@
 
 import assert from 'assert'
 import parse from '.'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+import setLocale from '../setLocale'
 
 describe('parse', () => {
   const referenceDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900)
@@ -2315,6 +2318,24 @@ describe('parse', () => {
         const result = parse('60', 'ss', referenceDate)
         assert(result instanceof Date && isNaN(result.getTime()))
       })
+    })
+  })
+
+  describe('global locale', () => {
+    afterEach(() => {
+      setLocale(enUS)
+    })
+
+    it('uses the global locale', () => {
+      assert.deepStrictEqual(
+        parse('11 February 1987', 'dd MMMM yyyy', new Date()),
+        new Date(1987, 1, 11)
+      )
+      setLocale(ru)
+      assert.deepStrictEqual(
+        parse('11 Февраля 1987', 'dd MMMM yyyy', new Date()),
+        new Date(1987, 1, 11)
+      )
     })
   })
 

--- a/src/setLocale/index.ts
+++ b/src/setLocale/index.ts
@@ -1,0 +1,48 @@
+import enUS from '../locale/en-US/index'
+import type { Locale } from '../locale/types'
+
+let currentLocale = enUS
+
+/**
+ * @name setLocale
+ * @category Common Helpers
+ * @summary Set the current locale
+ *
+ * @description
+ * Set the current locale to be used in the functions that support I18n, such
+ * as `format`, `formatRelative`, `parse`, etc.
+ *
+ * @param {Locale} locale - the locale to set as the current
+ *
+ * @example
+ * import ru from 'date-fns/locale/ru'
+ * import { setLocale, format } from 'date-fns'
+ *
+ * format(new Date(2014, 6, 2), "PPpp")
+ * //=> "Jul 2, 2014, 12:00:00 AM"
+ *
+ * // Set Russian locale as the default
+ * setLocale(ru)
+ *
+ * format(new Date(2014, 6, 2), "PPpp")
+ * //=> "2 июл. 2014 г., 0:00:00"
+ */
+export default function setLocale(locale: Locale) {
+  currentLocale = locale
+}
+
+/**
+ * @private
+ *
+ * @name getLocale
+ * @category Common Helpers
+ * @summary Get the current locale
+ *
+ * @description
+ * Get the current locale.
+ *
+ * @returns the current locale
+ */
+export function getLocale(): Locale {
+  return currentLocale
+}

--- a/src/setLocale/test.ts
+++ b/src/setLocale/test.ts
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+
+import assert from 'assert'
+import setLocale, { getLocale } from '.'
+import format from '../format'
+import enUS from '../locale/en-US'
+import ru from '../locale/ru'
+
+describe('setLocale', () => {
+  afterEach(() => {
+    setLocale(enUS)
+  })
+
+  it('allows to set the current locale', () => {
+    const date = new Date(2014, 6, 2)
+    assert(format(date, 'PPpp') === 'Jul 2, 2014, 12:00:00 AM')
+    setLocale(ru)
+    assert(format(date, 'PPpp') === '2 июл. 2014 г., 0:00:00')
+  })
+
+  describe('getLocale', () => {
+    it('returns the current locale', () => {
+      assert(getLocale() === enUS)
+      setLocale(ru)
+      assert(getLocale() === ru)
+    })
+  })
+})


### PR DESCRIPTION
`setLocale` allows setting the global locale instead of `en-US`.

It affects `format`, `formatDistance`, `formatDistanceStrict`, `formatDuration`, formatRelative` and `parse` and well "now" variants of some of those functions.