### PR TITLE
Update url to iso_8601_duration_format

### DIFF
--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -6,7 +6,7 @@ import type { Duration } from '../types'
  * @summary Format a duration object according as ISO 8601 duration string
  *
  * @description
- * Format a duration object according to the ISO 8601 duration standard (https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
+ * Format a duration object according to the ISO 8601 duration standard (https://www.digi.com/resources/documentation/digidocs//90001488-13/reference/r_iso_8601_duration_format.htm)
  *
  * @param duration - the duration to format
  *


### PR DESCRIPTION
It looks like the old URL is pointing to a 404 page. I've updated it to point to the working one.