### PR TITLE
Fix german grammar

### DIFF
--- a/src/locale/de/_lib/formatDistance/index.ts
+++ b/src/locale/de/_lib/formatDistance/index.ts
@@ -31,8 +31,8 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   },
 
   halfAMinute: {
-    standalone: 'halbe Minute',
-    withPreposition: 'halben Minute',
+    standalone: 'eine halbe Minute',
+    withPreposition: 'einer halben Minute',
   },
 
   lessThanXMinutes: {


### PR DESCRIPTION
In German it sounds better when it's "vor einer halben Minute" or "in einer halben Minute" than just "vor halben Minute" or "in halben Minute".