### PR TITLE
fix: small grammar correction on short day values

### DIFF
--- a/src/locale/pt-BR/_lib/localize/index.ts
+++ b/src/locale/pt-BR/_lib/localize/index.ts
@@ -52,7 +52,7 @@ const monthValues = {
 
 const dayValues = {
   narrow: ["D", "S", "T", "Q", "Q", "S", "S"] as const,
-  short: ["dom", "seg", "ter", "qua", "qui", "sex", "sab"] as const,
+  short: ["dom", "seg", "ter", "qua", "qui", "sex", "sáb"] as const,
   abbreviated: [
     "domingo",
     "segunda",


### PR DESCRIPTION
## Summary

This pull request fixes a grammatical error in the short days of the week in the `pt-BR` language.

Previously, the short day of the week Saturday is grammatically incorrect, being `sab`, but the correct one is `sáb`, that is, they forgot the accent.