### PR TITLE
Add two new functionalities

### DIFF
--- a/src/hasIdenticalCalander/index.ts
+++ b/src/hasIdenticalCalander/index.ts
@@ -1,0 +1,33 @@
+import { getYear } from "../getYear";
+import { getDay } from "../getDay";
+import { getDaysInYear } from "../getDaysInYear";
+
+/**
+ * @name hasIndenticalCalander
+ * @category Year helper
+ * @summary Checks two years has identical calander or not
+ * 
+ * @description 
+ * Checks two years has identical calander or not
+ * 
+ * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
+ *
+ * @param { Date | String | number } year1 - year1
+ * @param { Date | string | number } [year2=Date.now()] - year2
+ * 
+ * @returns {boolean}
+ *
+ * @example
+ * // 2024 and 2052 has identical calander?
+ * const result = hasIndenticalCalander(2024,2052);
+ * //=> true
+ */
+
+export function hasIndenticalCalander<DateType extends Date>(year1: DateType | string | number, year2: DateType | string | number = Date.now()) {
+
+    const day1 = getDay(new Date(getYear(year1), 0, 1));
+    const day2 = getDay(new Date(getYear(year2), 0, 1));
+    if (day1 !== day2)
+        return false;
+    return getDaysInYear(year1) === getDaysInYear(year2);
+}

--- a/src/hasIdenticalCalander/test.ts
+++ b/src/hasIdenticalCalander/test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { hasIndenticalCalander } from "./index";
+
+describe('hasIdenticalCalander', () => {
+    it('checking following years has identical calander', () => {
+        
+        expect(hasIndenticalCalander(new Date(1996, 1, 23))).toEqual(true);
+        
+        expect(hasIndenticalCalander(new Date(2028, 4, 12), new Date(2000, 0, 1))).toEqual(true);
+        
+        expect(hasIndenticalCalander(new Date(2000, 0, 1), new Date(2001, 0, 1))).toEqual(false);
+        
+        expect(hasIndenticalCalander(new Date(1970, 0, 1), new Date(1976, 0, 1))).toEqual(false);
+        
+        expect(hasIndenticalCalander(new Date(1970, 3, 10))).toEqual(false);
+        
+        expect(hasIndenticalCalander(new Date(2025, 6, 1), new Date(2026, 0, 1))).toEqual(false);
+    
+    });
+
+    it('return false for invalid dates', () => {
+        expect(hasIndenticalCalander(new Date(NaN), new Date(NaN))).toEqual(false);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,4 +246,5 @@ export * from "./yearsToDays/index.js";
 export * from "./yearsToMonths/index.js";
 export * from "./yearsToQuarters/index.js";
 export * from "./nextIdenticalCalanderYear";
+export * from "./hasIdenticalCalander";
 export type * from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,4 +245,5 @@ export * from "./weeksToDays/index.js";
 export * from "./yearsToDays/index.js";
 export * from "./yearsToMonths/index.js";
 export * from "./yearsToQuarters/index.js";
+export * from "./nextIdenticalCalanderYear";
 export type * from "./types.js";

--- a/src/nextIdenticalCalanderYear/index.ts
+++ b/src/nextIdenticalCalanderYear/index.ts
@@ -1,0 +1,44 @@
+import { isLeapYear } from "../isLeapYear";
+import { addYears } from "../addYears";
+import { getYear } from "../getYear";
+
+/**
+ * @name nextIdenticalCalanderYear
+ * @category Year Helpers
+ * @summary Determines the next year which has identical calendar as the given year.
+ *
+ * @description
+ * Determines the next year which has identical calendar as the given year.
+ *
+ * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
+ *
+ * @param {Date|number|string} year - The year as a Date object or a number or a string to which the next same calendar year needs to be found. 
+ *
+ * @returns {number} The next year with the same calendar
+ *
+ * @example
+ * //Next same calander year for 2024
+ * const result=nextIdenticalCalanderYear(new Date(2024,0,0));
+ * //=> 2056
+ */
+export function nextIdenticalCalanderYear<DateType extends Date>(
+    year: DateType | number | string
+): number {
+    const extraDays = getExtraDays(year);
+    let sum = 0, nextYear = year;
+    while (nextYear !== null) {
+        nextYear = addYears(nextYear, 1);
+        sum = (sum + getExtraDays(nextYear)) % 7;
+        if (sum === 0 && getExtraDays(nextYear) === extraDays) {
+            return getYear(nextYear);
+        }
+    }
+    return getYear(nextYear);
+}
+
+// returns the extra days in a year
+function getExtraDays<DateType extends Date>(year: DateType | number | string) {
+    if (isLeapYear(year))
+        return 2;
+    return 1;
+}

--- a/src/nextIdenticalCalanderYear/test.ts
+++ b/src/nextIdenticalCalanderYear/test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { nextIdenticalCalanderYear } from "./index.js";
+
+describe('nextIdenticalCalanderYear', () => {
+    it("returns the following next calander year for given various dates", () => {
+        expect(nextIdenticalCalanderYear(new Date(1900, 10, 20))).toEqual(1906);
+
+        expect(nextIdenticalCalanderYear(new Date(1950, 3, 17))).toEqual(1961);
+
+        expect(nextIdenticalCalanderYear(new Date(1999, 0, 17))).toEqual(2010);
+
+        expect(nextIdenticalCalanderYear(new Date(2000, 1, 17))).toEqual(2028);
+
+        expect(nextIdenticalCalanderYear(new Date(2020, 2, 23))).toEqual(2048);
+
+        expect(nextIdenticalCalanderYear(new Date(2021, 3, 22))).toEqual(2027);
+
+        expect(nextIdenticalCalanderYear(new Date(2022, 11, 21))).toEqual(2033);
+
+        expect(nextIdenticalCalanderYear(new Date(2023, 5, 20))).toEqual(2034);
+
+        expect(nextIdenticalCalanderYear(new Date(2024, 6, 19))).toEqual(2052);
+
+        expect(nextIdenticalCalanderYear(new Date(2025, 7, 18))).toEqual(2031);
+
+    });
+    it("returns NaN if the given date is invalid", () => {
+        const result = nextIdenticalCalanderYear(new Date(NaN));
+        expect(isNaN(result)).toBe(true);
+    });
+});


### PR DESCRIPTION
**Added functionalities:**

1. `hasIdenticalCalander`: This is used to check whether two given years has same Calander or not.
2. `nextIdenticalCalanderYear`: Gives the next year which has same Calander as given year.

## Changes

- Added `hasIdenticalCalander` folder in `src`.
- Added `hasIdenticalCalander` folder in `src`.
- Updated `index.js` file in `src` folder
- Added tests for both functionalities in corresponding folders

