### PR TITLE
refactor: Move locale snapshots to ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "karma start config/karma.js",
     "lint": "eslint .",
     "lint-types": "eslint --config=.ts-eslintrc.js typings.d.ts",
-    "locale-snapshots": "env TZ=utc babel-node --extensions .ts,.js ./scripts/build/localeSnapshots/index.js",
+    "locale-snapshots": "env TZ=utc babel-node --extensions .ts,.js ./scripts/build/localeSnapshots/index.ts",
     "stats": "cloc . --exclude-dir=node_modules,tmp,.git"
   },
   "husky": {

--- a/scripts/build/localeSnapshots/index.ts
+++ b/scripts/build/localeSnapshots/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFile, readFileSync, writeFile } from 'mz/fs'
-import path from 'path'
+import * as path from 'path'
 import listLocales from '../../_lib/listLocales'
 import prettier from '../_lib/prettier'
 import renderFormatDistance from './renderFormatDistance'

--- a/scripts/build/localeSnapshots/index.ts
+++ b/scripts/build/localeSnapshots/index.ts
@@ -17,7 +17,7 @@ import renderFormatParse from './renderFormatParse'
 import renderFormatRelative from './renderFormatRelative'
 import renderFormatDuration from './renderFormatDuration'
 
-const mode = process.argv[2] || 'generate'
+const mode = process.argv[2] ?? 'generate'
 
 if ((process.env.TZ ?? '').toLowerCase() !== 'utc')
   throw new Error('The locale snapshots generation must be run with TZ=utc')

--- a/scripts/build/localeSnapshots/index.ts
+++ b/scripts/build/localeSnapshots/index.ts
@@ -19,7 +19,7 @@ import renderFormatDuration from './renderFormatDuration'
 
 const mode = process.argv[2] || 'generate'
 
-if (process.env.TZ.toLowerCase() !== 'utc')
+if ((process.env.TZ ?? '').toLowerCase() !== 'utc')
   throw new Error('The locale snapshots generation must be run with TZ=utc')
 
 listLocales()


### PR DESCRIPTION
As per the contributing guildelines, I've converted localeSnapshots to TypeScript.

This mostly worked as it was, but I've also made a couple of minor fixes to make it more inline with best practice TypeScript.