### PR TITLE
Adding Usage Trend for date-fns and Moment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ yarn add date-fns
 [See date-fns.org](https://date-fns.org/) for more details, API,
 and other docs.
 
+## Usage Trend of Date & Time Manipulation Libraries
+
+[Usage Trend of Legacy Moment.js and Modern Date-Fns](https://npm-compare.com/moment,date-fns)
+
 <br />
 <!-- END OF README-JOB SECTION -->
 


### PR DESCRIPTION
 I would like to propose a change that adds NPM usage trend links for date-fns and Moment.js to our repository. This enhancement will make it easier for users and contributors to track the popularity and adoption of our library compared to legacy Moment.js.

By providing these links, we aim to offer our community a quick and easy way to compare the popularity and trends of date-fns and Moment.js. This information can be valuable for users who are evaluating which library to choose for their projects.