### PR TITLE
docs: clarify the difference between parseJSON and parseISO

### DIFF
--- a/pkgs/core/src/parseISO/index.ts
+++ b/pkgs/core/src/parseISO/index.ts
@@ -27,6 +27,11 @@ export interface ParseISOOptions<
  * Function accepts complete ISO 8601 formats as well as partial implementations.
  * ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
  *
+ * Use this when the string may be a partial ISO 8601 value (date-only,
+ * week dates, ordinal dates, extended years). For a complete JSON / ISO
+ * datetime such as `JSON.stringify(new Date())` output, prefer
+ * {@link parseJSON}, which is a smaller parser for that narrower set.
+ *
  * If the argument isn't a string, the function cannot parse the string or
  * the values are invalid, it returns Invalid Date.
  *

--- a/pkgs/core/src/parseJSON/index.ts
+++ b/pkgs/core/src/parseJSON/index.ts
@@ -14,6 +14,8 @@ export interface ParseJSONOptions<
  *
  * This is a minimal implementation for converting dates retrieved from a JSON API to
  * a `Date` instance which can be used with other functions in the `date-fns` library.
+ * Unlike {@link parseISO}, it does not accept partial ISO 8601 values (date-only,
+ * week dates, ordinal dates). Use {@link parseISO} when the input may be incomplete.
  * The following formats are supported:
  *
  * - `2000-03-15T05:20:10.123Z`: The output of `.toISOString()` and `JSON.stringify(new Date())`


### PR DESCRIPTION
## Problem

Issue #2368 points out that the docs do not explain when to use `parseJSON` versus `parseISO`; both parse ISO-like strings, so users cannot tell them apart from the doc comments alone.

## Solution

Add short cross-referencing sentences to both doc comments:

- `parseJSON`: states it does not accept partial ISO 8601 values (date-only, week dates, ordinal dates) and points to `parseISO` for incomplete input.
- `parseISO`: states it also accepts partial ISO 8601 values and points to `parseJSON` for complete JSON datetime strings.

Both use `{@link ...}` so TypeDoc keeps them connected.

Fixes #2368

## Verification

- Comment-only change; no runtime code touched.
- The behavior claims match the existing test suites: `pkgs/core/src/parseJSON/test.ts` only feeds complete datetimes, while `parseISO/test.ts` covers date-only, week, and ordinal formats.
