### PR TITLE
Add alias formatDate for format function

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -40,6 +40,9 @@ const escapedStringRegExp = /^'([^]*?)'?$/;
 const doubleQuoteRegExp = /''/g;
 const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
 
+export { format as formatDate };
+export type { FormatOptions as FormatDateOptions };
+
 /**
  * The {@link format} function options.
  */
@@ -51,6 +54,7 @@ export interface FormatOptions
 
 /**
  * @name format
+ * @alias formatDate
  * @category Common Helpers
  * @summary Format the date.
  *

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -11,7 +11,7 @@ import {
   vi,
 } from "vitest";
 import sinon from "sinon";
-import { format } from "./index.js";
+import { format, formatDate } from "./index.js";
 
 describe("format", () => {
   const date = new Date(1986, 3 /* Apr */, 4, 10, 32, 55, 123);
@@ -64,6 +64,14 @@ describe("format", () => {
     assert.strictEqual(
       format(date, "yyyy-MM-dd'\n'HH:mm:ss"),
       "2014-04-04\n05:00:00",
+    );
+  });
+
+  it("alias formatDate has same behavior as format", () => {
+    const date = new Date(2014, 3, 4, 5);
+    assert.strictEqual(
+      formatDate(date, "yyyy-MM-dd'\n'HH:mm:ss"),
+      format(date, "yyyy-MM-dd'\n'HH:mm:ss"),
     );
   });
 


### PR DESCRIPTION
Part of #776 

This PR adds an alias `formatDate()` for the `format()` function based on the implementation approach suggested in the latest comment in PR #793. 