### PR TITLE
intlFormat: fix a typo in examples

### DIFF
--- a/src/intlFormat/index.ts
+++ b/src/intlFormat/index.ts
@@ -34,7 +34,7 @@ export interface IntlFormatLocaleOptions {
  * @throws {RangeError} `date` must not be Invalid Date
  *
  * @example
- * // Represent 10 October 2019 in middle-endian format:
+ * // Represent 4 October 2019 in middle-endian format:
  * const result = intlFormat(new Date(2019, 9, 4, 12, 30, 13, 456))
  * //=> 10/4/2019
  */
@@ -53,7 +53,7 @@ export default function intlFormat<DateType extends Date>(
  * @throws {RangeError} `date` must not be Invalid Date
  *
  * @example
- * // Represent 10 October 2019 in Korean.
+ * // Represent 4 October 2019 in Korean.
  * // Convert the date with locale's options.
  * const result = intlFormat(new Date(2019, 9, 4, 12, 30, 13, 456), {
  *   locale: 'ko-KR',
@@ -76,7 +76,7 @@ export default function intlFormat<DateType extends Date>(
  * @throws {RangeError} `date` must not be Invalid Date
  *
  * @example
- * // Represent 10 October 2019.
+ * // Represent 4 October 2019.
  * // Convert the date with format's options.
  * const result = intlFormat.default(new Date(2019, 9, 4, 12, 30, 13, 456), {
  *   year: 'numeric',
@@ -103,7 +103,7 @@ export default function intlFormat<DateType extends Date>(
  * @throws {RangeError} `date` must not be Invalid Date
  *
  * @example
- * // Represent 10 October 2019 in German.
+ * // Represent 4 October 2019 in German.
  * // Convert the date with format's options and locale's options.
  * const result = intlFormat(new Date(2019, 9, 4, 12, 30, 13, 456), {
  *   weekday: 'long',


### PR DESCRIPTION
I've noted a small typo in the examples titles for intlFormat function.
It says 10 October, but in the examples it is 4 October