### PR TITLE
formatISODuration example fix

### DIFF
--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -22,7 +22,7 @@ import type { Duration } from '../types'
  *   minutes: 5,
  *   seconds: 0
  * })
- * //=> 'P39Y2M20DT0H0M0S'
+ * //=> 'P39Y2M20DT7H5M0S'
  */
 export default function formatISODuration(duration: Duration): string {
   const {


### PR DESCRIPTION
The example in the docs for formatISODuration is showing the wrong output.

This change is only fixing the output-text in the example.