### PR TITLE
Replace git.io link

### DIFF
--- a/src/_lib/protectedTokens/index.ts
+++ b/src/_lib/protectedTokens/index.ts
@@ -16,19 +16,19 @@ export function throwProtectedError(
 ): void {
   if (token === 'YYYY') {
     throw new RangeError(
-      `Use \`yyyy\` instead of \`YYYY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`yyyy\` instead of \`YYYY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md`
     )
   } else if (token === 'YY') {
     throw new RangeError(
-      `Use \`yy\` instead of \`YY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`yy\` instead of \`YY\` (in \`${format}\`) for formatting years to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md`
     )
   } else if (token === 'D') {
     throw new RangeError(
-      `Use \`d\` instead of \`D\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`d\` instead of \`D\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md`
     )
   } else if (token === 'DD') {
     throw new RangeError(
-      `Use \`dd\` instead of \`DD\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://git.io/fxCyr`
+      `Use \`dd\` instead of \`DD\` (in \`${format}\`) for formatting days of the month to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md`
     )
   }
 }

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -50,7 +50,7 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * Return the formatted date string in the given format. The result may vary by locale.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -286,10 +286,10 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *    - `p`: long localized time
  *
  * 8. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 9. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * @param {Date|Number} date - the original date
  * @param {String} format - the string of tokens
@@ -298,9 +298,9 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {Number} [options.firstWeekContainsDate=1] - the day of January, which is
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
- *   see: https://git.io/fxCyr
+ *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
- *   see: https://git.io/fxCyr
+ *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `date` must not be Invalid Date
@@ -308,10 +308,10 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @throws {RangeError} `options.locale` must contain `formatLong` property
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
- * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -829,7 +829,7 @@ describe('format', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `d` instead of `D` \(in `yyyy-MM-D`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `d` instead of `D` \(in `yyyy-MM-D`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
       )
     })
 
@@ -845,7 +845,7 @@ describe('format', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `dd` instead of `DD` \(in `yyyy-MM-DD`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `dd` instead of `DD` \(in `yyyy-MM-DD`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
       )
     })
 
@@ -861,7 +861,7 @@ describe('format', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `yy` instead of `YY` \(in `YY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `yy` instead of `YY` \(in `YY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
       )
     })
 
