### PR TITLE
intlFormatDistance: refactor options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
     ],
     "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/no-namespace": "off",
     // The following rules are deprecated: https://eslint.org/blog/2023/10/deprecating-formatting-rules
     "array-bracket-newline": "off",
     "array-bracket-spacing": "off",

--- a/src/intlFormat/index.ts
+++ b/src/intlFormat/index.ts
@@ -1,7 +1,11 @@
 import { toDate } from "../toDate/index.js";
+import type { DateFns } from "../types.js";
 
 /**
  * The locale string (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
+ * @deprecated
+ *
+ * [TODO] Remove in v4
  */
 export type IntlFormatLocale = Intl.ResolvedDateTimeFormatOptions["locale"];
 
@@ -14,8 +18,10 @@ export type IntlFormatFormatOptions = Intl.DateTimeFormatOptions;
  * The locale options.
  */
 export interface IntlFormatLocaleOptions {
-  /** The locale(s) to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
-  locale: IntlFormatLocale | IntlFormatLocale[];
+  /** The locales to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
+  locale: DateFns.Utils.MaybeArray<
+    Intl.ResolvedDateTimeFormatOptions["locale"]
+  >;
 }
 
 /**

--- a/src/intlFormatDistance/index.ts
+++ b/src/intlFormatDistance/index.ts
@@ -26,7 +26,7 @@ export interface IntlFormatDistanceOptions
   /** Force the distance unit */
   unit?: IntlFormatDistanceUnit;
   /** The locales to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
-  locale: DateFns.Utils.MaybeArray<
+  locale?: DateFns.Utils.MaybeArray<
     Intl.ResolvedDateTimeFormatOptions["locale"]
   >;
 }

--- a/src/intlFormatDistance/index.ts
+++ b/src/intlFormatDistance/index.ts
@@ -16,16 +16,19 @@ import { differenceInHours } from "../differenceInHours/index.js";
 import { differenceInMinutes } from "../differenceInMinutes/index.js";
 import { differenceInSeconds } from "../differenceInSeconds/index.js";
 import { toDate } from "../toDate/index.js";
-import type { IntlFormatLocale } from "../intlFormat/index.js";
+import type { DateFns } from "../types.js";
 
 /**
  * The {@link intlFormatDistance} function options.
  */
-export interface IntlFormatDistanceOptions extends Intl.RelativeTimeFormatOptions {
+export interface IntlFormatDistanceOptions
+  extends Intl.RelativeTimeFormatOptions {
   /** Force the distance unit */
   unit?: IntlFormatDistanceUnit;
-  /** The locale(s) to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
-  locale?: IntlFormatLocale | IntlFormatLocale[];
+  /** The locales to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
+  locale: DateFns.Utils.MaybeArray<
+    Intl.ResolvedDateTimeFormatOptions["locale"]
+  >;
 }
 
 /**

--- a/src/intlFormatDistance/index.ts
+++ b/src/intlFormatDistance/index.ts
@@ -16,21 +16,16 @@ import { differenceInHours } from "../differenceInHours/index.js";
 import { differenceInMinutes } from "../differenceInMinutes/index.js";
 import { differenceInSeconds } from "../differenceInSeconds/index.js";
 import { toDate } from "../toDate/index.js";
+import type { IntlFormatLocale } from "../intlFormat/index.js";
 
 /**
  * The {@link intlFormatDistance} function options.
  */
-export interface IntlFormatDistanceOptions {
+export interface IntlFormatDistanceOptions extends Intl.RelativeTimeFormatOptions {
   /** Force the distance unit */
   unit?: IntlFormatDistanceUnit;
   /** The locale(s) to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
-  locale?: Intl.UnicodeBCP47LocaleIdentifier | Intl.UnicodeBCP47LocaleIdentifier[];
-  /** The locale matching algorithm to use. Other value: 'lookup'. See MDN for details [Locale identification and negotiation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_identification_and_negotiation) */
-  localeMatcher?: Intl.RelativeTimeFormatLocaleMatcher;
-  /** The output message format. The values are 'auto' (e.g. `yesterday`), 'always'(e.g. `1 day ago`) */
-  numeric?: Intl.RelativeTimeFormatNumeric;
-  /** The length of the result. The values are: 'long' (e.g. `1 month`), 'short' (e.g. 'in 1 mo.'), 'narrow' (e.g. 'in 1 mo.'). The narrow one could be similar to the short one for some locales. */
-  style?: Intl.RelativeTimeFormatStyle;
+  locale?: IntlFormatLocale | IntlFormatLocale[];
 }
 
 /**
@@ -219,9 +214,8 @@ export function intlFormatDistance<DateType extends Date>(
   }
 
   const rtf = new Intl.RelativeTimeFormat(options?.locale, {
-    localeMatcher: options?.localeMatcher,
-    numeric: options?.numeric || "auto",
-    style: options?.style,
+    numeric: "auto",
+    ...options,
   });
 
   return rtf.format(value, unit);

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,3 +301,22 @@ export interface NearestToUnitOptions<Unit extends number> {
    * hours. */
   nearestTo?: Unit;
 }
+
+/**
+ * Namespace for service-level types that are not oriented to the end users.
+ *
+ * [NOTE] Right now it is empty except the utils, but it will be useful to move
+ * some types here in the future. For instance {@link GenericDateConstructor}
+ * doesn't belong in the root namespace.
+ */
+export namespace DateFns {
+  /**
+   * Type utilities.
+   */
+  export namespace Utils {
+    /**
+     * Resolves passed type or array of types.
+     */
+    export type MaybeArray<Type> = Type | Type[];
+  }
+}


### PR DESCRIPTION
This small change refactors the options interface in intlFormatDistance to inherit from Intl.RelativeTimeFormatOptions, similar to how the equivalent options interface works in intlFormat.

This has the advantage of keeping the RelativeTimeFormat options up-to-date with any TypeScript library changes, as well as simplifying the declarations somewhat.

Unit tests are unaffected.