### PR TITLE
Fixes for roundToNearestMinutes()

### DIFF
--- a/src/roundToNearestMinutes/index.ts
+++ b/src/roundToNearestMinutes/index.ts
@@ -49,7 +49,7 @@ export default function roundToNearestMinutes<DateType extends Date>(
   const milliseconds = date.getMilliseconds()
   const seconds = date.getSeconds() + milliseconds / 1000
   const minutes = date.getMinutes() + seconds / 60
-  const roundingMethod = getRoundingMethod(options?.roundingMethod)
+  const roundingMethod = getRoundingMethod(options?.roundingMethod || 'round')
   const roundedMinutes = roundingMethod(minutes / nearestTo) * nearestTo
 
   const result = constructFrom(date, date)

--- a/src/roundToNearestMinutes/index.ts
+++ b/src/roundToNearestMinutes/index.ts
@@ -51,10 +51,8 @@ export default function roundToNearestMinutes<DateType extends Date>(
   const minutes = date.getMinutes() + seconds / 60
   const roundingMethod = getRoundingMethod(options?.roundingMethod)
   const roundedMinutes = roundingMethod(minutes / nearestTo) * nearestTo
-  const remainderMinutes = minutes % nearestTo
-  const addedMinutes = Math.round(remainderMinutes / nearestTo) * nearestTo
 
   const result = constructFrom(date, date)
-  result.setMinutes(roundedMinutes + addedMinutes, 0, 0)
+  result.setMinutes(roundedMinutes, 0, 0)
   return result
 }

--- a/src/roundToNearestMinutes/index.ts
+++ b/src/roundToNearestMinutes/index.ts
@@ -46,7 +46,8 @@ export default function roundToNearestMinutes<DateType extends Date>(
   }
 
   const date = toDate(dirtyDate)
-  const seconds = date.getSeconds() // relevant if nearestTo is 1, which is the default case
+  const milliseconds = date.getMilliseconds()
+  const seconds = date.getSeconds() + milliseconds / 1000
   const minutes = date.getMinutes() + seconds / 60
   const roundingMethod = getRoundingMethod(options?.roundingMethod)
   const roundedMinutes = roundingMethod(minutes / nearestTo) * nearestTo

--- a/src/roundToNearestMinutes/test.ts
+++ b/src/roundToNearestMinutes/test.ts
@@ -1,29 +1,14 @@
 /* eslint-env mocha */
 
 import assert from 'assert'
-import roundToNearestMinutes from './index'
+import roundToNearestMinutes, { RoundToNearestMinutesOptions } from './index'
 
 describe('roundToNearestMinutes', () => {
-  it('rounds given date to the nearest minute by default', () => {
-    const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 16, 16)
-    )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 16, 0))
-  })
-
   it('accepts a timestamp', () => {
     const result = roundToNearestMinutes(
       new Date(2014, 6 /* Jul */, 10, 12, 13, 16).getTime()
     )
     assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 13, 0))
-  })
-
-  it('rounds to the closest x minutes if nearestTo is provided', () => {
-    const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30),
-      { nearestTo: 4 }
-    )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 12, 0))
   })
 
   it('rounds up >=30 seconds for nearestTo=1', () => {
@@ -51,47 +36,55 @@ describe('roundToNearestMinutes', () => {
 
   it('rounds according to the passed mode - floor', () => {
     const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),
+      new Date(2014, 6 /* Jul */, 10, 12, 10, 59, 999),
       { roundingMethod: 'floor' }
     )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 11, 0))
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 10))
   })
 
   it('rounds according to the passed mode - floor - when nearestTo is provided', () => {
     const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),
+      new Date(2014, 6 /* Jul */, 10, 12, 19, 59, 999),
       { nearestTo: 10, roundingMethod: 'floor' }
     )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 10, 0))
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 10))
   })
 
   it('rounds according to the passed mode - ceil', () => {
     const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),
+      new Date(2014, 6 /* Jul */, 10, 12, 10, 0, 1),
       { roundingMethod: 'ceil' }
     )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 12, 0))
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 11))
   })
 
   it('rounds according to the passed mode - ceil - when nearestTo is provided', () => {
     const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),
+      new Date(2014, 6 /* Jul */, 10, 12, 10, 0, 1),
       { nearestTo: 10, roundingMethod: 'ceil' }
     )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 20, 0))
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 20))
   })
 
-  it('rounds according to the passed mode - round - when nearestTo is provided', () => {
+  it('rounds down according to the passed mode - round - when nearestTo is provided', () => {
     const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),
+      new Date(2014, 6 /* Jul */, 10, 12, 14, 59, 999),
       { nearestTo: 10, roundingMethod: 'round' }
     )
-    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 10, 0))
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 10))
+  })
+
+  it('rounds up according to the passed mode - round - when nearestTo is provided', () => {
+    const result = roundToNearestMinutes(
+      new Date(2014, 6 /* Jul */, 10, 12, 15),
+      { nearestTo: 10, roundingMethod: 'round' }
+    )
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 20))
   })
 
   it('rounds according to the passed mode - trunc - when nearestTo is provided', () => {
     const result = roundToNearestMinutes(
-      new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),
+      new Date(2014, 6 /* Jul */, 10, 12, 19, 59, 999),
       { nearestTo: 10, roundingMethod: 'trunc' }
     )
     assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 10, 0))


### PR DESCRIPTION
#3429 demonstrated that `roundToNearestMinutes()` did not produce expected behaviour. This PR makes a few changes so that `roundToNearestMinutes()` fixes that misbehaviour...

* Previously, there was an inexplicable `addedMinutes` variable which added minutes on to the result. There was no obvious reason for this, and it could only ever cause the result to go wrong: indeed, this seemed to be the chief culprit in the case of #3429. I have removed this variable
* Fixing this behaviour caused the tests to fail. This was because the tests had been engineered to expect the wrong results. I fixed this, and while I was there, removed duplicate tests and replaced test inputs with boundary cases
* Fixing the tests to expect what they ought to expect and putting in boundary cases caused further test failures. This in turn was partly because there was no account made of the milliseconds field of the input. Now, milliseconds are accounted for, which allowed some more of the tests to pass.
* Finally, the remaining issue was that the rounding method was expected to default to `round`, but in fact it was defaulting to `trunc`. I have fixed this as well.

Now, all tests pass, and I have manually checked that this should fix #3429 