### PR TITLE
feat: add allClosestIndicesTo

### DIFF
--- a/pkgs/core/package.json
+++ b/pkgs/core/package.json
@@ -35,6 +35,7 @@
     "./addSeconds": "./src/addSeconds/index.ts",
     "./addWeeks": "./src/addWeeks/index.ts",
     "./addYears": "./src/addYears/index.ts",
+    "./allClosestIndicesTo": "./src/allClosestIndicesTo/index.ts",
     "./areIntervalsOverlapping": "./src/areIntervalsOverlapping/index.ts",
     "./clamp": "./src/clamp/index.ts",
     "./closestIndexTo": "./src/closestIndexTo/index.ts",
@@ -292,6 +293,7 @@
     "./fp/addWithOptions": "./fp/src/addWithOptions/index.ts",
     "./fp/addYears": "./fp/src/addYears/index.ts",
     "./fp/addYearsWithOptions": "./fp/src/addYearsWithOptions/index.ts",
+    "./fp/allClosestIndicesTo": "./fp/src/allClosestIndicesTo/index.ts",
     "./fp/areIntervalsOverlapping": "./fp/src/areIntervalsOverlapping/index.ts",
     "./fp/areIntervalsOverlappingWithOptions": "./fp/src/areIntervalsOverlappingWithOptions/index.ts",
     "./fp/clamp": "./fp/src/clamp/index.ts",
