### PR TITLE
fix addMonths when amount is passed as a String

### DIFF
--- a/src/addMonths/index.ts
+++ b/src/addMonths/index.ts
@@ -46,7 +46,7 @@ export function addMonths<DateType extends Date>(
   // month and using a date of 0 to back up one day to the end of the desired
   // month.
   const endOfDesiredMonth = constructFrom(date, _date.getTime());
-  endOfDesiredMonth.setMonth(_date.getMonth() + amount + 1, 0);
+  endOfDesiredMonth.setMonth(_date.getMonth() + +amount + 1, 0);
   const daysInMonth = endOfDesiredMonth.getDate();
   if (dayOfMonth >= daysInMonth) {
     // If we're already at the end of the month, then this is the correct date


### PR DESCRIPTION
When using this library in a javascript project, we can pass an amount as a string and when we do that, it generates an incorrect value as it is just concatenating the string 

![image](https://github.com/date-fns/date-fns/assets/9250618/df33d363-d0fe-405a-a999-6076d9f98663)

here is where it happens

<img width="561" alt="image" src="https://github.com/date-fns/date-fns/assets/9250618/469d7e9c-90f9-499f-8fc1-bd23c7b1c9ef">


This conversion makes sure that this works and doesn't affect number values.

<img width="561" alt="image" src="https://github.com/date-fns/date-fns/assets/9250618/d3ae59c3-fa4c-4abc-9a50-5137294949ab">

I tried to add a test case, but as it is using TypeScript, it does not allow the string to be passed as a parameter.

PS: I am not a javascript developer and if this solution is bad, feel free to provide a better solution or just tell me what could make it better
