### PR TITLE
Change german dateformat into expected spelling (#3275)

### DIFF
--- a/src/locale/de/_lib/formatLong/index.ts
+++ b/src/locale/de/_lib/formatLong/index.ts
@@ -4,9 +4,9 @@ import type { FormatLong } from '../../../types'
 // DIN 5008: https://de.wikipedia.org/wiki/Datumsformat#DIN_5008
 const dateFormats = {
   full: 'EEEE, do MMMM y', // Montag, 7. Januar 2018
-  long: 'do MMMM y', // 7. Januar 2018
-  medium: 'do MMM y', // 7. Jan. 2018
-  short: 'dd.MM.y', // 07.01.2018
+  long: 'do MMMM yyyy', // 7. Januar 2018
+  medium: 'do MMM yyyy', // 7. Jan. 2018
+  short: 'dd.MM.yyyy', // 07.01.2018
 }
 
 const timeFormats = {


### PR DESCRIPTION
This pull requests fixes the (german) issue [#3275](https://github.com/date-fns/date-fns/issues/3275#issuecomment-1316944439) when the locale dateformats are used as placeholders in UI components. The spelling is not the expected format in german (see [german DIN 5008](https://de.wikipedia.org/wiki/Datumsformat#DIN_5008))

>Ähnlich wie in den meisten anderen europäischen Ländern wurde die Norm auch in Deutschland und Österreich weitgehend ignoriert, wo allgemein weiterhin das gewohnte Format TT.MM.[JJ]JJ in Gebrauch blieb.
>
> (Translated: Similar to most other European countries, the standard was largely ignored in Germany and Austria, where generally the familiar format DD.MM.[YY]YY remained in use.)

Previously and after this change, the formatted dates are still the same (snapshot tests passing):
* pervious short format `dd.MM.y` creates for example `07.01.2018`
* the updated format `dd.MM.yyyy` is fitting the german spelling and still creates for example `07.01.2018`.