### PR TITLE
Fix x/xx/xxx/xxxx/xxxxx timezone tokens incorrectly accepting 'Z'

### DIFF
--- a/pkgs/core/src/parse/_lib/constants.ts
+++ b/pkgs/core/src/parse/_lib/constants.ts
@@ -22,10 +22,22 @@ export const numericPatterns = {
   fourDigitsSigned: /^-?\d{1,4}/, // 0 to 9999, -0 to -9999
 };
 
-export const timezonePatterns = {
+// Used by the uppercase X token family (ISOTimezoneWithZParser), where a
+// bare 'Z' is a valid ISO-8601 UTC designator.
+export const timezonePatternsWithZ = {
   basicOptionalMinutes: /^([+-])(\d{2})(\d{2})?|Z/,
   basic: /^([+-])(\d{2})(\d{2})|Z/,
   basicOptionalSeconds: /^([+-])(\d{2})(\d{2})((\d{2}))?|Z/,
   extended: /^([+-])(\d{2}):(\d{2})|Z/,
   extendedOptionalSeconds: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?|Z/,
+};
+
+// Used by the lowercase x token family (ISOTimezoneParser), which per
+// ISO-8601 does not accept 'Z' -- only a signed numeric offset.
+export const timezonePatternsWithoutZ = {
+  basicOptionalMinutes: /^([+-])(\d{2})(\d{2})?/,
+  basic: /^([+-])(\d{2})(\d{2})/,
+  basicOptionalSeconds: /^([+-])(\d{2})(\d{2})((\d{2}))?/,
+  extended: /^([+-])(\d{2}):(\d{2})/,
+  extendedOptionalSeconds: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?/,
 };

--- a/pkgs/core/src/parse/_lib/parsers/ISOTimezoneParser.ts
+++ b/pkgs/core/src/parse/_lib/parsers/ISOTimezoneParser.ts
@@ -1,6 +1,6 @@
 import { constructFrom } from "../../../constructFrom/index.ts";
 import { getTimezoneOffsetInMilliseconds } from "../../../_lib/getTimezoneOffsetInMilliseconds/index.ts";
-import { timezonePatterns } from "../constants.ts";
+import { timezonePatternsWithoutZ } from "../constants.ts";
 import { Parser } from "../Parser.ts";
 import type { ParseFlags, ParseResult } from "../types.ts";
 import { parseTimezonePattern } from "../utils.ts";
@@ -13,24 +13,27 @@ export class ISOTimezoneParser extends Parser<number> {
     switch (token) {
       case "x":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalMinutes,
+          timezonePatternsWithoutZ.basicOptionalMinutes,
           dateString,
         );
       case "xx":
-        return parseTimezonePattern(timezonePatterns.basic, dateString);
+        return parseTimezonePattern(timezonePatternsWithoutZ.basic, dateString);
       case "xxxx":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalSeconds,
+          timezonePatternsWithoutZ.basicOptionalSeconds,
           dateString,
         );
       case "xxxxx":
         return parseTimezonePattern(
-          timezonePatterns.extendedOptionalSeconds,
+          timezonePatternsWithoutZ.extendedOptionalSeconds,
           dateString,
         );
       case "xxx":
       default:
-        return parseTimezonePattern(timezonePatterns.extended, dateString);
+        return parseTimezonePattern(
+          timezonePatternsWithoutZ.extended,
+          dateString,
+        );
     }
   }
 

--- a/pkgs/core/src/parse/_lib/parsers/ISOTimezoneWithZParser.ts
+++ b/pkgs/core/src/parse/_lib/parsers/ISOTimezoneWithZParser.ts
@@ -1,6 +1,6 @@
 import { constructFrom } from "../../../constructFrom/index.ts";
 import { getTimezoneOffsetInMilliseconds } from "../../../_lib/getTimezoneOffsetInMilliseconds/index.ts";
-import { timezonePatterns } from "../constants.ts";
+import { timezonePatternsWithZ } from "../constants.ts";
 import { Parser } from "../Parser.ts";
 import type { ParseFlags, ParseResult } from "../types.ts";
 import { parseTimezonePattern } from "../utils.ts";
