### PR TITLE
fix: Correct Lithuanian translation of seconds in some instances.

### DIFF
--- a/src/locale/lt/_lib/formatDistance/index.ts
+++ b/src/locale/lt/_lib/formatDistance/index.ts
@@ -21,7 +21,7 @@ type FormatDistanceTokenValue =
     }
 
 const translations = {
-  xseconds_other: 'sekundė_sekundžių_sekundes',
+  xseconds_other: 'sekundė_sekundžių_sekundes_sekundės',
   xminutes_one: 'minutė_minutės_minutę',
   xminutes_other: 'minutės_minučių_minutes',
   xhours_one: 'valanda_valandos_valandą',
@@ -57,18 +57,29 @@ const translate: Translater = (number, addSuffix, key, isFuture) => {
   if (number === 1) {
     return result + translateSingular(number, addSuffix, key, isFuture)
   } else if (!addSuffix) {
-    return result + (special(number) ? forms(key)[1] : forms(key)[0])
+    return (
+      result +
+      (special_tens(number)
+        ? forms(key)[1]
+        : special_seconds(number, key)
+        ? forms(key)[3]
+        : forms(key)[0])
+    )
   } else {
     if (isFuture) {
       return result + forms(key)[1]
     } else {
-      return result + (special(number) ? forms(key)[1] : forms(key)[2])
+      return result + (special_tens(number) ? forms(key)[1] : forms(key)[2])
     }
   }
 }
 
-function special(number: number): boolean {
+function special_tens(number: number): boolean {
   return number % 10 === 0 || (number > 10 && number < 20)
+}
+
+function special_seconds(number: number, key: string): boolean {
+  return key === 'xseconds_other' && number % 10 !== 1
 }
 
 function forms(key: TranslationKey): string[] {

--- a/src/locale/lt/snapshot.md
+++ b/src/locale/lt/snapshot.md
@@ -413,7 +413,7 @@ If now is January 1st, 2000, 00:00.
 | 2000-01-01T00:00:25.000Z | mažiau nei minutė | pusė minutės            | po mažiau nei minutės   |
 | 2000-01-01T00:00:15.000Z | mažiau nei minutė | mažiau nei 20 sekundžių | po mažiau nei minutės   |
 | 2000-01-01T00:00:05.000Z | mažiau nei minutė | mažiau nei 10 sekundžių | po mažiau nei minutės   |
-| 2000-01-01T00:00:00.000Z | mažiau nei minutė | mažiau nei 5 sekundė    | prieš mažiau nei minutę |
+| 2000-01-01T00:00:00.000Z | mažiau nei minutė | mažiau nei 5 sekundės   | prieš mažiau nei minutę |
 | 1999-12-31T23:59:55.000Z | mažiau nei minutė | mažiau nei 10 sekundžių | prieš mažiau nei minutę |
 | 1999-12-31T23:59:45.000Z | mažiau nei minutė | mažiau nei 20 sekundžių | prieš mažiau nei minutę |
 | 1999-12-31T23:59:35.000Z | mažiau nei minutė | pusė minutės            | prieš mažiau nei minutę |
@@ -462,13 +462,13 @@ If now is January 1st, 2000, 00:00.
 | 2000-01-01T00:30:00.000Z | 30 minučių   | po 30 minučių      | valanda                        |
 | 2000-01-01T00:15:00.000Z | 15 minučių   | po 15 minučių      | 0 valandų                      |
 | 2000-01-01T00:01:00.000Z | minutė       | po minutės         | 0 valandų                      |
-| 2000-01-01T00:00:25.000Z | 25 sekundė   | po 25 sekundžių    | 0 valandų                      |
+| 2000-01-01T00:00:25.000Z | 25 sekundės  | po 25 sekundžių    | 0 valandų                      |
 | 2000-01-01T00:00:15.000Z | 15 sekundžių | po 15 sekundžių    | 0 valandų                      |
-| 2000-01-01T00:00:05.000Z | 5 sekundė    | po 5 sekundžių     | 0 valandų                      |
+| 2000-01-01T00:00:05.000Z | 5 sekundės   | po 5 sekundžių     | 0 valandų                      |
 | 2000-01-01T00:00:00.000Z | 0 sekundžių  | prieš 0 sekundžių  | 0 valandų                      |
-| 1999-12-31T23:59:55.000Z | 5 sekundė    | prieš 5 sekundes   | 0 valandų                      |
+| 1999-12-31T23:59:55.000Z | 5 sekundės   | prieš 5 sekundes   | 0 valandų                      |
 | 1999-12-31T23:59:45.000Z | 15 sekundžių | prieš 15 sekundžių | 0 valandų                      |
-| 1999-12-31T23:59:35.000Z | 25 sekundė   | prieš 25 sekundes  | 0 valandų                      |
+| 1999-12-31T23:59:35.000Z | 25 sekundės  | prieš 25 sekundes  | 0 valandų                      |
 | 1999-12-31T23:59:00.000Z | minutė       | prieš minutę       | 0 valandų                      |
 | 1999-12-31T23:45:00.000Z | 15 minučių   | prieš 15 minučių   | 0 valandų                      |
 | 1999-12-31T23:30:00.000Z | 30 minučių   | prieš 30 minučių   | valanda                        |
@@ -527,4 +527,4 @@ If now is January 1st, 2000, 00:00.
 | {"minutes":2} | 2 minutės       |
 | {"seconds":0} | 0 sekundžių     |
 | {"seconds":1} | kelios sekundės |
-| {"seconds":2} | 2 sekundė       |
+| {"seconds":2} | 2 sekundės      |


### PR DESCRIPTION
Lithuanian uses a different form of 'seconds' for numbers ending in 1. This change handles that form.

Fixes #3204 