### PR TITLE
Fix `differenceInMonths` counting an unfinished month (#4150)

### DIFF
--- a/pkgs/core/src/differenceInMonths/index.ts
+++ b/pkgs/core/src/differenceInMonths/index.ts
@@ -1,7 +1,7 @@
 import { normalizeDates } from "../_lib/normalizeDates/index.ts";
+import { addMonths } from "../addMonths/index.ts";
 import { compareAsc } from "../compareAsc/index.ts";
 import { differenceInCalendarMonths } from "../differenceInCalendarMonths/index.ts";
-import { isLastDayOfMonth } from "../isLastDayOfMonth/index.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
 
 /**
@@ -30,35 +30,26 @@ export function differenceInMonths(
   earlierDate: DateArg<Date> & {},
   options?: DifferenceInMonthsOptions | undefined,
 ): number {
-  const [laterDate_, workingLaterDate, earlierDate_] = normalizeDates(
+  const [laterDate_, earlierDate_] = normalizeDates(
     options?.in,
-    laterDate,
     laterDate,
     earlierDate,
   );
 
-  const sign = compareAsc(workingLaterDate, earlierDate_);
+  const sign = compareAsc(laterDate_, earlierDate_);
   const difference = Math.abs(
-    differenceInCalendarMonths(workingLaterDate, earlierDate_),
+    differenceInCalendarMonths(laterDate_, earlierDate_),
   );
 
   if (difference < 1) return 0;
 
-  if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
-    workingLaterDate.setDate(30);
+  // `addMonths` clamps to the end of a shorter month, so January 31st plus one
+  // month is February 28th. Stepping the earlier date forward keeps this in
+  // step with `add`, which is how callers subtract the months again.
+  const anniversary = addMonths(earlierDate_, sign * difference);
+  const overshot =
+    sign > 0 ? +anniversary > +laterDate_ : +anniversary < +laterDate_;
 
-  workingLaterDate.setMonth(workingLaterDate.getMonth() - sign * difference);
-
-  let isLastMonthNotFull = compareAsc(workingLaterDate, earlierDate_) === -sign;
-
-  if (
-    isLastDayOfMonth(laterDate_) &&
-    difference === 1 &&
-    compareAsc(laterDate_, earlierDate_) === 1
-  ) {
-    isLastMonthNotFull = false;
-  }
-
-  const result = sign * (difference - +isLastMonthNotFull);
+  const result = sign * (difference - +overshot);
   return result === 0 ? 0 : result;
 }

--- a/pkgs/core/src/differenceInMonths/test.ts
+++ b/pkgs/core/src/differenceInMonths/test.ts
@@ -45,6 +45,32 @@ describe("differenceInMonths", () => {
       expect(result).toBe(1);
     });
 
+    it("doesn't count a month that the time of day hasn't completed", () => {
+      // see https://github.com/date-fns/date-fns/issues/4150
+      const result = differenceInMonths(
+        new Date(2021, 1 /* Feb */, 28, 17, 23),
+        new Date(2021, 0 /* Jan */, 28, 23, 45),
+      );
+      expect(result).toBe(0);
+    });
+
+    it("doesn't count a month when the anniversary day still exists", () => {
+      // Feb 2024 has 29 days, so Jan 29 has an anniversary that Feb 28 misses
+      const result = differenceInMonths(
+        new Date(2024, 1 /* Feb */, 28),
+        new Date(2024, 0 /* Jan */, 29),
+      );
+      expect(result).toBe(0);
+    });
+
+    it("counts the month once the time of day is reached", () => {
+      const result = differenceInMonths(
+        new Date(2021, 1 /* Feb */, 28, 23, 45),
+        new Date(2021, 0 /* Jan */, 28, 23, 45),
+      );
+      expect(result).toBe(1);
+    });
+
     it("it returns diff of 1 month between Nov, 30 2021 and Oct, 31 2021", () => {
       const result = differenceInMonths(
         new Date(2021, 10 /* Nov */, 30),

--- a/pkgs/core/src/intervalToDuration/test.ts
+++ b/pkgs/core/src/intervalToDuration/test.ts
@@ -34,6 +34,19 @@ describe("intervalToDuration", () => {
     });
   });
 
+  it("doesn't return negative components when the end is later than the start", () => {
+    // see https://github.com/date-fns/date-fns/issues/4150
+    const start = new Date(2026, 0 /* Jan */, 28, 23, 45);
+    const end = new Date(2026, 1 /* Feb */, 28, 17, 23);
+    const result = intervalToDuration({ start, end });
+
+    expect(result).toEqual({
+      days: 30,
+      hours: 17,
+      minutes: 38,
+    });
+  });
+
   it("returns duration of 0 when the dates are the same", () => {
     const start = new Date(2020, 2, 1, 12, 0, 0);
     const end = new Date(2020, 2, 1, 12, 0, 0);


### PR DESCRIPTION
Closes #4150.

### Problem

The reported symptom is `intervalToDuration` returning negative components for an interval whose end is after its start:

```js
intervalToDuration({
  start: parseISO("2026-01-28 22:45:00+00"),
  end: parseISO("2026-02-28 16:23:00+00"),
});
//=> { months: 1, hours: -6, minutes: -22 }  ❌
```

`intervalToDuration` peels off each unit with `differenceInX`, then subtracts it with `add` before measuring the next one. If a step reports more than has actually elapsed, `add` moves past the end date and every later unit comes out negative. So the negatives are a symptom; the over-count is in `differenceInMonths`.

Two things caused it, and they're independent:

**1. The last-day-of-month branch was too broad.**

```js
if (isLastDayOfMonth(laterDate_) && difference === 1 && compareAsc(laterDate_, earlierDate_) === 1) {
  isLastMonthNotFull = false;
}
```

This exists so that Jan 31 → Feb 28 counts as a full month, which is right — February has no 31st, so the clamped anniversary is the best available. But it fired for *any* landing on a month end, including Jan 28 23:45 → Feb 28 17:23, where Feb 28 23:45 is a real anniversary that hasn't been reached yet.

**2. The February adjustment above it.**

```js
if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
  workingLaterDate.setDate(30);
```

`setDate(30)` on a February date rolls over into March, and the following `setMonth(getMonth() - sign * difference)` then reads the rolled-over month. Jan 29 → Feb 28 2024 counted as a full month even though 2024 is a leap year, Feb 28 is *not* the last day, and Feb 29 is a genuine anniversary that hasn't arrived. That case can't be explained by the branch above.

### Fix

Step the earlier date forward by the calendar-month difference and check whether it overshoots:

```js
const anniversary = addMonths(earlierDate_, sign * difference);
const overshot = sign > 0 ? +anniversary > +laterDate_ : +anniversary < +laterDate_;
const result = sign * (difference - +overshot);
```

`addMonths` already clamps to the end of a shorter month, so Jan 31 → Feb 28 keeps counting as a full month without needing a special case, and both hacks come out. More importantly it makes the result consistent with `add` **by construction**, which is the invariant `intervalToDuration` actually depends on — it subtracts the months with `add`, so anything `differenceInMonths` reports must be reachable by `add`.

`addMonths` only pulls in `constructFrom` and `toDate`, so this doesn't add meaningful weight.

### Verification

I wrote a brute-force oracle — the largest `n` where `add(earlier, { months: n }) <= later`, using date-fns' own `add` so month-end clamping matches — and compared it against `differenceInMonths` across every day of Jan/Feb/Mar in 2021 (non-leap) and 2024 (leap), at several times of day, for one- and two-month gaps:

- **before:** 120 mismatches out of 175,168 comparisons
- **after:** 0

Then the same brute force over `intervalToDuration` itself, 201,025 intervals spanning both years and gaps from 1 to 365 days:

- **before:** 435 intervals with a negative component
- **after:** 0

The reported case now gives `{ days: 30, hours: 17, minutes: 38 }`.

All 21 existing `differenceInMonths` tests pass unchanged, including the three month-end cases (Feb 28 vs Jan 30, Feb 28 vs Jan 31, Nov 30 vs Oct 31) — those pin exactly the behaviour the clamping preserves.

Full `pkgs/core` suite: 3092 passed. The 124 failures are pre-existing on the base commit, all `ReferenceError: Temporal is not defined` in `*.tp.ts` under Node 24, and identical before and after; the delta is the 4 added tests. Regenerating the locale snapshots produces no change from this fix, so `formatDistance` output is unaffected.

### Behaviour change worth calling out

Where the later date is a month end *and* the earlier day-of-month cannot exist in that month, the result is now decided by the clamped anniversary rather than the day alone. Jan 31 00:00 → Feb 28 00:00 is still 1 month. Jan 31 23:45 → Feb 28 00:00 is now 0 rather than 1, because the clamped anniversary is Feb 28 23:45. That follows from `add` and is what keeps `intervalToDuration` non-negative, but it is a change in a documented edge case, so flagging it rather than burying it. Existing tests only pinned midnight, where old and new agree.

### Tests

- `differenceInMonths`: an unfinished month landing on a month end, the leap-year Jan 29 → Feb 28 case, and a guard that the month *is* counted once the time of day is reached.
- `intervalToDuration`: the reported interval, asserting the full duration rather than just the absence of negatives.

Without the fix, three of the four fail; the "counts the month once the time of day is reached" guard passes both ways.
