### PR TITLE
Type-safe implementation of convertToFP

### DIFF
--- a/src/fp/_lib/convertToFP/index.ts
+++ b/src/fp/_lib/convertToFP/index.ts
@@ -23,3 +23,34 @@ export function convertToFP<Fn extends FPFnInput, Arity extends FPArity>(
       : (...args: unknown[]) => convertToFP(fn, arity, curriedArgs.concat(args))
   ) as FPFn<Fn, Arity>;
 }
+
+/**
+ * An experimental alternative implementation of {@link convertToFP} with
+ * more type-safety.
+ */
+export function convertToFP2<A1, B>(fn: (a1: A1) => B): (a1: A1) => B;
+export function convertToFP2<A1, A2, B>(
+  fn: (a1: A1, a2: A2) => B,
+): (a2: A2) => (a1: A1) => B;
+export function convertToFP2<A1, A2, A3, B>(
+  fn: (a1: A1, a2: A2, a3: A3) => B,
+): (a3: A3) => (a2: A2) => (a1: A1) => B;
+export function convertToFP2<A1, A2, A3, A4, B>(
+  fn: (a1: A1, a2: A2, a3: A3, a4: A4) => B,
+): (a4: A4) => (a3: A3) => (a2: A2) => (a1: A1) => B;
+export function convertToFP2<A1, A2, A3, A4, B>(
+  fn: (a1: A1, a2?: A2, a3?: A3, a4?: A4) => B,
+): unknown {
+  switch (fn.length) {
+    case 1:
+      return fn;
+    case 2:
+      return (a2: A2) => (a1: A1) => fn(a1, a2);
+    case 3:
+      return (a3: A3) => (a2: A2) => (a1: A1) => fn(a1, a2, a3);
+    case 4:
+      return (a4: A4) => (a3: A3) => (a2: A2) => (a1: A1) => fn(a1, a2, a3, a4);
+    default:
+      throw new TypeError("Unexpected arity");
+  }
+}

--- a/src/fp/_lib/convertToFP/index.ts
+++ b/src/fp/_lib/convertToFP/index.ts
@@ -51,6 +51,98 @@ export function convertToFP2<A1, A2, A3, A4, B>(
     case 4:
       return (a4: A4) => (a3: A3) => (a2: A2) => (a1: A1) => fn(a1, a2, a3, a4);
     default:
-      throw new TypeError("Unexpected arity");
+      throw new RangeError(`Invalid arity ${fn.length}`);
   }
 }
+
+/**
+ * An experimental alternative implementation of {@link convertToFP} using
+ * code from effect-ts.
+ * @see https://github.com/Effect-TS/effect/blob/effect%402.0.0/packages/effect/src/Function.ts#L71
+ */
+/* eslint-disable */
+export const convertToFPDual: {
+  <
+    DataLast extends (...args: Array<any>) => any,
+    DataFirst extends (...args: Array<any>) => any,
+  >(
+    arity: Parameters<DataFirst>["length"],
+    body: DataFirst,
+  ): DataLast & DataFirst;
+  <
+    DataLast extends (...args: Array<any>) => any,
+    DataFirst extends (...args: Array<any>) => any,
+  >(
+    isDataFirst: (args: IArguments) => boolean,
+    body: DataFirst,
+  ): DataLast & DataFirst;
+} = function (arity, body) {
+  if (typeof arity === "function") {
+    return function () {
+      if (arity(arguments)) {
+        // @ts-expect-error
+        return body.apply(this, arguments);
+      }
+      return ((self: any) => body(self, ...arguments)) as any;
+    };
+  }
+
+  switch (arity) {
+    case 0:
+    case 1:
+      throw new RangeError(`Invalid arity ${arity}`);
+
+    case 2:
+      return function (a, b) {
+        if (arguments.length >= 2) {
+          return body(a, b);
+        }
+        return function (self: any) {
+          return body(self, a);
+        };
+      };
+
+    case 3:
+      return function (a, b, c) {
+        if (arguments.length >= 3) {
+          return body(a, b, c);
+        }
+        return function (self: any) {
+          return body(self, a, b);
+        };
+      };
+
+    case 4:
+      return function (a, b, c, d) {
+        if (arguments.length >= 4) {
+          return body(a, b, c, d);
+        }
+        return function (self: any) {
+          return body(self, a, b, c);
+        };
+      };
+
+    case 5:
+      return function (a, b, c, d, e) {
+        if (arguments.length >= 5) {
+          return body(a, b, c, d, e);
+        }
+        return function (self: any) {
+          return body(self, a, b, c, d);
+        };
+      };
+
+    default:
+      return function () {
+        if (arguments.length >= arity) {
+          // @ts-expect-error
+          return body.apply(this, arguments);
+        }
+        const args = arguments;
+        return function (self: any) {
+          return body(self, ...args);
+        };
+      };
+  }
+};
+/* eslint-enable */

