### PR TITLE
Fixed a breaking change in intervalToDuration by removing a recently introduced RangeError

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -1,3 +1,4 @@
+import compareAsc from '../compareAsc/index'
 import add from '../add/index'
 import differenceInDays from '../differenceInDays/index'
 import differenceInHours from '../differenceInHours/index'
@@ -23,7 +24,6 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * @throws {TypeError} Requires 2 arguments
  * @throws {RangeError} `start` must not be Invalid Date
  * @throws {RangeError} `end` must not be Invalid Date
- * @throws {RangeError} The start of an interval cannot be after its end
  *
  * @example
  * // Get the duration between January 15, 1929 and April 4, 1968.
@@ -41,28 +41,28 @@ export default function intervalToDuration(interval: Interval): Duration {
 
   if (isNaN(start.getTime())) throw new RangeError('Start Date is invalid')
   if (isNaN(end.getTime())) throw new RangeError('End Date is invalid')
-  if (start > end) {
-    throw new RangeError('The start of an interval cannot be after its end')
-  }
 
-  const duration: Duration = {
-    years: differenceInYears(end, start),
-  }
+  const duration: Duration = {}
+  duration.years = Math.abs(differenceInYears(end, start))
 
-  const remainingMonths = add(start, { years: duration.years })
-  duration.months = differenceInMonths(end, remainingMonths)
+  const sign = compareAsc(end, start)
 
-  const remainingDays = add(remainingMonths, { months: duration.months })
-  duration.days = differenceInDays(end, remainingDays)
+  const remainingMonths = add(start, { years: sign * duration.years })
+  duration.months = Math.abs(differenceInMonths(end, remainingMonths))
 
-  const remainingHours = add(remainingDays, { days: duration.days })
-  duration.hours = differenceInHours(end, remainingHours)
+  const remainingDays = add(remainingMonths, { months: sign * duration.months })
+  duration.days = Math.abs(differenceInDays(end, remainingDays))
 
-  const remainingMinutes = add(remainingHours, { hours: duration.hours })
-  duration.minutes = differenceInMinutes(end, remainingMinutes)
+  const remainingHours = add(remainingDays, { days: sign * duration.days })
+  duration.hours = Math.abs(differenceInHours(end, remainingHours))
 
-  const remainingSeconds = add(remainingMinutes, { minutes: duration.minutes })
-  duration.seconds = differenceInSeconds(end, remainingSeconds)
+  const remainingMinutes = add(remainingHours, { hours: sign * duration.hours })
+  duration.minutes = Math.abs(differenceInMinutes(end, remainingMinutes))
+
+  const remainingSeconds = add(remainingMinutes, {
+    minutes: sign * duration.minutes,
+  })
+  duration.seconds = Math.abs(differenceInSeconds(end, remainingSeconds))
 
   return duration
 }

--- a/src/intervalToDuration/test.ts
+++ b/src/intervalToDuration/test.ts
@@ -50,13 +50,19 @@ describe('intervalToDuration', () => {
     })
   })
 
-  it("throws a RangeError if interval's start date is greater than its end date", () => {
-    const interval = {
-      start: new Date(2020, 3, 1),
-      end: new Date(2020, 2, 1),
-    }
+  it("returns positive numbers even if interval's start date is after its end date", () => {
+    const start = new Date(1929, 0, 15, 12, 0, 0)
+    const end = new Date(1968, 3, 4, 19, 5, 0)
+    const result = intervalToDuration({ start: end, end: start })
 
-    assert.throws(intervalToDuration.bind(null, interval), RangeError)
+    assert.deepStrictEqual(result, {
+      years: 39,
+      months: 2,
+      days: 20,
+      hours: 7,
+      minutes: 5,
+      seconds: 0,
+    })
   })
 
   it("throws a RangeError if interval's start date invalid", () => {


### PR DESCRIPTION
Partially reverts #2616 which contained a breaking change in v2.29.0. This should be fixed in v2.29.1, while the breaking change remains in `main` (aka v3)