### PR TITLE
Fix build system

### DIFF
--- a/src/constructFrom/index.ts
+++ b/src/constructFrom/index.ts
@@ -10,9 +10,9 @@ import type { GenericDateConstructor } from '../types'
  * date and the given value. It helps to build generic functions that accept
  * date extensions.
  *
- * @param date {Date|number} - the reference date to take constructor from
- * @param value {Date|number} - the value to create the date
- * @returns date initialized using the given date and value
+ * @param {Date|number} date - the reference date to take constructor from
+ * @param {Date|number} value - the value to create the date
+ * @returns {Date} date initialized using the given date and value
  *
  * @example
  * import { constructFrom } from 'date-fns'

--- a/src/transpose/index.ts
+++ b/src/transpose/index.ts
@@ -1,5 +1,5 @@
-import type { GenericDateConstructor } from '../types'
 import constructFrom from '../constructFrom/index'
+import type { GenericDateConstructor } from '../types'
 
 /**
  * @name transpose
@@ -11,9 +11,9 @@ import constructFrom from '../constructFrom/index'
  * to transpose the date in the system time zone to say `UTCDate` or any other
  * date extension.
  *
- * @param fromDate {Date|number} - the date to use values from
- * @param constructor {Date|DateConstructor} - the date constructor to use
- * @returns date transposed to the given constructor
+ * @param {Date|number} fromDate - the date to use values from
+ * @param {Date|DateConstructor} constructor - the date constructor to use
+ * @returns {Date} date transposed to the given constructor
  *
  * @example
  * // Create July 10, 2022 00:00 in locale time zone


### PR DESCRIPTION
#3089 introduced bad jsdocs in the `constructFrom` and `transpose` functions, which made the `./scripts/build/typings.js` build step choke.