### PR TITLE
Removed duplicate declaration of const daysInWeek

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1196,8 +1196,6 @@ declare module 'date-fns' {
 
   const daysInWeek: number
 
-  const daysInWeek: number
-
   const maxTime: number
 
   const millisecondsInMinute: number


### PR DESCRIPTION
**const daysInWeek: number;**  _declared twice_ throwing error of redeclare variable.