### PR TITLE
Reject non-number amounts in addDays, addMonths, and addBusinessDays

### DIFF
--- a/pkgs/core/src/addBusinessDays/index.tp.ts
+++ b/pkgs/core/src/addBusinessDays/index.tp.ts
@@ -15,7 +15,8 @@ export function tpyAddBusinessDays<
   options?: AddBusinessDaysOptions<ResultDate> | undefined,
 ): ResultDate {
   let [temporal, invalidDate] = toTpInstant(date, options);
-  if (!temporal || isNaN(amount)) return invalidDate;
+  if (!temporal || typeof amount !== "number" || isNaN(amount))
+    return invalidDate;
 
   const startedOnWeekend = tpIsWeekend(temporal);
   const hours = temporal.hour;

--- a/pkgs/core/src/addBusinessDays/index.ts
+++ b/pkgs/core/src/addBusinessDays/index.ts
@@ -51,7 +51,8 @@ export function addBusinessDays<
   const _date = toDate(date, options?.in);
   const startedOnWeekend = isWeekend(_date, options);
 
-  if (isNaN(amount)) return constructFrom(options?.in, NaN);
+  if (typeof amount !== "number" || isNaN(amount))
+    return constructFrom(options?.in, NaN);
 
   const hours = _date.getHours();
   const sign = amount < 0 ? -1 : 1;

--- a/pkgs/core/src/addBusinessDays/test.ts
+++ b/pkgs/core/src/addBusinessDays/test.ts
@@ -69,6 +69,12 @@ describe("addBusinessDays", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
+  it("returns `Invalid Date` if the given amount is not a number", () => {
+    // @ts-expect-error - We're testing an invalid amount
+    const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1), "10");
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
   it("starting from a weekend day should land on a weekday when reducing a divisible by 5", () => {
     const subtractResult = addBusinessDays(new Date(2019, 7, 18), -5);
     expect(subtractResult).toEqual(new Date(2019, 7, 12));

--- a/pkgs/core/src/addBusinessDays/test.ts
+++ b/pkgs/core/src/addBusinessDays/test.ts
@@ -69,7 +69,7 @@ describe("addBusinessDays", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
-  it("returns `Invalid Date` if the given amount is not a number", () => {
+  it("returns `Invalid Date` if the given amount is a numeric string", () => {
     // @ts-expect-error - We're testing an invalid amount
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1), "10");
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);

--- a/pkgs/core/src/addDays/index.tp.ts
+++ b/pkgs/core/src/addDays/index.tp.ts
@@ -11,7 +11,8 @@ export function tpyAddDays<
   options?: AddDaysOptions<ResultDate> | undefined,
 ): ResultDate {
   let [temporal, invalidDate] = toTpInstant(date, options);
-  if (!temporal || isNaN(amount)) return invalidDate;
+  if (!temporal || typeof amount !== "number" || isNaN(amount))
+    return invalidDate;
 
   const result = temporal.add({ days: amount });
 

--- a/pkgs/core/src/addDays/index.ts
+++ b/pkgs/core/src/addDays/index.ts
@@ -59,7 +59,8 @@ export function addDays<
   options?: AddDaysOptions<ResultDate> | undefined,
 ): ResultDate {
   const _date = toDate(date, options?.in);
-  if (isNaN(amount)) return constructFrom(options?.in || date, NaN);
+  if (typeof amount !== "number" || isNaN(amount))
+    return constructFrom(options?.in || date, NaN);
 
   // If 0 days, no-op to avoid changing times in the hour before end of DST
   if (!amount) return _date;

--- a/pkgs/core/src/addDays/test.ts
+++ b/pkgs/core/src/addDays/test.ts
@@ -32,6 +32,12 @@ describe("addDays", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
+  it("returns `Invalid Date` if the given amount is not a number", () => {
+    // @ts-expect-error - We're testing an invalid amount
+    const result = addDays(new Date(2014, 8 /* Sep */, 1), "10");
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
   it("resolves the date type by default", () => {
     const result = addDays(Date.now(), 5);
     expect(result).toBeInstanceOf(Date);

--- a/pkgs/core/src/addDays/test.ts
+++ b/pkgs/core/src/addDays/test.ts
@@ -32,7 +32,7 @@ describe("addDays", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
-  it("returns `Invalid Date` if the given amount is not a number", () => {
+  it("returns `Invalid Date` if the given amount is a numeric string", () => {
     // @ts-expect-error - We're testing an invalid amount
     const result = addDays(new Date(2014, 8 /* Sep */, 1), "10");
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);

--- a/pkgs/core/src/addMonths/index.ts
+++ b/pkgs/core/src/addMonths/index.ts
@@ -44,7 +44,8 @@ export function addMonths<
   options?: AddMonthsOptions<ResultDate> | undefined,
 ): ResultDate {
   const _date = toDate(date, options?.in);
-  if (isNaN(amount)) return constructFrom(options?.in || date, NaN);
+  if (typeof amount !== "number" || isNaN(amount))
+    return constructFrom(options?.in || date, NaN);
   if (!amount) {
     // If 0 months, no-op to avoid changing times in the hour before end of DST
     return _date;

--- a/pkgs/core/src/addMonths/test.ts
+++ b/pkgs/core/src/addMonths/test.ts
@@ -49,6 +49,12 @@ describe("addMonths", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
+  it("returns `Invalid Date` if the given amount is not a number", () => {
+    // @ts-expect-error - We're testing an invalid amount
+    const result = addMonths(new Date(2014, 8 /* Sep */, 1), "10");
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
   const dstTransitions = getDstTransitions(2017);
   const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip;
   const tzName =

--- a/pkgs/core/src/addMonths/test.ts
+++ b/pkgs/core/src/addMonths/test.ts
@@ -49,7 +49,7 @@ describe("addMonths", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
-  it("returns `Invalid Date` if the given amount is not a number", () => {
+  it("returns `Invalid Date` if the given amount is a numeric string", () => {
     // @ts-expect-error - We're testing an invalid amount
     const result = addMonths(new Date(2014, 8 /* Sep */, 1), "10");
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## 🧩 Context

`addDays`, `addMonths` and `addBusinessDays` guard an invalid `amount` with

```ts
if (isNaN(amount)) return constructFrom(..., NaN)
```

but `isNaN` coerces its argument, so a numeric string like `"10"` bypasses the guard (#4284). It then reaches e.g. `_date.setDate(_date.getDate() + amount)`, where `+` concatenates the string and the date jumps to a bogus value:

```ts
addDays(new Date(2026, 8, 10), 10)   // 2026-09-20  ✓
addDays(new Date(2026, 8, 10), "10") // 2029-06-05  ✗ (string concatenation in setDate)
```

The type signature is `amount: number`, so a string is a misuse — but the current behaviour fails silently with a plausible-looking result instead of failing predictably.

## 📦 Changes

Reject non-number amounts up front, so the call returns an Invalid Date (`NaN`) — matching the existing `NaN`-amount behaviour:

```diff
-  if (isNaN(amount)) return constructFrom(options?.in || date, NaN);
+  if (typeof amount !== "number" || isNaN(amount))
+    return constructFrom(options?.in || date, NaN);
```

Applied to:

- `addDays`, `addMonths`, `addBusinessDays`: the only `add*` helpers that can emit a plausible-but-wrong date from a non-number amount. Each keeps its own `constructFrom(...)` clause.
- `tpyAddDays` and `tpyAddBusinessDays`, the Temporal implementations that share the same guard, so both implementations agree.

The other `add*` helpers don't share this hazard: `addWeeks`, `addYears`, `addQuarters`, `addHours`, `addMinutes`, and `addSeconds` multiply `amount` by a factor, so a numeric string coerces to a number and they return the correct result; `addMilliseconds` computes `+toDate(date) + amount`, which for a string becomes `new Date("<timestamp>10")` and parses to an Invalid Date.

Number amounts — including `0` (no-op) and `NaN` — are unchanged.

## 🧪 Testing

Added a regression test for the `"10"` input to each of `addDays`, `addMonths`, and `addBusinessDays`. The `addDays` and `addBusinessDays` suites are shared with their Temporal implementations via `test.tp.ts`, so those tests cover both the regular and Temporal code paths.

```ts
addDays(date, "10") // Invalid Date  (was: 2029-…)
addDays(date, 10)   // +10 days      (unchanged)
addDays(date, NaN)  // Invalid Date  (unchanged)
addDays(date, 0)    // no-op         (unchanged)
```

Verified locally:

- `vitest run --project main src/addDays/test.ts src/addMonths/test.ts src/addBusinessDays/test.ts` → 38 passed, 15 skipped.
- `vitest run --project temporarily src/addDays/test.tp.ts src/addBusinessDays/test.tp.ts` → 26 passed, 8 skipped.
- `tsgo --build` → passes.
- `oxlint --type-aware` on the changed files → passes.

## 🛠 Alternative considered

Instead of rejecting, the string could be coerced (`amount = Number(amount)`) so `"10"` behaves like `10`. I went with rejecting because `amount` is typed `number`, the existing guard already returns Invalid Date for invalid numeric input, and a predictable failure is safer than an implicit coercion. Happy to switch if coercion is preferred.

Closes #4284