--- a/src/fp/_lib/convertToFP/test.ts
+++ b/src/fp/_lib/convertToFP/test.ts
@@ -2,7 +2,7 @@
 
 import assert from "assert";
 import { describe, it } from "vitest";
-import { convertToFP, convertToFP2 } from "./index.js";
+import { convertToFP, convertToFP2, convertToFPDual } from "./index.js";
 
 describe("convertToFP", () => {
   function fn(a: unknown, b: unknown, c: unknown) {
@@ -133,6 +133,18 @@ describe("convertToFP2", () => {
     it("type-checks with fp-ts style pipe function", () => {
       const fpFn = convertToFP2(fn);
       const result = pipe(1, fpFn(2), fpFn(3));
+      assertType<IsEqual<typeof result, string>>();
+      assert.strictEqual(result, "1 2 3");
+    });
+  });
+
+  describe("alternative implementation using effect-ts dual", () => {
+    it("type-checks with dual conversion", () => {
+      const fpFn: {
+        (that: unknown): (self: unknown) => string;
+        (self: unknown, that: unknown): string;
+      } = convertToFPDual(2, fn);
+      const result = [1].map(fpFn(2)).map(fpFn(3))[0];
       assertType<IsEqual<typeof result, string>>();
       assert.strictEqual(result, "1 2 3");
     });


### PR DESCRIPTION
As seen in #3641, the functions provided in v3 of `date-fns/fp` can't be used with `compose`/`flow`/`pipe` constructs from TS libraries for functional programming or even with the native Array `map`.

```typescript
import { isEqual } from 'date-fns/fp'
import { pipe } from 'fp-ts/function'

const d1 = new Date()
const d2 = new Date()

// Type of r1 is boolean
const r1 = isEqual(d2)(d1)

// Type of r2 is "any"
const r2 = pipe(d1, isEqual(d2))
```

This PR is two things:
- A demonstration of the problem through tests for the `convertToFP` function.
- A starting point for a discussion around currying.

It provides an alternative implementation named `convertToFP2` that resolves the type-level issues. However, this implementation does no longer allow for more advanced partial application scenarios, because they can't be properly implemented in TypeScript (to my current knowledge – maybe this has become possible in recent TS versions, but neither [fp-ts](https://gcanti.github.io/fp-ts/) nor [effect-ts](https://github.com/Effect-TS/effect) do this, so I assume it still isn't possible).

An example of what would no longer be possible is this:

```typescript
it("allows to group arguments", () => {
  const fpFn = convertToFP(fn, 3);
  assert(fpFn(3, 2)(1) === "1 2 3");
  assert(fpFn(3)(2, 1) === "1 2 3");
});
```

And this is an example that I would like to question: this seems really unsound and unnecessary to me, is this really something that needs to be supported?

```typescript
it("ignores calls without curried arguments", () => {
  const fpFn = convertToFP(fn, 3);
  assert(fpFn()()(3, 2)()()(1) === "1 2 3");
});
```

In my opinion the type-safety gained is more important than being able to write `fpFn(3, 2)(1)` instead of the simpler (and more idiomatic/pipeline-compatible in TS functional programming) `fpFn(3)(2)(1)`. My question for resolving this issue is whether this kind of currying could be removed as a way forward with this PR or whether there are other ideas.