### PR TITLE
Chore/cursor rules setup

### DIFF
--- a/.cursor/rules/business-day-contribution.mdc
+++ b/.cursor/rules/business-day-contribution.mdc
@@ -1,0 +1,30 @@
+---
+description: Business-day and weekend helpers — Mon–Fri, caller-supplied exclusions, no bundled holiday data
+globs:
+  - "pkgs/core/src/{addBusinessDays,subBusinessDays,differenceInBusinessDays}/**"
+  - "pkgs/core/src/{isWeekend,eachWeekendOfInterval,eachWeekendOfMonth,eachWeekendOfYear}/**"
+alwaysApply: false
+---
+
+# Business days and weekends
+
+Business days are **Mon–Fri**. Weekends are Saturday (`6`) and Sunday (`0`).
+
+Core holds no bundled holiday calendar data and shouldn't gain any — holiday data lives in separate ecosystem packages like `date-fns-holiday-us`. Business-day functions may accept a caller-supplied exclusion list or predicate; they must not embed holiday data themselves.
+
+- Reuse `isWeekend` (and `isSaturday`/`isSunday` as `addBusinessDays` already does). Weekend lists: `eachWeekendOfInterval` filters with `isWeekend`; month/year wrappers stay thin.
+- Keep `subBusinessDays` as `addBusinessDays(date, -amount, options)`.
+- Convert with `toDate`, pass `options?.in`, use `constructFrom` for Invalid Date; never mutate the input.
+- After `setDate` arithmetic, restore hours (`_date.setHours(hours)`) so DST does not lag the clock.
+- `differenceInBusinessDays` strips times like `differenceInCalendarDays`, uses `normalizeDates`, and returns `0` not `-0`.
+- Handle weekend starts, amounts divisible by 5 that land on a weekend, Friday+1 → Monday, large ranges, negative amounts, Invalid Date, and NaN amount.
+- Tests: colocated Vitest, month comments (`8 /* Sep */`), weekend-start cases, large counts.
+
+```typescript
+// ✅ GOOD — Friday + 1 business day → Monday
+it("returns the Monday when 1 day is added on the Friday", () => {
+  expect(addBusinessDays(new Date(2020, 0 /* Jan */, 10), 1)).toEqual(
+    new Date(2020, 0 /* Jan */, 13),
+  );
+});
+```

--- a/.cursor/rules/date-fns-contribution-standards.mdc
+++ b/.cursor/rules/date-fns-contribution-standards.mdc
@@ -1,0 +1,57 @@
+---
+description: date-fns contribution standards — packages, PRs, tests, i18n, and what not to change
+alwaysApply: true
+---
+
+# date-fns Contribution Standards
+
+## Packages
+
+- `pkgs/core`: core `date-fns`
+- `pkgs/utc`: `@date-fns/utc` (`UTCDate`)
+- `pkgs/tz`: `@date-fns/tz` (`TZDate` and time zone helpers)
+
+Use Node.js 22+ and `pnpm`. Lint with `pnpm run lint` (Prettier + ESLint).
+
+## Do not change
+
+- Changelog
+- Library version
+- Git history, commits, or remotes unless the human explicitly asks (or this rule requires a checkout/rebase)
+
+## Functions and tests
+
+Put each function in its own directory: `pkgs/core/src/<fn>/index.ts` with colocated `test.ts`.
+
+Mirror existing helpers: convert input with `toDate`, preserve date extensions via `constructFrom` / `options?.in`, do not mutate the argument, and document with TSDoc (`@name`, `@category`, `@param`, `@example`).
+
+```typescript
+// ✅ GOOD — colocated Vitest, month comments, type resolution
+it("adds the given number of days", () => {
+  const result = addDays(new Date(2014, 8 /* Sep */, 1), 10);
+  expect(result).toEqual(new Date(2014, 8 /* Sep */, 11));
+});
+```
+
+```sh
+pnpm vitest run              # Node
+pnpm vitest run --browser    # Browser
+```
+
+Reject PRs that only duplicate native APIs or inflate bundle size; new features belong in a focused package when they do not fit core.
+
+## I18n
+
+Follow `pkgs/core/docs/i18nContributionGuide.md`. After locale changes, regenerate snapshots:
+
+```sh
+mise //pkgs/core:gen/locales/snapshots
+```
+
+## PRs
+
+Checkout with `gh pr checkout <pr_number>`. If the working tree is dirty, stop and ask the human.
+
+Rebase onto latest `main` only when asked; do not push. After a rebase, say so in the summary.
+
+When done, report what changed. Do not commit or push unless explicitly requested.


### PR DESCRIPTION
Specification authorship → the two rules files. Grounded in the real CONTRIBUTING.md and real sibling conventions, not invented. Iterated once a real UI (/create-rule) produced a materially better draft than if written by hand - because it was grounded in the actual repo.