### PR TITLE
Fix issue in bun test runner

### DIFF
--- a/src/isDate/test.ts
+++ b/src/isDate/test.ts
@@ -43,7 +43,7 @@ describe("isDate", () => {
           document.body.appendChild(iframe);
         }));
     } else {
-      it.skip("returns true for a date passed from another iframe");
+      it.skip("returns true for a date passed from another iframe", () => {});
     }
 
     function execScript(scriptText: string) {


### PR DESCRIPTION
As discovered in PR #3824, there's a bug that was introduced in bun 1.1.11 that fails the run if a function body is lacked in tests.