### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Please follow the main contributing rules, to maintain date-fns' top quality:
 
 2. Fork the project, and clone your fork of the repo
 
-3. Run `npm` to install the dependencies
+3. Run `npm install` to install the dependencies
 
 ## Testing
 


### PR DESCRIPTION
Unlike Yarn, `npm` by itself just lists the available commands. Contributors need to run `npm i` or `npm install` to properly install the dev dependencies.