### PR TITLE
docs: link UTCDate to the utc package

### DIFF
--- a/pkgs/core/docs/timeZones.md
+++ b/pkgs/core/docs/timeZones.md
@@ -17,7 +17,7 @@ There are two ways to start working with time zones:
 
 ### Using `TZDate` & `UTCDate`
 
-One way is to use [`TZDate`](https://github.com/date-fns/tz) or [`UTCDate`](https://github.com/date-fns/tz) `Date` extensions,with regular date-fns functions:
+One way is to use [`TZDate`](https://github.com/date-fns/tz) or [`UTCDate`](https://github.com/date-fns/utc) `Date` extensions, with regular date-fns functions:
 
 ```ts
 import { TZDate } from "@date-fns/tz";


### PR DESCRIPTION
## Problem

In `pkgs/core/docs/timeZones.md`, the `UTCDate` link in the "Using `TZDate` & `UTCDate`" section points at the `@date-fns/tz` repository instead of the `@date-fns/utc` repository:

```md
One way is to use [`TZDate`](https://github.com/date-fns/tz) or [`UTCDate`](https://github.com/date-fns/tz) ...
```

The file's own "Further reading" section already maps `@date-fns/utc` to `https://github.com/date-fns/utc`, so line 20 contradicts it.

## Solution

Point the `UTCDate` link at `https://github.com/date-fns/utc` (and add the missing space before "with" in the same sentence).

## Verification

- `curl -L -o /dev/null -w "%{http_code}"` returns 200 for both `https://github.com/date-fns/utc` and `https://github.com/date-fns/tz`
- `grep -rn "date-fns/utc" pkgs/core/docs/timeZones.md` shows the footer reference this change now agrees with
