### PR TITLE
Grammar error in Day.js

### DIFF
--- a/docs/Day.js
+++ b/docs/Day.js
@@ -4,7 +4,7 @@
  *
  * @description
  * The day of the week type alias (`0 | 1 | 2 | 3 | 4 | 5 | 6`). Unlike the date
- * (the number of days since the beginningof the month), which starts with 1
+ * (the number of days since the beginning of the month), which starts with 1
  * and is dynamic (can go up to 28, 30, or 31), the day starts with 0 and static
  * (always ends at 6). Look at it as an index in an array where Sunday is
  * the first element, and Saturday is the last.


### PR DESCRIPTION
There was a typing error in one sentence. It should've been, "beginning of", but "beginningof" was written.