### PR TITLE
Document that `fromUnixTime` keeps fractional seconds (#4248)

### DIFF
--- a/pkgs/core/src/fromUnixTime/index.ts
+++ b/pkgs/core/src/fromUnixTime/index.ts
@@ -14,7 +14,8 @@ export interface FromUnixTimeOptions<
  * @summary Create a date from a Unix timestamp.
  *
  * @description
- * Create a date from a Unix timestamp (in seconds). Decimal values will be discarded.
+ * Create a date from a Unix timestamp (in seconds). Fractional seconds are
+ * kept as milliseconds.
  *
  * @param unixTime - The given Unix timestamp (in seconds)
  * @param options - An object with options. Allows to pass a context.
@@ -27,6 +28,11 @@ export interface FromUnixTimeOptions<
  * // Create the date 29 February 2012 11:45:05:
  * const result = fromUnixTime(1330515905)
  * //=> Wed Feb 29 2012 11:45:05
+ *
+ * @example
+ * // Fractional seconds become milliseconds:
+ * const result = fromUnixTime(1330515905.25)
+ * //=> Wed Feb 29 2012 11:45:05.250
  */
 export function fromUnixTime<DateType extends Date = Date>(
   unixTime: number,

--- a/pkgs/core/src/fromUnixTime/test.ts
+++ b/pkgs/core/src/fromUnixTime/test.ts
@@ -9,6 +9,13 @@ describe("fromUnixTime", () => {
     expect(result.getTime()).toBe(1330515499000);
   });
 
+  it("keeps fractional seconds as milliseconds", () => {
+    // see https://github.com/date-fns/date-fns/issues/4248
+    expect(fromUnixTime(1330515499.872).getTime()).toBe(1330515499872);
+    expect(fromUnixTime(0.001).getTime()).toBe(1);
+    expect(fromUnixTime(-0.001).getTime()).toBe(-1);
+  });
+
   it("returns invalid if the given timestamp is invalid", () => {
     const result = fromUnixTime(NaN);
     expect(isNaN(result.getTime())).toBe(true);


### PR DESCRIPTION
Closes #4248.

### Problem

`fromUnixTime` is documented as discarding decimals:

```
Create a date from a Unix timestamp (in seconds). Decimal values will be discarded.
```

but it doesn't:

```js
fromUnixTime(0.001).getTime();            //=> 1        (documented: 0)
fromUnixTime(-0.001).getTime();           //=> -1       (documented: 0)
fromUnixTime(1640888727.872).toISOString();
//=> "2021-12-30T18:25:27.872Z"           (documented: ...:27.000Z)
```

### Why it drifted

The sentence used to be accurate. Before the v3 conversion the argument was rounded first:

```js
const unixTime = toInteger(dirtyUnixTime);
return toDate(unixTime * 1000);
```

`Convert functions to v3` (d9831ea16) dropped the `toInteger` call and left the description alone, so the docs have described pre-v3 behaviour since.

### Which way to resolve it

The issue offers both directions. I've taken the documentation one, because restoring the truncation would change runtime behaviour that has shipped since v3 — anyone passing a timestamp with millisecond precision would silently start losing it, and this is the only place the old contract is still written down.

If you'd rather have the truncation back, that's a call for you to make rather than me, and I'm happy to send that instead. It would want a changelog entry as a breaking change.

### Change

The description now reads:

```
Create a date from a Unix timestamp (in seconds). Fractional seconds are
kept as milliseconds.
```

plus a second `@example` showing it, since the existing one uses a whole-second timestamp and doesn't illustrate the question. This is the only occurrence of the old sentence in the repo.

### Tests

`fromUnixTime`'s tests covered whole seconds only, which is why the drift went unnoticed. Added the three cases from the issue — `1330515499.872`, `0.001` and `-0.001`, the last two pinning the sign behaviour around zero.

Full `pkgs/core` suite: 3089 passed. The 124 failures are pre-existing on the base commit — all `ReferenceError: Temporal is not defined` in `*.tp.ts` under Node 24 — unchanged before and after; the delta is the single added test.
