### PR TITLE
Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "require": {
         "types": "./index.d.ts",

--- a/scripts/build/indices.ts
+++ b/scripts/build/indices.ts
@@ -52,6 +52,7 @@ async function generatePackageJSON({
   const packageJSON = JSON.parse(await readFile("package.json", "utf-8"));
   packageJSON.exports = Object.fromEntries(
     [
+      ["./package.json", "./package.json"],
       [
         ".",
         {


### PR DESCRIPTION
webpack:  

> warn Package date-fns has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in ./node_modules/date-fns/package.json

node:

```
node -e "require('date-fns/package.json')"

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in ./node_modules/date-fns/package.json
```