### PR TITLE
Correct URL to ISO 8601 duration standard in formatISODuration description

### DIFF
--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -6,7 +6,7 @@ import type { Duration } from '../types'
  * @summary Format a duration object according as ISO 8601 duration string
  *
  * @description
- * Format a duration object according to the ISO 8601 duration standard (https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
+ * Format a duration object according to the ISO 8601 duration standard (https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm)
  *
  * @param duration - the duration to format
  *


### PR DESCRIPTION
It seems that the URL to digi.com listed on https://date-fns.org/v2.30.0/docs/formatISODuration is no longer accurate.
From what I could gather https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm should be the current working URL describing the ISO 8601 duration format.