### PR TITLE
Add babel plugin transform optional chaining for cjs build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,6 +13,7 @@ module.exports = {
       plugins: [
         ['@babel/plugin-transform-modules-commonjs', { strict: true }],
         ['babel-plugin-add-import-extension', { extension: 'js' }],
+        ['@babel/plugin-transform-optional-chaining']
       ],
     },
 
@@ -21,7 +22,10 @@ module.exports = {
         ['@babel/preset-env', { targets: { node: 'current' }, modules: false }],
       ],
 
-      plugins: [['babel-plugin-add-import-extension', { extension: 'mjs' }]],
+      plugins: [
+        ['babel-plugin-add-import-extension', { extension: 'mjs' }],
+        ['@babel/plugin-transform-optional-chaining']
+      ],
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@babel/cli": "^7.22.10",
         "@babel/core": "^7.22.10",
+        "@babel/plugin-transform-optional-chaining": "^7.23.4",
         "@babel/preset-env": "^7.22.10",
         "@babel/preset-typescript": "^7.22.5",
         "@date-fns/docs": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -6019,6 +6019,7 @@
   "devDependencies": {
     "@babel/cli": "^7.22.10",
     "@babel/core": "^7.22.10",
+    "@babel/plugin-transform-optional-chaining": "^7.23.4",
     "@babel/preset-env": "^7.22.10",
     "@babel/preset-typescript": "^7.22.5",
     "@date-fns/docs": "^0.29.0",


### PR DESCRIPTION
This pull request introduces a new Babel plugin, @babel/plugin-transform-optional-chaining, to our project's Babel configuration. The optional chaining feature (?.) provides a concise and robust way to access properties on potentially nullable objects, improving code readability and reducing the risk of runtime errors caused by null or undefined values.

Changes Made:

-   Added @babel/plugin-transform-optional-chaining to the list of plugins in the Babel configuration.
-   Ensured consistency across different environments (CommonJS and ECMAScript Modules) by including the plugin in both configurations.
-   Did not modify any existing code or behavior; this change is additive and does not affect the functionality of the project.

Purpose:

-   Enhance code maintainability and readability by adopting modern JavaScript syntax features.
-   Mitigate potential runtime errors related to null or undefined values.
-   Align our codebase with best practices and industry standards for JavaScript development.