### PR TITLE
`parse` should use defaultLocale instead of `en-US`

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -1,6 +1,5 @@
 import constructFrom from '../constructFrom/index'
 import getDefaultOptions from '../getDefaultOptions/index'
-import defaultLocale from '../locale/en-US/index'
 import toDate from '../toDate/index'
 import type {
   AdditionalTokensOptions,
@@ -9,6 +8,7 @@ import type {
   WeekStartOptions,
 } from '../types'
 import assign from '../_lib/assign/index'
+import defaultLocale from '../_lib/defaultLocale'
 import longFormatters from '../_lib/format/longFormatters/index'
 import {
   isProtectedDayOfYearToken,


### PR DESCRIPTION
This looks like a regression on the main branch only, v2 is OK.

It would be a good idea to introduce unit tests as I did in my original PR for the default locale feature. #2816