### PR TITLE
Fix constructFrom for Date subclasses with extra constructor args

### DIFF
--- a/pkgs/core/src/constructFrom/index.ts
+++ b/pkgs/core/src/constructFrom/index.ts
@@ -53,8 +53,14 @@ export function constructFrom<
   if (date && typeof date === "object" && constructFromSymbol in date)
     return date[constructFromSymbol](value);
 
-  if (date instanceof Date)
-    return new (date.constructor as GenericDateConstructor<ResultDate>)(value);
+  if (date instanceof Date) {
+    if (date.constructor === Date) return new Date(value) as ResultDate;
+
+    const result = new (date.constructor as GenericDateConstructor<ResultDate>)(
+      value,
+    );
+    if (result instanceof Date && +result === +new Date(value)) return result;
+  }
 
   return new Date(value) as ResultDate;
 }

--- a/pkgs/core/src/constructFrom/test.ts
+++ b/pkgs/core/src/constructFrom/test.ts
@@ -91,6 +91,26 @@ describe("constructFrom", () => {
   });
 
   describe("edge cases", () => {
+    it("falls back when a custom Date constructor takes extra arguments", () => {
+      class RangeDate extends Date {
+        range: number;
+        constructor(
+          range: number,
+          ...args: ConstructorParameters<typeof Date>
+        ) {
+          super(...args);
+          this.range = range;
+        }
+      }
+
+      const referenceDate = new RangeDate(5, new Date(2026, 1, 3, 5));
+      const value = new Date(2024, 0, 1);
+      const result = constructFrom(referenceDate, value);
+
+      expect(result instanceof Date).toBe(true);
+      expect(result.getTime()).toEqual(value.getTime());
+    });
+
     it("does not trip over null", () => {
       const value = 1635244800000; // October 26, 2023
       // @ts-expect-error - We want to pass null here


### PR DESCRIPTION
## Problem

`constructFrom` builds a date with `new (date.constructor)(value)`. For a subclass whose first constructor parameter is not the date value (the `RangeDate` example in #4160), that value is treated as the extra argument and `super()` runs as `Date()` — i.e. now — so functions that go through `toDate`/`constructFrom` return the wrong instant.

Custom types that need extra constructor state already have `[Symbol.for("constructDateFrom")]`. This only stops the silent wrong-date path.

## Solution

- Keep the `Date` constructor fast path.
- For other `Date` subclasses, use `new Ctor(value)` only when the result is a `Date` whose time matches `new Date(value)`.
- Otherwise fall back to `new Date(value)`.

Date-compatible subclasses (`class CustomDate extends Date {}`, `UTCDate`) are unchanged. Types with extra constructor args should still implement `constructFromSymbol` if they need those properties copied.

Fixes #4160