### PR TITLE
fix: correct the formatISODuration example output

### DIFF
--- a/pkgs/core/src/formatISODuration/index.ts
+++ b/pkgs/core/src/formatISODuration/index.ts
@@ -22,7 +22,7 @@ import type { Duration } from "../types.ts";
  *   minutes: 5,
  *   seconds: 0
  * })
- * //=> 'P39Y2M20DT0H0M0S'
+ * //=> 'P39Y2M20DT7H5M0S'
  */
 export function formatISODuration(duration: Duration): string {
   const {

--- a/pkgs/core/src/formatISODuration/test.ts
+++ b/pkgs/core/src/formatISODuration/test.ts
@@ -72,4 +72,19 @@ describe("formatISODuration", () => {
 
     expect(result).toBe("P0Y0M0DT0H0M0S");
   });
+
+  it("formats the duration used as the documented example", () => {
+    // Guards the @example in index.ts, which claimed 'P39Y2M20DT0H0M0S' and
+    // dropped the hours and minutes it was given.
+    const result = formatISODuration({
+      years: 39,
+      months: 2,
+      days: 20,
+      hours: 7,
+      minutes: 5,
+      seconds: 0,
+    });
+
+    expect(result).toBe("P39Y2M20DT7H5M0S");
+  });
 });


### PR DESCRIPTION
Fixes #3917

## Problem

The `@example` for `formatISODuration` passes `hours: 7` and `minutes: 5`, but documents the result as `'P39Y2M20DT0H0M0S'` — both values dropped to zero:

```ts
const result = formatISODuration({
  years: 39, months: 2, days: 20,
  hours: 7, minutes: 5, seconds: 0
})
//=> 'P39Y2M20DT0H0M0S'   // actually 'P39Y2M20DT7H5M0S'
```

This renders on the docs site, so it reads as though the function discards the time components.

The function is fine — only the comment was wrong. Worth noting the very first case in `formatISODuration/test.ts` has always asserted `"P39Y2M20DT7H5M0S"` for the same duration, so the example was contradicting the repo's own suite.

## Changes

- Correct the documented output to `'P39Y2M20DT7H5M0S'`.
- Add a test using the object literal from the example, so the documented call is pinned rather than only the `intervalToDuration`-derived equivalent.

## Notes on the sibling reports

While here I checked the other open "Problem in X documentation" issues, in case they were the same class:

- **#4017** (`differenceInCalendarISOWeeks`) — not a defect. The example reads "6 July 2014 and 21 July 2014" against `new Date(2014, 6, 21)`, and month index 6 *is* July, so the prose already matches. The suggested change to June would make it wrong.
- **#3947** (`differenceInDays`) and **#3961** (`setDate`) are requests to extend or reword the docs rather than incorrect output, so I left them alone.

`pkgs/core/src/formatISODuration` passes 11/11.