@@ -921,6 +923,16 @@
         "import": {
           "types": "./addYears.d.ts",
           "default": "./addYears.js"
+        }
+      },
+      "./allClosestIndicesTo": {
+        "require": {
+          "types": "./allClosestIndicesTo.d.cts",
+          "default": "./allClosestIndicesTo.cjs"
+        },
+        "import": {
+          "types": "./allClosestIndicesTo.d.ts",
+          "default": "./allClosestIndicesTo.js"
         }
       },
       "./areIntervalsOverlapping": {
@@ -3491,6 +3503,16 @@
         "import": {
           "types": "./fp/addYearsWithOptions.d.ts",
           "default": "./fp/addYearsWithOptions.js"
+        }
+      },
+      "./fp/allClosestIndicesTo": {
+        "require": {
+          "types": "./fp/allClosestIndicesTo.d.cts",
+          "default": "./fp/allClosestIndicesTo.cjs"
+        },
+        "import": {
+          "types": "./fp/allClosestIndicesTo.d.ts",
+          "default": "./fp/allClosestIndicesTo.js"
         }
       },
       "./fp/areIntervalsOverlapping": {

--- a/pkgs/core/src/allClosestIndicesTo/index.ts
+++ b/pkgs/core/src/allClosestIndicesTo/index.ts
@@ -1,0 +1,57 @@
+import { toDate } from "../toDate/index.ts";
+import type { DateArg } from "../types.ts";
+
+/**
+ * @name allClosestIndicesTo
+ * @category Common Helpers
+ * @summary Return the indices of all dates in the array closest to the given date.
+ *
+ * @description
+ * Return the indices of all dates from the array closest to the given date.
+ * Unlike `closestIndexTo`, which returns a single index, this returns every
+ * index that shares the minimum distance to the given date, preserving their
+ * order in the input array.
+ *
+ * @param dateToCompare - The date to compare with
+ * @param dates - The array to search
+ *
+ * @returns The indices of the dates closest to the given date, or an empty
+ * array if no valid value is given
+ *
+ * @example
+ * // Which dates are closest to 6 September 2015?
+ * const dateToCompare = new Date(2015, 8, 6)
+ * const result = allClosestIndicesTo(dateToCompare, [
+ *   new Date(2015, 8, 5),
+ *   new Date(2015, 8, 7),
+ *   new Date(2015, 8, 10),
+ * ])
+ * //=> [0, 1]
+ */
+export function allClosestIndicesTo(
+  dateToCompare: DateArg<Date> & {},
+  dates: Array<DateArg<Date> & {}>,
+): number[] {
+  const timeToCompare = +toDate(dateToCompare);
+
+  if (isNaN(timeToCompare)) return [];
+
+  let result: number[] = [];
+  let minDistance = Infinity;
+
+  for (let index = 0; index < dates.length; index++) {
+    const date = toDate(dates[index]!);
+
+    if (isNaN(+date)) return [];
+
+    const distance = Math.abs(timeToCompare - +date);
+    if (distance < minDistance) {
+      minDistance = distance;
+      result = [index];
+    } else if (distance === minDistance) {
+      result.push(index);
+    }
+  }
+
+  return result;
+}

--- a/pkgs/core/src/allClosestIndicesTo/test.ts
+++ b/pkgs/core/src/allClosestIndicesTo/test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { allClosestIndicesTo } from "./index.ts";
+
+describe("allClosestIndicesTo", () => {
+  it("returns the index of the single closest date", () => {
+    const date = new Date(2014, 6 /* Jul */, 2);
+    const result = allClosestIndicesTo(date, [
+      new Date(2015, 7 /* Aug */, 31),
+      new Date(2012, 6 /* Jul */, 2),
+    ]);
+    expect(result).toEqual([0]);
+  });
+
+  it("returns every index that shares the minimum distance", () => {
+    const date = new Date(2015, 8 /* Sep */, 6);
+    const result = allClosestIndicesTo(date, [
+      new Date(2015, 8 /* Sep */, 5),
+      new Date(2015, 8 /* Sep */, 7),
+      new Date(2015, 8 /* Sep */, 10),
+    ]);
+    expect(result).toEqual([0, 1]);
+  });
+
+  it("preserves the input order of the tied indices", () => {
+    const date = new Date(2014, 6 /* Jul */, 2, 6, 30, 4, 500);
+    const result = allClosestIndicesTo(date, [
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 3, 900),
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 5, 100),
+      new Date(2014, 6 /* Jul */, 2, 6, 30, 5, 900),
+    ]);
+    expect(result).toEqual([0, 1]);
+  });
+
+  it("accepts timestamps", () => {
+    const date = new Date(2014, 6 /* Jul */, 2).getTime();
+    const result = allClosestIndicesTo(date, [
+      new Date(2015, 7 /* Aug */, 31).getTime(),
+      new Date(2012, 6 /* Jul */, 2).getTime(),
+    ]);
+    expect(result).toEqual([0]);
+  });
+
+  it("returns an empty array if the given array is empty", () => {
+    const date = new Date(2014, 6 /* Jul */, 2).getTime();
+    const result = allClosestIndicesTo(date, []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array if the given date is `Invalid Date`", () => {
+    const date = new Date(NaN);
+    const result = allClosestIndicesTo(date, [
+      new Date(2015, 7 /* Aug */, 31),
+      new Date(2012, 6 /* Jul */, 2),
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array if any date in the given array is `Invalid Date`", () => {
+    const date = new Date(2014, 6 /* Jul */, 2);
+    const result = allClosestIndicesTo(date, [
+      new Date(2015, 7 /* Aug */, 31),
+      new Date(NaN),
+      new Date(2012, 6 /* Jul */, 2),
+    ]);
+    expect(result).toEqual([]);
+  });
+});

--- a/pkgs/core/src/fp/allClosestIndicesTo/index.ts
+++ b/pkgs/core/src/fp/allClosestIndicesTo/index.ts
@@ -1,0 +1,6 @@
+// This file is generated automatically by `scripts/build/fp.ts`. Please, don't change it.
+
+import { allClosestIndicesTo as fn } from "../../allClosestIndicesTo/index.ts";
+import { convertToFP } from "../_lib/convertToFP/index.ts";
+
+export const allClosestIndicesTo = convertToFP(fn, 2);

--- a/pkgs/core/src/fp/index.ts
+++ b/pkgs/core/src/fp/index.ts
@@ -24,6 +24,7 @@ export * from "./addWeeksWithOptions/index.ts";
 export * from "./addWithOptions/index.ts";
 export * from "./addYears/index.ts";
 export * from "./addYearsWithOptions/index.ts";
+export * from "./allClosestIndicesTo/index.ts";
 export * from "./areIntervalsOverlapping/index.ts";
 export * from "./areIntervalsOverlappingWithOptions/index.ts";
 export * from "./clamp/index.ts";

--- a/pkgs/core/src/index.ts
+++ b/pkgs/core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./addQuarters/index.ts";
 export * from "./addSeconds/index.ts";
 export * from "./addWeeks/index.ts";
 export * from "./addYears/index.ts";
+export * from "./allClosestIndicesTo/index.ts";
 export * from "./areIntervalsOverlapping/index.ts";
 export * from "./clamp/index.ts";
 export * from "./closestIndexTo/index.ts";

--- a/pkgs/core/typedoc.json
+++ b/pkgs/core/typedoc.json
@@ -14,6 +14,7 @@
     "./src/addSeconds/index.ts",
     "./src/addWeeks/index.ts",
     "./src/addYears/index.ts",
+    "./src/allClosestIndicesTo/index.ts",
     "./src/areIntervalsOverlapping/index.ts",
     "./src/clamp/index.ts",
     "./src/closestIndexTo/index.ts",


### PR DESCRIPTION
Closes #2027

Adds `allClosestIndicesTo(dateToCompare, dates)` — returns the indices of every date tied for the closest distance to `dateToCompare`, complementing `closestIndexTo`, which returns only a single index.

This is the non-breaking new function @kossnocorp asked for in #2027 for the equal-dates case (and uses the name he proposed there):

```ts
allClosestIndicesTo(new Date(2015, 8, 6), [
  new Date(2015, 8, 5),
  new Date(2015, 8, 7),
  new Date(2015, 8, 10),
]);
//=> [0, 1]
```

It mirrors `closestIndexTo`'s signature, `DateArg` handling, and invalid-input rules (empty array on empty/invalid input). Tests, TSDoc, and the FP variant are included; the generated index/exports were regenerated.
