### PR TITLE
Fix `constructNow` import paths

### DIFF
--- a/src/constructNow/index.ts
+++ b/src/constructNow/index.ts
@@ -1,4 +1,4 @@
-import { constructFrom } from "../index.js";
+import { constructFrom } from "../constructFrom/index.js";
 
 /**
  * @name constructNow

--- a/src/formatDistanceToNow/index.ts
+++ b/src/formatDistanceToNow/index.ts
@@ -1,6 +1,6 @@
+import { constructNow } from "../constructNow/index.js";
 import type { FormatDistanceOptions } from "../formatDistance/index.js";
 import { formatDistance } from "../formatDistance/index.js";
-import { constructNow } from "../index.js";
 
 /**
  * The {@link formatDistanceToNow} function options.

--- a/src/formatDistanceToNowStrict/index.ts
+++ b/src/formatDistanceToNowStrict/index.ts
@@ -1,6 +1,6 @@
 import type { FormatDistanceStrictOptions } from "../formatDistanceStrict/index.js";
 import { formatDistanceStrict } from "../formatDistanceStrict/index.js";
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 
 /**
  * The {@link formatDistanceToNowStrict} function options.

--- a/src/isThisHour/index.ts
+++ b/src/isThisHour/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameHour } from "../isSameHour/index.js";
 
 /**

--- a/src/isThisISOWeek/index.ts
+++ b/src/isThisISOWeek/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameISOWeek } from "../isSameISOWeek/index.js";
 
 /**

--- a/src/isThisMinute/index.ts
+++ b/src/isThisMinute/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameMinute } from "../isSameMinute/index.js";
 
 /**

--- a/src/isThisMonth/index.ts
+++ b/src/isThisMonth/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameMonth } from "../isSameMonth/index.js";
 
 /**

--- a/src/isThisQuarter/index.ts
+++ b/src/isThisQuarter/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameQuarter } from "../isSameQuarter/index.js";
 
 /**

--- a/src/isThisSecond/index.ts
+++ b/src/isThisSecond/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameSecond } from "../isSameSecond/index.js";
 
 /**

--- a/src/isThisWeek/index.ts
+++ b/src/isThisWeek/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameWeek } from "../isSameWeek/index.js";
 import type { LocalizedOptions, WeekOptions } from "../types.js";
 

--- a/src/isThisYear/index.ts
+++ b/src/isThisYear/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameYear } from "../isSameYear/index.js";
 
 /**

--- a/src/isTomorrow/index.ts
+++ b/src/isTomorrow/index.ts
@@ -1,5 +1,5 @@
 import { addDays } from "../addDays/index.js";
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameDay } from "../isSameDay/index.js";
 
 /**

--- a/src/isYesterday/index.ts
+++ b/src/isYesterday/index.ts
@@ -1,4 +1,4 @@
-import { constructNow } from "../index.js";
+import { constructNow } from "../constructNow/index.js";
 import { isSameDay } from "../isSameDay/index.js";
 import { subDays } from "../subDays/index.js";
 


### PR DESCRIPTION
Introduced by #3731. None of the internal imports go through the root index that re-exports all functions.

Although maybe this is not an issue anymore? The browser tests on GitHub actions are not timing out like they used to (see #3677) since the Vitest 1.3 upgrade.

If this can still cause problems, maybe the root index (and fp index) could be removed from the repo and only generated when publishing to the npm registry?