### PR TITLE
Update nl datetime medium/short format

### DIFF
--- a/src/locale/nl/_lib/formatLong/index.ts
+++ b/src/locale/nl/_lib/formatLong/index.ts
@@ -18,8 +18,8 @@ const timeFormats = {
 const dateTimeFormats = {
   full: "{{date}} 'om' {{time}}",
   long: "{{date}} 'om' {{time}}",
-  medium: '{{date}}, {{time}}',
-  short: '{{date}}, {{time}}',
+  medium: '{{date}} {{time}}',
+  short: '{{date}} {{time}}',
 }
 
 const formatLong: FormatLong = {


### PR DESCRIPTION
Date time formats in the NL do not have a comma in the format.
Can be verified by https://st.unicode.org/cldr-apps/v#/nl/Gregorian/43da060150c3ffc1