### PR TITLE
Fix a couple of typos in the docs

### DIFF
--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -19,7 +19,7 @@ import requiredArgs from '../_lib/requiredArgs'
  * @throws {TypeError} 1 argument required
  * @throws {RangeError} `date` must not be Invalid Date
  * @throws {RangeError} `options.format` must be 'extended' or 'basic'
- * @throws {RangeError} `options.represenation` must be 'date', 'time' or 'complete'
+ * @throws {RangeError} `options.representation` must be 'date', 'time' or 'complete'
  *
  * @example
  * // Represent 18 September 2019 in ISO 8601 format (local time zone is UTC):

--- a/src/formatISO9075/index.ts
+++ b/src/formatISO9075/index.ts
@@ -23,7 +23,7 @@ export interface FormatISO9075Options {
  * @throws {TypeError} 1 argument required
  * @throws {RangeError} `date` must not be Invalid Date
  * @throws {RangeError} `options.format` must be 'extended' or 'basic'
- * @throws {RangeError} `options.represenation` must be 'date', 'time' or 'complete'
+ * @throws {RangeError} `options.representation` must be 'date', 'time' or 'complete'
  *
  * @example
  * // Represent 18 September 2019 in ISO 9075 format:


### PR DESCRIPTION
Just a single missing letter in the docs for `formatISO` and `formatISO9075`.