### PR TITLE
fixes german grammer for "half a minute" texts

### DIFF
--- a/src/locale/de-AT/snapshot.md
+++ b/src/locale/de-AT/snapshot.md
@@ -414,13 +414,13 @@ If now is January 1st, 2000, 00:00.
 | 2000-01-01T00:30:00.000Z | 30 Minuten           | 30 Minuten              | in 30 Minuten            |
 | 2000-01-01T00:15:00.000Z | 15 Minuten           | 15 Minuten              | in 15 Minuten            |
 | 2000-01-01T00:01:00.000Z | 1 Minute             | 1 Minute                | in 1 Minute              |
-| 2000-01-01T00:00:25.000Z | weniger als 1 Minute | halbe Minute            | in weniger als 1 Minute  |
+| 2000-01-01T00:00:25.000Z | weniger als 1 Minute | eine halbe Minute       | in weniger als 1 Minute  |
 | 2000-01-01T00:00:15.000Z | weniger als 1 Minute | weniger als 20 Sekunden | in weniger als 1 Minute  |
 | 2000-01-01T00:00:05.000Z | weniger als 1 Minute | weniger als 10 Sekunden | in weniger als 1 Minute  |
 | 2000-01-01T00:00:00.000Z | weniger als 1 Minute | weniger als 5 Sekunden  | vor weniger als 1 Minute |
 | 1999-12-31T23:59:55.000Z | weniger als 1 Minute | weniger als 10 Sekunden | vor weniger als 1 Minute |
 | 1999-12-31T23:59:45.000Z | weniger als 1 Minute | weniger als 20 Sekunden | vor weniger als 1 Minute |
-| 1999-12-31T23:59:35.000Z | weniger als 1 Minute | halbe Minute            | vor weniger als 1 Minute |
+| 1999-12-31T23:59:35.000Z | weniger als 1 Minute | eine halbe Minute       | vor weniger als 1 Minute |
 | 1999-12-31T23:59:00.000Z | 1 Minute             | 1 Minute                | vor 1 Minute             |
 | 1999-12-31T23:45:00.000Z | 15 Minuten           | 15 Minuten              | vor 15 Minuten           |
 | 1999-12-31T23:30:00.000Z | 30 Minuten           | 30 Minuten              | vor 30 Minuten           |

--- a/src/locale/de/_lib/formatDistance/index.ts
+++ b/src/locale/de/_lib/formatDistance/index.ts
@@ -31,8 +31,8 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   },
 
   halfAMinute: {
-    standalone: "halbe Minute",
-    withPreposition: "halben Minute",
+    standalone: "eine halbe Minute",
+    withPreposition: "einer halben Minute",
   },
 
   lessThanXMinutes: {

--- a/src/locale/de/snapshot.md
+++ b/src/locale/de/snapshot.md
@@ -414,13 +414,13 @@ If now is January 1st, 2000, 00:00.
 | 2000-01-01T00:30:00.000Z | 30 Minuten           | 30 Minuten              | in 30 Minuten            |
 | 2000-01-01T00:15:00.000Z | 15 Minuten           | 15 Minuten              | in 15 Minuten            |
 | 2000-01-01T00:01:00.000Z | 1 Minute             | 1 Minute                | in 1 Minute              |
-| 2000-01-01T00:00:25.000Z | weniger als 1 Minute | halbe Minute            | in weniger als 1 Minute  |
+| 2000-01-01T00:00:25.000Z | weniger als 1 Minute | eine halbe Minute       | in weniger als 1 Minute  |
 | 2000-01-01T00:00:15.000Z | weniger als 1 Minute | weniger als 20 Sekunden | in weniger als 1 Minute  |
 | 2000-01-01T00:00:05.000Z | weniger als 1 Minute | weniger als 10 Sekunden | in weniger als 1 Minute  |
 | 2000-01-01T00:00:00.000Z | weniger als 1 Minute | weniger als 5 Sekunden  | vor weniger als 1 Minute |
 | 1999-12-31T23:59:55.000Z | weniger als 1 Minute | weniger als 10 Sekunden | vor weniger als 1 Minute |
 | 1999-12-31T23:59:45.000Z | weniger als 1 Minute | weniger als 20 Sekunden | vor weniger als 1 Minute |
-| 1999-12-31T23:59:35.000Z | weniger als 1 Minute | halbe Minute            | vor weniger als 1 Minute |
+| 1999-12-31T23:59:35.000Z | weniger als 1 Minute | eine halbe Minute       | vor weniger als 1 Minute |
 | 1999-12-31T23:59:00.000Z | 1 Minute             | 1 Minute                | vor 1 Minute             |
 | 1999-12-31T23:45:00.000Z | 15 Minuten           | 15 Minuten              | vor 15 Minuten           |
 | 1999-12-31T23:30:00.000Z | 30 Minuten           | 30 Minuten              | vor 30 Minuten           |


### PR DESCRIPTION
In German it sounds better when it's "vor einer halben Minute" or "in einer halben Minute" than just "vor halben Minute" or "in halben Minute".