### PR TITLE
Fix issue where setISOWeekYear modified original resets time to midnight

### DIFF
--- a/src/setISOWeekYear/index.ts
+++ b/src/setISOWeekYear/index.ts
@@ -28,6 +28,12 @@ export default function setISOWeekYear(
   year: number
 ): Date {
   let result = new Date(date)
+  const times: [number, number, number, number] = [
+    result.getHours(),
+    result.getMinutes(),
+    result.getSeconds(),
+    result.getMilliseconds(),
+  ]
   const isoWeekYear = Math.trunc(year)
   const diff = differenceInCalendarDays(result, startOfISOWeekYear(result))
   const fourthOfJanuary = new Date(0)
@@ -35,5 +41,6 @@ export default function setISOWeekYear(
   fourthOfJanuary.setHours(0, 0, 0, 0)
   result = startOfISOWeekYear(fourthOfJanuary)
   result.setDate(result.getDate() + diff)
+  result.setHours(...times)
   return result
 }

--- a/src/setISOWeekYear/test.ts
+++ b/src/setISOWeekYear/test.ts
@@ -28,6 +28,16 @@ describe('setISOWeekYear', () => {
     assert.deepStrictEqual(date, new Date(2008, 11 /* Dec */, 29))
   })
 
+  it('maintains the original time', () => {
+    const initialDate = new Date(2021, 0 /* Jan */, 1)
+    initialDate.setHours(1, 2, 3, 4)
+    const expectedResult = new Date(2020, 11 /* Dec */, 29)
+    initialDate.setFullYear(2020, 11 /* Dec */, 29)
+    expectedResult.setHours(1, 2, 3, 4)
+    const result = setISOWeekYear(initialDate, 2020)
+    assert.deepStrictEqual(result, expectedResult)
+  })
+
   it('sets ISO week-numbering years less than 100', () => {
     const initialDate = new Date(2008, 11 /* Dec */, 29)
     const expectedResult = new Date(0)


### PR DESCRIPTION
Resolves #1757.

`setISOWeekYear` uses January 4th midnight for calculations, but inadvertently sets the resulting date's time to midnight. I reset the date's hours, minutes, seconds, and milliseconds after its calendar day has been set.