### PR TITLE
Fix parseISO throwing instead of returning Invalid Date for non-string arguments

### DIFF
--- a/pkgs/core/src/parseISO/index.ts
+++ b/pkgs/core/src/parseISO/index.ts
@@ -55,6 +55,8 @@ export function parseISO<
 >(argument: string, options?: ParseISOOptions<ResultDate>): ResultDate {
   const invalidDate = () => constructFrom(options?.in, NaN);
 
+  if (typeof argument !== "string") return invalidDate();
+
   const additionalDigits = options?.additionalDigits ?? 2;
   const dateStrings = splitDateString(argument);
 

--- a/pkgs/core/src/parseISO/test.ts
+++ b/pkgs/core/src/parseISO/test.ts
@@ -362,6 +362,28 @@ describe("parseISO", () => {
       expect(result instanceof Date).toBe(true);
       expect(isNaN(result.getTime())).toBe(true);
     });
+
+    // Regression: callers commonly pass values typed `string` that are
+    // `null`/`undefined`/non-string at runtime (e.g. from an untyped API
+    // response). The docs promise Invalid Date for a non-string argument;
+    // it used to throw instead.
+    it("returns Invalid Date if argument is null", () => {
+      const result = parseISO(null as unknown as string);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is undefined", () => {
+      const result = parseISO(undefined as unknown as string);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is a number", () => {
+      const result = parseISO(20140211 as unknown as string);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
   });
 
   it("resolves the date type by default", () => {


### PR DESCRIPTION
Fixes #4127.

## What

`parseISO`'s own docstring says:

> If the argument isn't a string, the function cannot parse the string or the values are invalid, it returns Invalid Date.

The implementation never checked this. It calls `splitDateString(argument)` unconditionally, which does `dateString.split(patterns.dateTimeDelimiter)` -- so a non-string argument throws instead of returning `Invalid Date`:

```js
parseISO(null)
// TypeError: Cannot read properties of null (reading 'split')
```

This is a common real-world case despite the TS signature declaring `argument: string` -- values coming from an untyped API response, a form field, etc. are frequently `null`/`undefined` at runtime even when a type elsewhere claims `string`.

## Fix

One-line guard at the top of the function, matching the documented contract exactly:

```diff
  const invalidDate = () => constructFrom(options?.in, NaN);

+ if (typeof argument !== "string") return invalidDate();
+
  const additionalDigits = options?.additionalDigits ?? 2;
```

## Testing

- Added three tests to the existing `describe("invalid argument", ...)` block in `parseISO/test.ts`: `null`, `undefined`, and a `number`, all asserting `Invalid Date` rather than a thrown error.
- Verified as a negative control: all three fail on unfixed source with the exact reported `TypeError`, and pass with the fix (61/61 in the file total, 58 unaffected).
- Ran the full `pkgs/core` suite: 3151 passing, 28 skipped, no regressions. The 37 pre-existing failures are all in the unrelated `*.test.tp.ts` project (`Temporal is not defined`) -- same count with or without this change.
- `oxfmt` formatting applied and clean.

## Scope note

`parseJSON` has an analogous docstring promise ("Any other input type or invalid date strings will return an `Invalid Date`") and the same unguarded `dateStr.match(...)` shape, so it likely has the identical bug for `null`/`undefined`. Didn't fix it here since it's a separate function with its own tests and isn't what #4127 reports, but flagging in case a maintainer wants it as a quick follow-up.

## Notes for reviewers

`oxlint --type-aware` (`pnpm lint`) and `tsc --build` both fail in my local environment with tooling errors that reproduce identically on a clean checkout with no changes (a Windows-specific `@typescript/native-preview` binary install gap, unrelated to this diff) -- same caveat as my other recent PR here (#4303). Happy to have CI run those first.
