### PR TITLE
chore: remove moment.js from the deps list

### DIFF
--- a/package.json
+++ b/package.json
@@ -2447,7 +2447,6 @@
     "lodash": "^4.17.15",
     "lodash.clonedeep": "^4.5.0",
     "mocha": "^3.5.3",
-    "moment": "^2.24.0",
     "node-fetch": "^1.7.3",
     "p-limit": "^3.1.0",
     "playwright": "^1.37.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8490,7 +8490,7 @@ modern-node-polyfills@^0.1.3:
     esbuild "^0.14.54"
     local-pkg "^0.4.3"
 
-moment@2.x.x, moment@^2.24.0:
+moment@2.x.x:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
I noticed the moment.js was in the dependency list, however it is never used in the code (why would it)