### PR TITLE
Add "1" to time periods

### DIFF
--- a/src/locale/cs/_lib/formatDistance/index.ts
+++ b/src/locale/cs/_lib/formatDistance/index.ts
@@ -39,7 +39,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xSeconds: {
     one: {
-      regular: 'sekunda',
+      regular: '1 sekunda',
       past: 'před sekundou',
       future: 'za sekundu',
     },
@@ -84,7 +84,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xMinutes: {
     one: {
-      regular: 'minuta',
+      regular: '1 minuta',
       past: 'před minutou',
       future: 'za minutu',
     },
@@ -120,7 +120,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xHours: {
     one: {
-      regular: 'hodina',
+      regular: '1 hodina',
       past: 'před hodinou',
       future: 'za hodinu',
     },
@@ -138,7 +138,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xDays: {
     one: {
-      regular: 'den',
+      regular: '1 den',
       past: 'před dnem',
       future: 'za den',
     },
@@ -176,7 +176,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xWeeks: {
     one: {
-      regular: 'týden',
+      regular: '1 týden',
       past: 'před týdnem',
       future: 'za týden',
     },
@@ -216,7 +216,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xMonths: {
     one: {
-      regular: 'měsíc',
+      regular: '1 měsíc',
       past: 'před měsícem',
       future: 'za měsíc',
     },
@@ -254,7 +254,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xYears: {
     one: {
-      regular: 'rok',
+      regular: '1 rok',
       past: 'před rokem',
       future: 'za rok',
     },


### PR DESCRIPTION
Standalone period names are only usable in a sentence, but not in standalone text. Also their English locale equivalent also states the number 1 in front of the period name.

Adding 1 to the period name does not break current usage, but adds usability.

Consider following Czech sentence, which retains same meaning, possibly adding more readability: Zbývá {{distance}} – Zbývá hodina 40 minut. -> Zbývá 1 hodina 40 minut.

Consider following GUI, which currently is not usable and gains usability: ⏱️ {{distance}} – ⏱️ hodina 40 minut -> ⏱️ 1 hodina 40 minut

That is the reason to include the extra 1 in front of the period name.