### PR TITLE
Update Locale docs description to include a sorted list of fns

### DIFF
--- a/docs/Locale.js
+++ b/docs/Locale.js
@@ -1,11 +1,35 @@
 /**
  * @category Types
- * @summary A locale object.
+ * @summary A locale object. Default locale is `en-US`.
  *
  * @description
- * A locale object.
+ * A locale object. Default locale is `en-US`.
  *
- * If you don't specify a locale in options, default locale is `en-US`.
+ * If you're using any of these date-fns, consider specifying a locale in options:
+ *
+ *   - `differenceInCalendarWeeks`
+ *   - `eachWeekOfInterval`
+ *   - `endOfWeek`
+ *   - `format`
+ *   - `formatDistance`
+ *   - `formatDistanceStrict`
+ *   - `formatRelative`
+ *   - `getWeek`
+ *   - `getWeekOfMonth`
+ *   - `getWeeksInMonth`
+ *   - `getWeekYear`
+ *   - `isMatch`
+ *   - `isSameWeek`
+ *   - `isThisWeek`
+ *   - `lastDayOfWeek`
+ *   - `parse`
+ *   - `setDay`
+ *   - `setWeek`
+ *   - `setWeekYear`
+ *   - `startOfWeek`
+ *   - `startOfWeekYear`
+ *
+ * Read the Properties section below for more details.
  *
  * @typedef {Object} Locale
  *


### PR DESCRIPTION
Whenever I want to check if I need to specify the locale for some date-fns usage, I find it useful to have a sorted fn names listed out.

This PR pulls out the function names as a list from the properties section and put them in the description section of `Locale`. 

I'm unable to figure out letting the docs server reading the local `docs.json`, so the formats of the description section might be off.

Please feel free to edit or close this PR. Thank you for the great library!

----

## Description

If you're using any of these date-fns, consider specifying a locale in options:

- `differenceInCalendarWeeks`
- `eachWeekOfInterval`
- `endOfWeek`
- `format`
- `formatDistance`
- `formatDistanceStrict`
- `formatRelative`
- `getWeek`
- `getWeekOfMonth`
- `getWeeksInMonth`
- `getWeekYear`
- `isMatch`
- `isSameWeek`
- `isThisWeek`
- `lastDayOfWeek`
- `parse`
- `setDay`
- `setWeek`
- `setWeekYear`
- `startOfWeek`
- `startOfWeekYear`

Read the Properties section below for more details.

## Screenshots

![JPEG-1](https://user-images.githubusercontent.com/922234/170183072-1ce8743e-4388-4cf9-b71a-d5f4e4b77fba.jpg)


