### PR TITLE
Update wikipedia location [snack]

### DIFF
--- a/docs/i18nContributionGuide.md
+++ b/docs/i18nContributionGuide.md
@@ -77,7 +77,7 @@ Use the two/three letter code:
 
 - if all countries who use the language
   also use the same regional standards: the first day of the week,
-  the week numbering (see: https://en.wikipedia.org/wiki/Week#Week_numbering),
+  the week numbering (see: https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system),
   calendar date format (see: https://en.wikipedia.org/wiki/Calendar_date)
   and date representation (see: https://en.wikipedia.org/wiki/Date_and_time_representation_by_country
   and: https://en.wikipedia.org/wiki/Date_format_by_country)
@@ -128,7 +128,7 @@ var locale = {
     weekStartsOn: 0,
 
     // Nth of January which is always in the first week of the year. See:
-    // https://en.wikipedia.org/wiki/Week#Week_numbering
+    // https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system
     // http://www.pjh2.de/datetime/weeknumber/wnd.php?l=en
     firstWeekContainsDate: 1,
   },

--- a/src/getWeek/index.ts
+++ b/src/getWeek/index.ts
@@ -28,7 +28,7 @@ export interface GetWeekOptions
  * and `options.firstWeekContainsDate` (which is the day of January, which is always in
  * the first week of the week-numbering year)
  *
- * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
+ * Week numbering: https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/getWeekYear/index.ts
+++ b/src/getWeekYear/index.ts
@@ -28,7 +28,7 @@ export interface GetWeekYearOptions
  * and `options.firstWeekContainsDate` (which is the day of January, which is always in
  * the first week of the week-numbering year)
  *
- * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
+ * Week numbering: https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/setWeek/index.ts
+++ b/src/setWeek/index.ts
@@ -26,7 +26,7 @@ export interface SetWeekOptions
  * and `options.firstWeekContainsDate` (which is the day of January, which is always in
  * the first week of the week-numbering year)
  *
- * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
+ * Week numbering: https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/setWeekYear/index.ts
+++ b/src/setWeekYear/index.ts
@@ -30,7 +30,7 @@ export interface SetWeekYearOptions
  * and `options.firstWeekContainsDate` (which is the day of January, which is always in
  * the first week of the week-numbering year)
  *
- * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
+ * Week numbering: https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/startOfWeekYear/index.ts
+++ b/src/startOfWeekYear/index.ts
@@ -28,7 +28,7 @@ export interface StartOfWeekYearOptions
  * and `options.firstWeekContainsDate` (which is the day of January, which is always in
  * the first week of the week-numbering year)
  *
- * Week numbering: https://en.wikipedia.org/wiki/Week#Week_numbering
+ * Week numbering: https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export type Month = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
  *
  * The day in that week can only be 1 (Monday) or 4 (Thursday).
  *
- * Please see https://en.wikipedia.org/wiki/Week#Week_numbering for more information.
+ * Please see https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system for more information.
  */
 export type FirstWeekContainsDate = 1 | 4;
 


### PR DESCRIPTION
The wikipedia link in the current documentation for "Week numbering" has a hash that's not valid (#Week_numbering).

This PR replaces the invalid link hash with a valid one:

Old
`https://en.wikipedia.org/wiki/Week#Week_numbering`
New
`https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system`