### PR TITLE
Added SECURITY.md file for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** 
+This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+Please disclose it to [Sasha Koss](mailto:kossnocorp@gmail.com) or [Lesha Koss](mailto:regiusprod@gmail.com).
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Closes #3543 

I used the emails provided in #687 to report a vulnerability but you can also consider [configuring private vulnerability reporting for the repo](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) if you would prefer. Appreciate any feedback!

Besides that, feel free to edit or suggest any changes to this document. It is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.