### PR TITLE
#3759 Docs: Fix intervalToDuration Example

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -14,7 +14,7 @@ import type { Duration, Interval } from "../types.js";
  * @summary Convert interval to duration
  *
  * @description
- * Convert a interval object to a duration object.
+ * Convert an interval object to a duration object.
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *
@@ -23,12 +23,12 @@ import type { Duration, Interval } from "../types.js";
  * @returns The duration object
  *
  * @example
- * // Get the duration between January 15, 1929 and April 4, 1968.
+ * // Get the duration between January 15, 1929, and April 4, 1968.
  * intervalToDuration({
  *   start: new Date(1929, 0, 15, 12, 0, 0),
  *   end: new Date(1968, 3, 4, 19, 5, 0)
  * })
- * // => { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
+ * // => { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
  */
 export function intervalToDuration<DateType extends Date>(
   interval: Interval<DateType>,


### PR DESCRIPTION
This PR fixes the `intervalToDuration` example, which incorrectly includes keys with a value of zero in the returned `Duration` object. It also fixes grammatical issues.

This closes #3759.