### PR TITLE
Fix weekday order in spanish

### DIFF
--- a/src/locale/es/_lib/localize/index.ts
+++ b/src/locale/es/_lib/localize/index.ts
@@ -47,17 +47,17 @@ const monthValues = {
 } as const
 
 const dayValues = {
-  narrow: ['d', 'l', 'm', 'm', 'j', 'v', 's'],
-  short: ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sá'],
-  abbreviated: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'],
+  narrow: ['l', 'm', 'm', 'j', 'v', 's', 'd'],
+  short: ['lu', 'ma', 'mi', 'ju', 'vi', 'sá', 'do'],
+  abbreviated: ['lun', 'mar', 'mié', 'jue', 'vie', 'sáb', 'dom'],
   wide: [
-    'domingo',
     'lunes',
     'martes',
     'miércoles',
     'jueves',
     'viernes',
     'sábado',
+    'domingo',
   ],
 } as const
 


### PR DESCRIPTION
This fixes the order of the weekdays in spanish since it should start with lunes (monday) and end with domingo (sunday).

Please check:   https://langster.org/en/blog/seasons-days-and-months-in-spanish