### PR TITLE
Removed typo in toDate/index.ts 

### DIFF
--- a/src/toDate/index.ts
+++ b/src/toDate/index.ts
@@ -49,7 +49,7 @@ export function toDate<DateType extends Date>(
   } else if (
     typeof argument === "number" ||
     argStr === "[object Number]" ||
-    typeof argStr === "string" ||
+    typeof argument === "string" ||
     argStr === "[object String]"
   ) {
     // TODO: Can we get rid of as?


### PR DESCRIPTION
in the else if part of the toDate function there are two things argument and argstr. argstr is the internal class property of the argument.The line number 52 was argStr === "String" which doesn't make sense because argStr in a internal class property. Also in line number 43 argStr in compared to "[object Date]" which further explane that line number 52 should be typeof argument === "string". Also the line no.53 is argStr === "[object String]" which further explane that line no. 52 must be typeof argument === "string" because first of all we need to check if argument if of string or not and but the way argstr is by default returned as a string.