@@ -13,24 +13,24 @@ export class ISOTimezoneWithZParser extends Parser<number> {
     switch (token) {
       case "X":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalMinutes,
+          timezonePatternsWithZ.basicOptionalMinutes,
           dateString,
         );
       case "XX":
-        return parseTimezonePattern(timezonePatterns.basic, dateString);
+        return parseTimezonePattern(timezonePatternsWithZ.basic, dateString);
       case "XXXX":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalSeconds,
+          timezonePatternsWithZ.basicOptionalSeconds,
           dateString,
         );
       case "XXXXX":
         return parseTimezonePattern(
-          timezonePatterns.extendedOptionalSeconds,
+          timezonePatternsWithZ.extendedOptionalSeconds,
           dateString,
         );
       case "XXX":
       default:
-        return parseTimezonePattern(timezonePatterns.extended, dateString);
+        return parseTimezonePattern(timezonePatternsWithZ.extended, dateString);
     }
   }
 

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -1743,6 +1743,15 @@ describe("parse", () => {
         );
         expect(result).toEqual(new Date("2016-11-25T16:38:38.123+05:00"));
       });
+
+      it("returns `Invalid Date` for 'Z' (unlike the uppercase X token, x does not accept the UTC designator)", () => {
+        const result = parse(
+          "2016-11-25T16:38:38.123Z",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSx",
+          referenceDate,
+        );
+        expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+      });
     });
 
     describe("xx", () => {
@@ -1763,6 +1772,15 @@ describe("parse", () => {
         );
         expect(result).toEqual(new Date("2016-11-25T16:38:38.123Z"));
       });
+
+      it("returns `Invalid Date` for 'Z'", () => {
+        const result = parse(
+          "2016-11-25T16:38:38.123Z",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxx",
+          referenceDate,
+        );
+        expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+      });
     });
 
     describe("xxx", () => {
@@ -1782,6 +1800,15 @@ describe("parse", () => {
           referenceDate,
         );
         expect(result).toEqual(new Date("2016-11-25T16:38:38.123Z"));
+      });
+
+      it("returns `Invalid Date` for 'Z'", () => {
+        const result = parse(
+          "2016-11-25T16:38:38.123Z",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+          referenceDate,
+        );
+        expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
       });
     });
 


### PR DESCRIPTION
Fixes #4114.

## What

The lowercase `x`/`xx`/`xxx`/`xxxx`/`xxxxx` timezone tokens are documented to follow ISO-8601 without the `Z` UTC designator -- that's the whole distinction from the uppercase `X` family, whose own docstring in `ISOTimezoneWithZParser` reads "+00:00 is `'Z'`". But both parsers read from the same shared `timezonePatterns` regex constants in `constants.ts`, and every one of those regexes has `|Z` appended as a fallback alternative (e.g. `/^([+-])(\d{2})(\d{2})?|Z/`). The lowercase parser had no way to opt out of that shared alternative, so:

```js
parse("2016-11-25T16:38:38.123Z", "yyyy-MM-dd'T'HH:mm:ss.SSSx", new Date())
```

incorrectly returns a valid date instead of `Invalid Date`.

## Fix

Split the shared constant into two: `timezonePatternsWithZ` (used by `ISOTimezoneWithZParser`/the `X` family, identical regexes, unchanged behavior) and `timezonePatternsWithoutZ` (used by `ISOTimezoneParser`/the `x` family, with the `|Z` alternative removed from each regex). Each parser now only accepts what its own token is documented to support.

## Testing

- Added one `Invalid Date`-for-`'Z'` test to each of the `x`, `xx`, and `xxx` describe blocks in `parse/test.ts` (matching the file's existing style and assertion pattern for other `Invalid Date` cases).
- Verified as a negative control: all three new tests fail on unfixed source (543 total in the file, 3 failing exactly as expected, 540 unaffected), and pass with the fix.
- The uppercase `X`/`XX`/`XXXX`/`XXXXX` describe blocks already have existing literal-`'Z'` test cases asserting successful parsing -- those are untouched by this PR and continue to pass, confirming the `X` family's `Z` support is unaffected by the split.
- Ran the full `pkgs/core` vitest suite: 3151 passing (28 skipped), no regressions. The 37 pre-existing failures are all in a separate `*.test.tp.ts` project (`ReferenceError: Temporal is not defined`) unrelated to timezone parsing -- confirmed identical on a clean, unmodified checkout of this branch's base commit.
- `oxfmt` formatting applied and clean.

## Notes for reviewers

`oxlint --type-aware` (via `pnpm lint`) and `tsc --build` both fail in my environment with tooling errors ("no files specified in config" / `tsc: command not found`) that reproduce identically on a completely clean checkout with no changes -- this looks like a local Windows setup gap on my end (`@typescript/native-preview`'s binary didn't install), not something introduced by this change. Happy to have CI be the first real run of those two checks.
