### PR TITLE
feat(devcontainers): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
 ENV EDITOR="code -w" VISUAL="code -w"
 
 # install system dependencies for playwright
-RUN npx playwright install-deps
+RUN npx --yes playwright install-deps
 
 # uncomment to install additional npm packages
 # RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,5 @@ ENV EDITOR="code -w" VISUAL="code -w"
 # install system dependencies for playwright
 RUN npx playwright install-deps
 
-# install playwright browsers for the non-root user
-RUN su node -c 'npx playwright install'
-
 # uncomment to install additional npm packages
 # RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+ARG NODE_MAJOR_VERSION
+
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
+
+ENV EDITOR="code -w" VISUAL="code -w"
+
+# install system dependencies for playwright
+RUN npx playwright install-deps
+
+# install playwright browsers for the non-root user
+RUN su node -c 'npx playwright install'
+
+# uncomment to install additional npm packages
+# RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "date-fns",
+  "dockerFile": "Dockerfile",
+  "build": {
+    "args": { "NODE_MAJOR_VERSION": "18" }
+  },
+  "postCreateCommand": [".devcontainer/post-create.sh"],
+  "portsAttributes": {
+    "63315": { "label": "Vitest Browser" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # when in a VS Code or GitHub Codespaces devcontainer
-if [ -n "${REMOTE_CONTAINERS}" ]; then
+if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
 	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
 	workspace_root=$(realpath ${this_dir}/..)
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# when in a VS Code or GitHub Codespaces devcontainer
+if [ -n "${REMOTE_CONTAINERS}" ]; then
+	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+	workspace_root=$(realpath ${this_dir}/..)
+
+	# perform additional one-time setup just after
+	# the devcontainer is created
+	yarn install --cwd "${workspace_root}"
+
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,6 +10,6 @@ if [ -n "${REMOTE_CONTAINERS}" ]; then
 	# perform additional one-time setup just after
 	# the devcontainer is created
 	yarn install --cwd "${workspace_root}" # install node dependencies
-	npx playwright install                 # install playwright browsers
+	npx --yes playwright install           # install playwright browsers
 
 fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,6 +9,7 @@ if [ -n "${REMOTE_CONTAINERS}" ]; then
 
 	# perform additional one-time setup just after
 	# the devcontainer is created
-	yarn install --cwd "${workspace_root}"
+	yarn install --cwd "${workspace_root}" # install node dependencies
+	npx playwright install                 # install playwright browsers
 
 fi


### PR DESCRIPTION
For `Hacktoberfest`, I have been adding `GitHub Codespaces` / `VS Code Remote Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via `GH Codespaces`, or inside of fully, and correctly configured containers on their own computer with `VS Code Remote Containers` (both of these use the same configuration, as `GH Codespaces` leverages the `Remote Containers` features under the hood).

For the `date-fns` project, this configuration includes the following:
- Preinstalled `Node LTS`
- Preinstalled `yarn@1.x`
- Preinstalled `ESLint` and `Prettier` extensions
- Preinstalled `playwright` dependencies
- Automation of the `yarn install` when the devcontainer is first created

Basically everything needed for a contributor to open the project after a fresh clone and be immediately productive, either locally with `VS Code` or remotely with `GitHub Codespaces`!

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36
- https://github.com/floating-ui/floating-ui/pull/2606
- https://github.com/compiler-explorer/compiler-explorer/pull/5631
- https://github.com/EveryBoard/EveryBoard/pull/155
- https://github.com/melt-ui/melt-ui/pull/658
- https://github.com/JamesLMilner/terra-draw/pull/108
