### PR TITLE
Fix en-US narrow noon parsing (#4271)

### DIFF
--- a/pkgs/core/src/locale/en-US/_lib/match/index.ts
+++ b/pkgs/core/src/locale/en-US/_lib/match/index.ts
@@ -80,7 +80,7 @@ const parseDayPeriodPatterns = {
     am: /^a/i,
     pm: /^p/i,
     midnight: /^mi/i,
-    noon: /^no/i,
+    noon: /^n/i,
     morning: /morning/i,
     afternoon: /afternoon/i,
     evening: /evening/i,

--- a/pkgs/core/src/locale/en-US/test.ts
+++ b/pkgs/core/src/locale/en-US/test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
+import { parse } from "../../parse/index.ts";
+import { enUS } from "./index.ts";
+
+describe("en-US locale", () => {
+  describe("day period matching", () => {
+    // see https://github.com/date-fns/date-fns/issues/4271
+
+    it("matches the narrow noon to the noon day period", () => {
+      expect(enUS.match.dayPeriod("n", { width: "narrow" })).toEqual({
+        value: "noon",
+        rest: "",
+      });
+    });
+
+    it("parses the narrow noon as midday", () => {
+      const referenceDate = new Date(2024, 0 /* Jan */, 1);
+
+      expect(parse("n", "bbbbb", referenceDate)).toEqual(
+        new Date(2024, 0 /* Jan */, 1, 12),
+      );
+    });
+
+    it("keeps parsing the wider noon and midnight forms", () => {
+      const referenceDate = new Date(2024, 0 /* Jan */, 1);
+
+      expect(parse("noon", "b", referenceDate)).toEqual(
+        new Date(2024, 0 /* Jan */, 1, 12),
+      );
+      expect(parse("midnight", "b", referenceDate)).toEqual(
+        new Date(2024, 0 /* Jan */, 1, 0),
+      );
+      expect(parse("mi", "bbbbb", referenceDate)).toEqual(
+        new Date(2024, 0 /* Jan */, 1, 0),
+      );
+    });
+
+    it("round-trips the day periods it formats", () => {
+      const referenceDate = new Date(2024, 0 /* Jan */, 1);
+
+      (
+        [
+          [new Date(2024, 0 /* Jan */, 1, 12), "b"],
+          [new Date(2024, 0 /* Jan */, 1, 12), "bbbbb"],
+          [new Date(2024, 0 /* Jan */, 1, 0), "b"],
+          [new Date(2024, 0 /* Jan */, 1, 0), "bbbbb"],
+        ] as const
+      ).forEach(([date, formatString]) => {
+        expect(
+          parse(format(date, formatString), formatString, referenceDate),
+        ).toEqual(date);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #4271.

### Problem

`matchDayPeriodPatterns.narrow` accepts a bare `n`, but `parseDayPeriodPatterns.any.noon` was `/^no/i`, which cannot match the single character the narrow pattern just consumed. `buildMatchFn` therefore returned `{ value: undefined, rest: "" }`, and `dayPeriodEnumToHours(undefined)` fell through to its default case and returned `0`.

The result is a format → parse round-trip that succeeds but yields the wrong time, with no `Invalid Date` to signal it:

```js
format(new Date(2024, 0, 1, 12, 0), "bbbbb"); //=> "n"
parse("n", "bbbbb", ref);                     //=> 2024-01-01 00:00  ❌ expected 12:00
```

Credit to the reporter for pinpointing the mismatch — the diagnosis in the issue was accurate.

### Fix

`noon: /^no/i` → `noon: /^n/i`, mirroring how `midnight: /^mi/i` already covers both the narrow `mi` and the wide `midnight`.

No matched string reaches this table starting with `n` other than `n` and `noon`: the narrow pattern's remaining alternatives start with `a`, `p`, `mi` or `in the`/`at`, and the `any` pattern's start with `a`, `p`, `m` or `in the`/`at`. `noon` is also tested before `night`, and `night` is only ever reached via `at night`.

### Scope

`en-AU`, `en-CA`, `en-GB`, `en-IE`, `en-IN`, `en-NZ` and `en-ZA` all import this match module rather than defining their own, so all eight English locales were affected and all eight are fixed by the one-line change.

### Tests

Added `pkgs/core/src/locale/en-US/test.ts` covering the narrow match result, the parsed hour, a regression guard on the wider `noon`/`midnight`/`mi` forms, and a `b`/`bbbbb` format → parse round-trip.

Full `pkgs/core` suite: 3092 passed, unchanged from the 124 pre-existing `Temporal is not defined` failures on the base commit (Node 24 has no `Temporal`); the only delta is the 4 added tests.

### Noted while here, not touched

A round-trip sweep across all locales turned up two adjacent things that are out of scope for this issue, but may be worth their own reports if they aren't already tracked:

- `enUS.match.dayPeriod("at night")` returns `am`, because `am: /^a/i` is tested before `night` and `at night` starts with `a`. `dayPeriodEnumToHours` maps both to `0`, so `parse` output is unaffected and only direct `match` callers see it.
- `ar-DZ`, `ar-MA` and `ar-SA` have English day period match patterns paired with Arabic localize values, so their noon and midnight round-trips return `Invalid Date`. That looks like a whole untranslated match table rather than a pattern bug.
