### PR TITLE
Allowing `formatRelative` to use partial locale values #1468

### DIFF
--- a/src/formatRelative/index.ts
+++ b/src/formatRelative/index.ts
@@ -5,8 +5,9 @@ import subMilliseconds from '../subMilliseconds/index'
 import toDate from '../toDate/index'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index'
 import requiredArgs from '../_lib/requiredArgs/index'
-import type { LocaleOptions, WeekStartOptions } from '../types'
+import type { WeekStartOptions } from '../types'
 import type { FormatRelativeToken } from '../locale/types'
+import { PartialLocaleOptions } from '../types';
 
 /**
  * @name formatRelative
@@ -47,26 +48,15 @@ import type { FormatRelativeToken } from '../locale/types'
 export default function formatRelative(
   dirtyDate: Date | number,
   dirtyBaseDate: Date | number,
-  dirtyOptions?: LocaleOptions & WeekStartOptions
+  dirtyOptions?: PartialLocaleOptions & WeekStartOptions
 ): string {
   requiredArgs(2, arguments)
 
   const date = toDate(dirtyDate)
   const baseDate = toDate(dirtyBaseDate)
 
-  const { locale = defaultLocale, weekStartsOn = 0 } = dirtyOptions || {}
-
-  if (!locale.localize) {
-    throw new RangeError('locale must contain localize property')
-  }
-
-  if (!locale.formatLong) {
-    throw new RangeError('locale must contain formatLong property')
-  }
-
-  if (!locale.formatRelative) {
-    throw new RangeError('locale must contain formatRelative property')
-  }
+  const weekStartsOn = dirtyOptions?.weekStartsOn || defaultLocale.options?.weekStartsOn || 0;
+  const locale = { ...defaultLocale, ...(dirtyOptions?.locale || {}) }
 
   const diff = differenceInCalendarDays(date, baseDate)
 

--- a/src/formatRelative/index.ts
+++ b/src/formatRelative/index.ts
@@ -28,16 +28,13 @@ import type { FormatRelativeToken } from '../locale/types'
  * @param {Date|Number} date - the date to format
  * @param {Date|Number} baseDate - the date to compare with
  * @param {Object} [options] - an object with options.
- * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @param {Partial<Locale>} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @returns {String} the date in words
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `date` must not be Invalid Date
  * @throws {RangeError} `baseDate` must not be Invalid Date
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
- * @throws {RangeError} `options.locale` must contain `localize` property
- * @throws {RangeError} `options.locale` must contain `formatLong` property
- * @throws {RangeError} `options.locale` must contain `formatRelative` property
  *
  * @example
  * // Represent the date of 6 days ago in words relative to the given base date. In this example, today is Wednesday

--- a/src/formatRelative/index.ts
+++ b/src/formatRelative/index.ts
@@ -5,9 +5,8 @@ import subMilliseconds from '../subMilliseconds/index'
 import toDate from '../toDate/index'
 import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMilliseconds/index'
 import requiredArgs from '../_lib/requiredArgs/index'
-import type { WeekStartOptions } from '../types'
+import type { PartialLocaleOptions, WeekStartOptions } from '../types'
 import type { FormatRelativeToken } from '../locale/types'
-import { PartialLocaleOptions } from '../types';
 
 /**
  * @name formatRelative

--- a/src/formatRelative/test.ts
+++ b/src/formatRelative/test.ts
@@ -123,50 +123,18 @@ describe('formatRelative', () => {
           locale: customLocale,
         }
       )
-      assert(result === 'It works perfectly!')
+      assert.strictEqual(result, 'It works perfectly!')
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `localize` property", () => {
+    it("works as usual even if `options.locale` only has `formatRelative` property", () => {
       const customLocale = {
-        formatLong: {},
-        formatRelative: () => {
-          return ''
-        },
+        formatRelative: () => 'MM/dd/yyyy',
       }
-      const block = () =>
-        formatRelative(new Date(2017, 0, 1), baseDate, {
-          // @ts-expect-error
-          locale: customLocale,
-        })
-      assert.throws(block, RangeError)
-    })
+      const result = formatRelative(new Date(2017, 0, 1), baseDate, {
+        locale: customLocale,
+      })
 
-    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", () => {
-      const customLocale = {
-        localize: {},
-        formatRelative: () => {
-          return ''
-        },
-      }
-      const block = () =>
-        formatRelative(new Date(2017, 0, 1), baseDate, {
-          // @ts-expect-error
-          locale: customLocale,
-        })
-      assert.throws(block, RangeError)
-    })
-
-    it("throws `RangeError` if `options.locale` doesn't have `formatRelative` property", () => {
-      const customLocale = {
-        localize: {},
-        formatLong: {},
-      }
-      const block = () =>
-        formatRelative(new Date(2017, 0, 1), baseDate, {
-          // @ts-expect-error
-          locale: customLocale,
-        })
-      assert.throws(block, RangeError)
+      assert.strictEqual(result, '01/01/2017')
     })
   })
 

--- a/src/locale/af/_lib/formatRelative/index.ts
+++ b/src/locale/af/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ar-DZ/_lib/formatRelative/index.ts
+++ b/src/locale/ar-DZ/_lib/formatRelative/index.ts
@@ -9,13 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (
-  token,
-  _date,
-  _baseDate,
-  _options
-) => {
-  return formatRelativeLocale[token]
-}
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ar-EG/_lib/formatRelative/index.ts
+++ b/src/locale/ar-EG/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ar-MA/_lib/formatRelative/index.ts
+++ b/src/locale/ar-MA/_lib/formatRelative/index.ts
@@ -9,13 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (
-  token,
-  _date,
-  _baseDate,
-  _options
-) => {
-  return formatRelativeLocale[token]
-}
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ar-SA/_lib/formatRelative/index.ts
+++ b/src/locale/ar-SA/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/az/_lib/formatRelative/index.ts
+++ b/src/locale/az/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/bn/_lib/formatRelative/index.ts
+++ b/src/locale/bn/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/bs/_lib/formatRelative/index.ts
+++ b/src/locale/bs/_lib/formatRelative/index.ts
@@ -31,7 +31,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/ca/_lib/formatRelative/index.ts
+++ b/src/locale/ca/_lib/formatRelative/index.ts
@@ -18,7 +18,7 @@ const formatRelativeLocalePlural = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   if (date.getUTCHours() !== 1) {
     return formatRelativeLocalePlural[token]
   }

--- a/src/locale/cy/_lib/formatRelative/index.ts
+++ b/src/locale/cy/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/da/_lib/formatRelative/index.ts
+++ b/src/locale/da/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/de/_lib/formatRelative/index.ts
+++ b/src/locale/de/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/en-US/_lib/formatRelative/index.ts
+++ b/src/locale/en-US/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/eo/_lib/formatRelative/index.ts
+++ b/src/locale/eo/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/es/_lib/formatRelative/index.ts
+++ b/src/locale/es/_lib/formatRelative/index.ts
@@ -18,7 +18,7 @@ const formatRelativeLocalePlural = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   if (date.getUTCHours() !== 1) {
     return formatRelativeLocalePlural[token]
   } else {

--- a/src/locale/et/_lib/formatRelative/index.ts
+++ b/src/locale/et/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/fa-IR/_lib/formatRelative/index.ts
+++ b/src/locale/fa-IR/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/fi/_lib/formatRelative/index.ts
+++ b/src/locale/fi/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/fr-CH/_lib/formatRelative/index.ts
+++ b/src/locale/fr-CH/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/fr/_lib/formatRelative/index.ts
+++ b/src/locale/fr/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/fy/_lib/formatRelative/index.ts
+++ b/src/locale/fy/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/gd/_lib/formatRelative/index.ts
+++ b/src/locale/gd/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/gl/_lib/formatRelative/index.ts
+++ b/src/locale/gl/_lib/formatRelative/index.ts
@@ -18,7 +18,7 @@ const formatRelativeLocalePlural = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   if (date.getUTCHours() !== 1) {
     return formatRelativeLocalePlural[token]
   }

--- a/src/locale/gu/_lib/formatRelative/index.ts
+++ b/src/locale/gu/_lib/formatRelative/index.ts
@@ -11,7 +11,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/he/_lib/formatRelative/index.ts
+++ b/src/locale/he/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/hi/_lib/formatRelative/index.ts
+++ b/src/locale/hi/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/hr/_lib/formatRelative/index.ts
+++ b/src/locale/hr/_lib/formatRelative/index.ts
@@ -31,7 +31,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/ht/_lib/formatRelative/index.ts
+++ b/src/locale/ht/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/hy/_lib/formatRelative/index.ts
+++ b/src/locale/hy/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/id/_lib/formatRelative/index.ts
+++ b/src/locale/id/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/is/_lib/formatRelative/index.ts
+++ b/src/locale/is/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ja-Hira/_lib/formatRelative/index.ts
+++ b/src/locale/ja-Hira/_lib/formatRelative/index.ts
@@ -9,13 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (
-  token,
-  _date,
-  _baseDate,
-  _options
-) => {
-  return formatRelativeLocale[token]
-}
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ja/_lib/formatRelative/index.ts
+++ b/src/locale/ja/_lib/formatRelative/index.ts
@@ -9,13 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (
-  token,
-  _date,
-  _baseDate,
-  _options
-) => {
-  return formatRelativeLocale[token]
-}
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ka/_lib/formatRelative/index.ts
+++ b/src/locale/ka/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/km/_lib/formatRelative/index.ts
+++ b/src/locale/km/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/kn/_lib/formatRelative/index.ts
+++ b/src/locale/kn/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ko/_lib/formatRelative/index.ts
+++ b/src/locale/ko/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/lb/_lib/formatRelative/index.ts
+++ b/src/locale/lb/_lib/formatRelative/index.ts
@@ -18,7 +18,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/lt/_lib/formatRelative/index.ts
+++ b/src/locale/lt/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/mn/_lib/formatRelative/index.ts
+++ b/src/locale/mn/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ms/_lib/formatRelative/index.ts
+++ b/src/locale/ms/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/mt/_lib/formatRelative/index.ts
+++ b/src/locale/mt/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/nb/_lib/formatRelative/index.ts
+++ b/src/locale/nb/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/nl-BE/_lib/formatRelative/index.ts
+++ b/src/locale/nl-BE/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/nl/_lib/formatRelative/index.ts
+++ b/src/locale/nl/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/nn/_lib/formatRelative/index.ts
+++ b/src/locale/nn/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/oc/_lib/formatRelative/index.ts
+++ b/src/locale/oc/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/pt-BR/_lib/formatRelative/index.ts
+++ b/src/locale/pt-BR/_lib/formatRelative/index.ts
@@ -13,7 +13,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/pt/_lib/formatRelative/index.ts
+++ b/src/locale/pt/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ro/_lib/formatRelative/index.ts
+++ b/src/locale/ro/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/sl/_lib/formatRelative/index.ts
+++ b/src/locale/sl/_lib/formatRelative/index.ts
@@ -35,7 +35,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/sq/_lib/formatRelative/index.ts
+++ b/src/locale/sq/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/sr-Latn/_lib/formatRelative/index.ts
+++ b/src/locale/sr-Latn/_lib/formatRelative/index.ts
@@ -31,7 +31,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/sr/_lib/formatRelative/index.ts
+++ b/src/locale/sr/_lib/formatRelative/index.ts
@@ -35,7 +35,7 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, date, _baseDate, _options) => {
+const formatRelative: FormatRelativeFn = (token, date) => {
   const format = formatRelativeLocale[token]
 
   if (typeof format === 'function') {

--- a/src/locale/sv/_lib/formatRelative/index.ts
+++ b/src/locale/sv/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ta/_lib/formatRelative/index.ts
+++ b/src/locale/ta/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/te/_lib/formatRelative/index.ts
+++ b/src/locale/te/_lib/formatRelative/index.ts
@@ -11,7 +11,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/th/_lib/formatRelative/index.ts
+++ b/src/locale/th/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/tr/_lib/formatRelative/index.ts
+++ b/src/locale/tr/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/ug/_lib/formatRelative/index.ts
+++ b/src/locale/ug/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/uz-Cyrl/_lib/formatRelative/index.ts
+++ b/src/locale/uz-Cyrl/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/uz/_lib/formatRelative/index.ts
+++ b/src/locale/uz/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/vi/_lib/formatRelative/index.ts
+++ b/src/locale/vi/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/zh-HK/_lib/formatRelative/index.ts
+++ b/src/locale/zh-HK/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/locale/zh-TW/_lib/formatRelative/index.ts
+++ b/src/locale/zh-TW/_lib/formatRelative/index.ts
@@ -9,7 +9,6 @@ const formatRelativeLocale = {
   other: 'P',
 }
 
-const formatRelative: FormatRelativeFn = (token, _date, _baseDate, _options) =>
-  formatRelativeLocale[token]
+const formatRelative: FormatRelativeFn = (token) => formatRelativeLocale[token]
 
 export default formatRelative

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,10 @@ export interface LocaleOptions {
   locale?: Locale
 }
 
+export interface PartialLocaleOptions {
+  locale?: Partial<Locale>
+}
+
 export interface FormatOptions {
   format?: 'extended' | 'basic'
 }


### PR DESCRIPTION
1. Allowed `locale` argument to be partial, where its missing values are replaced by the values of `defaultLocale`.
2. Removed exceptions throwing for missing `locale` fields.
3. Updated relevant tests.
4. Reformatted the `formatRelative` files in all locales to follow the same pattern (i.e. removed the unused arguments).

This PR (hopefully 🙃 ) resolves both issues: #1468 and #1273