### PR TITLE
Documentation modified for isWeekend days #3757

### DIFF
--- a/src/isWeekend/index.ts
+++ b/src/isWeekend/index.ts
@@ -6,7 +6,7 @@ import { toDate } from "../toDate/index.js";
  * @summary Does the given date fall on a weekend?
  *
  * @description
- * Does the given date fall on a weekend?
+ * Does the given date fall on a weekend? A weekend is either saturday(day=6) or sunday(day=0)
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/isWeekend/index.ts
+++ b/src/isWeekend/index.ts
@@ -6,7 +6,7 @@ import { toDate } from "../toDate/index.js";
  * @summary Does the given date fall on a weekend?
  *
  * @description
- * Does the given date fall on a weekend? A weekend is either saturday(day=6) or sunday(day=0)
+ * Does the given date fall on a weekend? A weekend is either a saturday(day=6) or a sunday(day=0).
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/isWeekend/index.ts
+++ b/src/isWeekend/index.ts
@@ -6,7 +6,7 @@ import { toDate } from "../toDate/index.js";
  * @summary Does the given date fall on a weekend?
  *
  * @description
- * Does the given date fall on a weekend? A weekend is either a saturday(day=6) or a sunday(day=0).
+ * Does the given date fall on a weekend? A weekend is either Saturday (`6`) or Sunday (`0`).
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *


### PR DESCRIPTION
Some countries have different weekend days. But isWeekend() treats Saturday and Sunday as weekend. This is added to the documentation.