@@ -877,7 +877,7 @@ describe('format', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /(Use `yyyy` instead of `YYYY` \(in `YYYY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/git.io\/fxCyr)/g
+        /(Use `yyyy` instead of `YYYY` \(in `YYYY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
       )
     })
 

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -825,12 +825,12 @@ describe('format', () => {
 
   describe('useAdditionalWeekYearTokens and useAdditionalDayOfYearTokens options', () => {
     it('throws an error if D token is used', () => {
-      const block = format.bind(null, date, 'yyyy-MM-D')
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /(Use `d` instead of `D` \(in `yyyy-MM-D`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
-      )
+      try {
+        format.bind(null, date, 'yyyy-MM-D')
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `d` instead of `D`'))
+      }
     })
 
     it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
@@ -841,12 +841,12 @@ describe('format', () => {
     })
 
     it('throws an error if DD token is used', () => {
-      const block = format.bind(null, date, 'yyyy-MM-DD')
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /(Use `dd` instead of `DD` \(in `yyyy-MM-DD`\) for formatting days of the month to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
-      )
+      try {
+        format.bind(null, date, 'yyyy-MM-DD')
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `dd` instead of `DD`'))
+      }
     })
 
     it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
@@ -857,12 +857,12 @@ describe('format', () => {
     })
 
     it('throws an error if YY token is used', () => {
-      const block = format.bind(null, date, 'YY-MM-dd')
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /(Use `yy` instead of `YY` \(in `YY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
-      )
+      try {
+        format.bind(null, date, 'YY-MM-dd')
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `yy` instead of `YY`'))
+      }
     })
 
     it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
@@ -873,12 +873,12 @@ describe('format', () => {
     })
 
     it('throws an error if YYYY token is used', () => {
-      const block = format.bind(null, date, 'YYYY-MM-dd')
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /(Use `yyyy` instead of `YYYY` \(in `YYYY-MM-dd`\) for formatting years to the input `Fri Apr 04 1986 10:32:55).*(`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments)/g
-      )
+      try {
+        format.bind(null, date, 'YYYY-MM-dd')
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `yyyy` instead of `YYYY`'))
+      }
     })
 
     it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {

--- a/src/isMatch/index.ts
+++ b/src/isMatch/index.ts
@@ -17,7 +17,7 @@ import type {
  * will return false.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -240,10 +240,10 @@ import type {
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -272,18 +272,18 @@ import type {
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
- *   see: https://git.io/fxCyr
+ *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
- *   see: https://git.io/fxCyr
+ *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @returns {Boolean}
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
  * @throws {RangeError} `options.locale` must contain `match` property
- * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years; see: https://git.io/fxCyr
- * @throws {RangeError} use `yy` instead of `YY` for formatting years; see: https://git.io/fxCyr
- * @throws {RangeError} use `d` instead of `D` for formatting days of the month; see: https://git.io/fxCyr
- * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `yy` instead of `YY` for formatting years; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `d` instead of `D` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/lightFormat/index.ts
+++ b/src/lightFormat/index.ts
@@ -30,7 +30,7 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * `lightFormat` doesn't use locales and outputs date using the most popular tokens.
  *
  * > ⚠️ Please note that the `lightFormat` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -47,7 +47,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * Return the date parsed from string using the given format string.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://git.io/fxCyr
+ * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -270,10 +270,10 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://git.io/fxCyr
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -312,18 +312,18 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
  * @param {1|2|3|4|5|6|7} [options.firstWeekContainsDate=1] - the day of January, which is always in the first week of the year
  * @param {Boolean} [options.useAdditionalWeekYearTokens=false] - if true, allows usage of the week-numbering year tokens `YY` and `YYYY`;
- *   see: https://git.io/fxCyr
+ *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @param {Boolean} [options.useAdditionalDayOfYearTokens=false] - if true, allows usage of the day of year tokens `D` and `DD`;
- *   see: https://git.io/fxCyr
+ *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @returns {Date} the parsed date
  * @throws {TypeError} 3 arguments required
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  * @throws {RangeError} `options.firstWeekContainsDate` must be between 1 and 7
  * @throws {RangeError} `options.locale` must contain `match` property
- * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
- * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
+ * @throws {RangeError} use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  * @throws {RangeError} format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/parse/test.ts
+++ b/src/parse/test.ts
@@ -2509,7 +2509,6 @@ describe('parse', () => {
         parse('2016 1', 'YYYY w', referenceDate)
       } catch (e) {
         assert(e instanceof RangeError)
-        console.log(e.message)
         assert(e.message.startsWith('Use `yyyy` instead of `YYYY`'))
       }
     })

--- a/src/parse/test.ts
+++ b/src/parse/test.ts
@@ -2461,7 +2461,7 @@ describe('parse', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `d` instead of `D` \(in `yyyy D`\) for formatting days of the month to the input `2016 5`; see: https:\/\/git.io\/fxCyr/
+        /Use `d` instead of `D` \(in `yyyy D`\) for formatting days of the month to the input `2016 5`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
       )
     })
 
@@ -2477,7 +2477,7 @@ describe('parse', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `dd` instead of `DD` \(in `yyyy DD`\) for formatting days of the month to the input `2016 05`; see: https:\/\/git.io\/fxCyr/
+        /Use `dd` instead of `DD` \(in `yyyy DD`\) for formatting days of the month to the input `2016 05`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
       )
     })
 
@@ -2493,7 +2493,7 @@ describe('parse', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `yy` instead of `YY` \(in `YY w`\) for formatting years to the input `16 1`; see: https:\/\/git.io\/fxCyr/
+        /Use `yy` instead of `YY` \(in `YY w`\) for formatting years to the input `16 1`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
       )
     })
 
@@ -2509,7 +2509,7 @@ describe('parse', () => {
       assert.throws(block, RangeError)
       assert.throws(
         block,
-        /Use `yyyy` instead of `YYYY` \(in `YYYY w`\) for formatting years to the input `2016 1`; see: https:\/\/git.io\/fxCyr/
+        /Use `yyyy` instead of `YYYY` \(in `YYYY w`\) for formatting years to the input `2016 1`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
       )
     })
 

--- a/src/parse/test.ts
+++ b/src/parse/test.ts
@@ -2457,12 +2457,12 @@ describe('parse', () => {
 
   describe('useAdditionalWeekYearTokens and useAdditionalDayOfYearTokens options', () => {
     it('throws an error if D token is used', () => {
-      const block = () => parse('2016 5', 'yyyy D', referenceDate)
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /Use `d` instead of `D` \(in `yyyy D`\) for formatting days of the month to the input `2016 5`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
-      )
+      try {
+        parse('2016 5', 'yyyy D', referenceDate)
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `d` instead of `D`'))
+      }
     })
 
     it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
@@ -2473,12 +2473,12 @@ describe('parse', () => {
     })
 
     it('throws an error if DD token is used', () => {
-      const block = () => parse('2016 05', 'yyyy DD', referenceDate)
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /Use `dd` instead of `DD` \(in `yyyy DD`\) for formatting days of the month to the input `2016 05`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
-      )
+      try {
+        parse('2016 05', 'yyyy DD', referenceDate)
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `dd` instead of `DD`'))
+      }
     })
 
     it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
@@ -2489,12 +2489,12 @@ describe('parse', () => {
     })
 
     it('throws an error if YY token is used', () => {
-      const block = () => parse('16 1', 'YY w', referenceDate)
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /Use `yy` instead of `YY` \(in `YY w`\) for formatting years to the input `16 1`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
-      )
+      try {
+        parse('16 1', 'YY w', referenceDate)
+      } catch (e) {
+        assert(e instanceof RangeError)
+        assert(e.message.startsWith('Use `yy` instead of `YY`'))
+      }
     })
 
     it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
@@ -2505,12 +2505,13 @@ describe('parse', () => {
     })
 
     it('throws an error if YYYY token is used', () => {
-      const block = () => parse('2016 1', 'YYYY w', referenceDate)
-      assert.throws(block, RangeError)
-      assert.throws(
-        block,
-        /Use `yyyy` instead of `YYYY` \(in `YYYY w`\) for formatting years to the input `2016 1`; see: https:\/\/github.com\/date-fns\/date-fns\/blob\/master\/docs\/upgradeGuide.md#string-arguments/
-      )
+      try {
+        parse('2016 1', 'YYYY w', referenceDate)
+      } catch (e) {
+        assert(e instanceof RangeError)
+        console.log(e.message)
+        assert(e.message.startsWith('Use `yyyy` instead of `YYYY`'))
+      }
     })
 
     it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {

--- a/src/toDate/index.ts
+++ b/src/toDate/index.ts
@@ -51,7 +51,7 @@ export default function toDate(argument: Date | number): Date {
     ) {
       // eslint-disable-next-line no-console
       console.warn(
-        "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
+        "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#string-arguments"
       )
       // eslint-disable-next-line no-console
       console.warn(new Error().stack)

--- a/src/toDate/test.ts
+++ b/src/toDate/test.ts
@@ -44,7 +44,7 @@ describe('toDate', () => {
         // eslint-disable-next-line no-console
         // @ts-expect-error
         console.warn.calledWith(
-          "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://git.io/fjule"
+          "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use `parseISO` to parse strings. See: https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#string-arguments"
         )
       )
     })


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace `git.io` links with their actual URL.