### PR TITLE
fix: yarn run ts-node in build.sh

### DIFF
--- a/scripts/build/fp.ts
+++ b/scripts/build/fp.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env yarn ts-node
 
 /**
  * @file

--- a/scripts/build/indices.ts
+++ b/scripts/build/indices.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env yarn ts-node
 
 /**
  * @file


### PR DESCRIPTION
Without this change, when I run the build script, I get this error:

```
 ./scripts/build/build.sh
+ ./scripts/build/docs.js
+ ./scripts/build/fp.ts
env: ts-node: No such file or directory
```

By specifying `yarn ts-node`, it'll enforce usage of the `ts-node` version defined in `package.json` and `yarn.lock`.