### PR TITLE
test: Add more information to snapshot test failures.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^4.0.2",
+    "line-diff": "^2.1.1",
     "lint-staged": "^7.3.0",
     "lodash": "^4.17.15",
     "lodash.clonedeep": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8824,6 +8824,11 @@ lcov-parse@^0.0.10:
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
   integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
 
+levdist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/levdist/-/levdist-1.0.0.tgz#91d7a3044964f2ccc421a0477cac827fe75c5718"
+  integrity sha512-YguwC2spb0pqpJM3a5OsBhih/GG2ZHoaSHnmBqhEI7997a36buhqcRTegEjozHxyxByIwLpZHZTVYMThq+Zd3g==
+
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -8849,6 +8854,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+line-diff@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/line-diff/-/line-diff-2.1.1.tgz#a389799b931375a3b1e764964ad0b0b3ce60d6f6"
+  integrity sha512-vswdynAI5AMPJacOo2o+JJ4caDJbnY2NEqms4MhMW0NJbjh3skP/brpVTAgBxrg55NRZ2Vtw88ef18hnagIpYQ==
+  dependencies:
+    levdist "^1.0.0"
 
 linkify-it@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
In the process of fixing #3204, I found it is difficult to determine the specific differences between a snapshot and the output of the current code.

This change makes it easier by adding the conflicting lines to the error message.

Example output:
```node ➜ /workspaces/date-fns (main ✗) $ yarn locale-snapshots test
yarn run v1.22.19
$ env TZ=utc babel-node --extensions .ts,.js ./scripts/build/localeSnapshots/index.js test
Error: The snapshot on the disk doesn't match the generated snapshot: /workspaces/date-fns/src/locale/en-NZ/snapshot.md. Please run yarn locale-snapshots and commit the results.
Line 530:
-| {"seconds":2} | 2 secondos|
+| {"seconds":2} | 2 seconds |
    at /workspaces/date-fns/scripts/build/localeSnapshots/index.js:65:21
    at async Promise.all (index 25)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.```