### PR TITLE
fix: pad years below 1000 in formatRFC3339 and formatRFC7231

### DIFF
--- a/pkgs/core/src/formatRFC3339/index.ts
+++ b/pkgs/core/src/formatRFC3339/index.ts
@@ -52,7 +52,7 @@ export function formatRFC3339(
 
   const day = addLeadingZeros(date_.getDate(), 2);
   const month = addLeadingZeros(date_.getMonth() + 1, 2);
-  const year = date_.getFullYear();
+  const year = addLeadingZeros(date_.getFullYear(), 4);
 
   const hour = addLeadingZeros(date_.getHours(), 2);
   const minute = addLeadingZeros(date_.getMinutes(), 2);

--- a/pkgs/core/src/formatRFC3339/test.ts
+++ b/pkgs/core/src/formatRFC3339/test.ts
@@ -62,4 +62,24 @@ describe("formatRFC3339", () => {
       ).toBe("2024-09-18T00:00:00+14:00");
     });
   });
+
+  it("pads years below 1000 to four digits", () => {
+    // RFC 3339 defines `date-fullyear = 4DIGIT`, so a year below 1000 has to be
+    // zero padded rather than emitted at its natural width.
+    const getTimezoneOffsetStub = vi.spyOn(Date.prototype, "getTimezoneOffset");
+    getTimezoneOffsetStub.mockReturnValue(0);
+
+    const date = new Date(2019, 0 /* Jan */, 1, 12, 0, 0);
+
+    date.setFullYear(999);
+    expect(formatRFC3339(date)).toBe("0999-01-01T12:00:00Z");
+
+    date.setFullYear(99);
+    expect(formatRFC3339(date)).toBe("0099-01-01T12:00:00Z");
+
+    date.setFullYear(1);
+    expect(formatRFC3339(date)).toBe("0001-01-01T12:00:00Z");
+
+    getTimezoneOffsetStub.mockRestore();
+  });
 });

--- a/pkgs/core/src/formatRFC7231/index.ts
+++ b/pkgs/core/src/formatRFC7231/index.ts
@@ -50,7 +50,7 @@ export function formatRFC7231(date: DateArg<Date> & {}): string {
   const dayName = days[_date.getUTCDay()];
   const dayOfMonth = addLeadingZeros(_date.getUTCDate(), 2);
   const monthName = months[_date.getUTCMonth()];
-  const year = _date.getUTCFullYear();
+  const year = addLeadingZeros(_date.getUTCFullYear(), 4);
 
   const hour = addLeadingZeros(_date.getUTCHours(), 2);
   const minute = addLeadingZeros(_date.getUTCMinutes(), 2);

--- a/pkgs/core/src/formatRFC7231/test.ts
+++ b/pkgs/core/src/formatRFC7231/test.ts
@@ -15,4 +15,19 @@ describe("formatRFC7231", () => {
   it("throws RangeError if the time value is invalid", () => {
     expect(formatRFC7231.bind(null, new Date(NaN))).toThrow(RangeError);
   });
+
+  it("pads years below 1000 to four digits", () => {
+    // RFC 7231 defines the HTTP-date year as `4DIGIT`, so a year below 1000 has
+    // to be zero padded rather than emitted at its natural width.
+    const date = new Date(Date.UTC(2019, 0 /* Jan */, 1, 12, 0, 0));
+
+    date.setUTCFullYear(999);
+    expect(formatRFC7231(date)).toBe("Tue, 01 Jan 0999 12:00:00 GMT");
+
+    date.setUTCFullYear(99);
+    expect(formatRFC7231(date)).toBe("Thu, 01 Jan 0099 12:00:00 GMT");
+
+    date.setUTCFullYear(1);
+    expect(formatRFC7231(date)).toBe("Mon, 01 Jan 0001 12:00:00 GMT");
+  });
 });


### PR DESCRIPTION
Fixes #4004

## Problem

RFC 3339 defines `date-fullyear = 4DIGIT`, and RFC 7231 defines the HTTP-date year as `4DIGIT`. Both formatters read the year without padding it, so any year below 1000 comes out at its natural width and the result is not a valid date string for either standard:

| year | `formatRFC3339` | `formatRFC7231` |
| --- | --- | --- |
| 999 | `999-01-01T12:00:00Z` | `Tue, 01 Jan 999 12:00:00 GMT` |
| 99 | `99-01-01T12:00:00Z` | `Thu, 01 Jan 99 12:00:00 GMT` |
| 1 | `1-01-01T12:00:00Z` | `Mon, 01 Jan 1 12:00:00 GMT` |

Every other field in both functions already goes through `addLeadingZeros`, and `formatISO` already does `addLeadingZeros(date_.getFullYear(), 4)` — the year is the only field that was left unpadded, in these two functions only.

## Changes

One line in each:

```ts
- const year = date_.getFullYear();
+ const year = addLeadingZeros(date_.getFullYear(), 4);
```

`addLeadingZeros` was already imported in both files.

**On scope:** the issue is filed against `formatRFC3339`. `formatRFC7231` had the identical defect two lines apart, and RFC 7231 §7.1.1.1 mandates the same 4-digit year, so fixing one and leaving the other seemed worse than covering both. Happy to split into two PRs if you'd rather keep them separate.

## Tests

A case in each function's `test.ts`, covering years 999, 99 and 1. Both fail on `main`:

```
AssertionError: expected '999-01-01T12:00:00Z' to be '0999-01-01T12:00:00Z'
AssertionError: expected 'Tue, 01 Jan 999 12:00:00 GMT' to be 'Tue, 01 Jan 0999 12:00:00 GMT'
```

The `formatRFC3339` case stubs `getTimezoneOffset` to 0 the way the existing tests in that file do, so it does not depend on the machine's zone.

Full `pkgs/core` suite: 3150 passed / 37 failed. The 37 are all in the `temporarily` project (`test.tp.ts`) and fail identically on a clean `main` checkout — 3148 passed / the same 37 — so they are unrelated to this change.
