### PR TITLE
`parse` function should use `defaultLocale` instead of `en-US` directly

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -1,6 +1,6 @@
 import { constructFrom } from "../constructFrom/index.js";
 import { getDefaultOptions } from "../getDefaultOptions/index.js";
-import { enUS as defaultLocale } from "../locale/en-US/index.js";
+import { defaultLocale } from "../_lib/defaultLocale/index.js";
 import { toDate } from "../toDate/index.js";
 import type {
   AdditionalTokensOptions,


### PR DESCRIPTION
#3261 bump for v3 since it hasn't been addressed yet.