### PR TITLE
Add CDN versions of modules

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,31 +1,37 @@
 module.exports = {
-  presets: ['@babel/preset-typescript'],
+  presets: ["@babel/preset-typescript"],
 
   env: {
     cjs: {
       presets: [
         [
-          '@babel/preset-env',
-          { targets: { node: 'current' }, modules: 'commonjs' },
+          "@babel/preset-env",
+          { targets: { node: "current" }, modules: "commonjs" },
         ],
       ],
 
       plugins: [
-        ['@babel/plugin-transform-modules-commonjs', { strict: true }],
-        ['babel-plugin-add-import-extension', { extension: 'js' }],
+        ["@babel/plugin-transform-modules-commonjs", { strict: true }],
+        ["babel-plugin-add-import-extension", { extension: "js" }],
       ],
     },
 
     esm: {
       presets: [
-        ['@babel/preset-env', { targets: { node: 'current' }, modules: false }],
+        ["@babel/preset-env", { targets: { node: "current" }, modules: false }],
       ],
 
-      plugins: [['babel-plugin-add-import-extension', { extension: 'mjs' }]],
+      plugins: [["babel-plugin-add-import-extension", { extension: "mjs" }]],
+    },
+
+    cdn: {
+      presets: [
+        ["@babel/preset-env", { targets: { ie: "11" }, modules: false }],
+      ],
     },
   },
 
   ignore: [],
 
   retainLines: true,
-}
+};

--- a/scripts/build/cdn.ts
+++ b/scripts/build/cdn.ts
@@ -1,0 +1,106 @@
+/**
+ * The script builds the CDN version of the library.
+ */
+
+import { $ } from "bun";
+import { writeFile } from "fs/promises";
+import { dirname, join, relative } from "path";
+import { listLocales, type LocaleFile } from "../_lib/listLocales";
+import { availableParallelism } from "node:os";
+import { promiseQueue } from "../test/_lib/queue";
+
+if (!process.env.PACKAGE_OUTPUT_PATH)
+  throw new Error("PACKAGE_OUTPUT_PATH is not set");
+
+const out = relative(process.cwd(), process.env.PACKAGE_OUTPUT_PATH);
+
+const indexPath = join(out, "cdn.js");
+const fpIndexPath = join(out, "fp", "cdn.js");
+const localesIndexPath = join(out, "locale", "cdn.js");
+
+Promise.all([
+  listLocales().then((locales) =>
+    Promise.all(
+      locales.map(async (locale) => {
+        const localePath = join(out, "locale", locale.code, "cdn.js");
+        await $`mkdir -p ${dirname(localePath)}`;
+        await writeFile(localePath, localeTemplate(locale));
+        return localePath;
+      }),
+    ),
+  ),
+
+  writeFile(indexPath, indexTemplate()).then(() => indexPath),
+
+  writeFile(fpIndexPath, fpIndexTemplate()).then(() => fpIndexPath),
+
+  writeFile(localesIndexPath, localesIndexTemplate()).then(
+    () => localesIndexPath,
+  ),
+])
+  .then(([localePaths, ...indexPaths]) => localePaths.concat(indexPaths))
+  .then(async (paths) => {
+    const buildOptions = {
+      entrypoints: paths,
+      outdir: ".",
+      sourcemap: "external" as const,
+      root: ".",
+    };
+
+    // First bundle code
+    await Bun.build(buildOptions);
+
+    // Make it compatible with older browser
+    await promiseQueue(
+      paths.map(
+        (path) => () =>
+          $`env BABEL_ENV=cdn npx babel ${path} --out-file ${path} --source-maps`,
+      ),
+      availableParallelism(),
+    );
+
+    // Now generate min versions
+    await Bun.build({
+      ...buildOptions,
+      minify: true,
+      naming: "/[dir]/[name].min.[ext]",
+    });
+  });
+
+function indexTemplate() {
+  return `import * as dateFns from "./index.mjs";
+window.dateFns = {
+  ...window.dateFns,
+  dateFns
+};`;
+}
+
+function fpIndexTemplate() {
+  return `import * as fp from "../fp.mjs";
+window.dateFns = {
+  ...window.dateFns,
+  fp
+};`;
+}
+
+function localesIndexTemplate() {
+  return ` import * as locales from "../locale.mjs";
+window.dateFns = {
+  ...window.dateFns,
+  locale: {
+    ...window.dateFns.locale,
+    ...locales
+  }
+};`;
+}
+
+function localeTemplate({ name, code }: LocaleFile) {
+  return `import { ${name} } from "../${code}.mjs";
+window.dateFns = {
+  ...window.dateFns,
+  locale: {
+    ...window.dateFns.locale,
+    ${name}
+  }
+};`;
+}

--- a/scripts/build/package.sh
+++ b/scripts/build/package.sh
@@ -70,3 +70,6 @@ if [ -z "$PACKAGE_SKIP_BEAUTIFY" ]; then
   # Make it prettier
   npx prettier "$dir" --write --ignore-path "" > /dev/null 2>&1 || exit 1
 fi
+
+# Build CDN versions
+bun ./scripts/build/cdn.ts

--- a/scripts/build/package.sh
+++ b/scripts/build/package.sh
@@ -71,5 +71,7 @@ if [ -z "$PACKAGE_SKIP_BEAUTIFY" ]; then
   npx prettier "$dir" --write --ignore-path "" > /dev/null 2>&1 || exit 1
 fi
 
-# Build CDN versions
-bun ./scripts/build/cdn.ts
+if [ -z "$PACKAGE_SKIP_BEAUTIFY" ]; then
+  # Build CDN versions
+  bun ./scripts/build/cdn.ts
+fi

--- a/scripts/test/types.sh
+++ b/scripts/test/types.sh
@@ -11,6 +11,7 @@ root="$(pwd)/$(dirname "$0")/../.."
 export PACKAGE_OUTPUT_PATH="$root/tmp/types"
 
 export PACKAGE_SKIP_BEAUTIFY=true
+export PACKAGE_SKIP_CDN=true
 
 ./scripts/build/package.sh
 


### PR DESCRIPTION
Added CDN versions of modules compatible with older browsers.

The PR adds a script that bundles scripts that can be included in HTML that expose the functionality via `window.dateFns`. The code is additionally processed to target IE11. The goal is to make it available through jsDelivr.
