### PR TITLE
Fix parseJSON throwing instead of returning Invalid Date for non-string arguments

### DIFF
--- a/pkgs/core/src/parseJSON/index.ts
+++ b/pkgs/core/src/parseJSON/index.ts
@@ -44,6 +44,8 @@ export function parseJSON<ResultDate extends Date = Date>(
   dateStr: string,
   options?: ParseJSONOptions<ResultDate> | undefined,
 ): ResultDate {
+  if (typeof dateStr !== "string") return toDate(NaN, options?.in);
+
   const parts = dateStr.match(
     /(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d{0,7}))?(?:Z|(.)(\d{2}):?(\d{2})?)?/,
   );

--- a/pkgs/core/src/parseJSON/test.ts
+++ b/pkgs/core/src/parseJSON/test.ts
@@ -129,6 +129,22 @@ describe("parseJSON", () => {
     expect(parseJSON("2020-10-10").toString()).toBe("Invalid Date");
   });
 
+  // Regression: callers commonly pass values typed `string` that are
+  // `null`/`undefined`/non-string at runtime (e.g. from an untyped API
+  // response). These used to throw (`dateStr.match is not a function`)
+  // instead of returning Invalid Date.
+  it("returns an invalid date if argument is null", () => {
+    expect(parseJSON(null as unknown as string).toString()).toBe(
+      "Invalid Date",
+    );
+  });
+
+  it("returns an invalid date if argument is undefined", () => {
+    expect(parseJSON(undefined as unknown as string).toString()).toBe(
+      "Invalid Date",
+    );
+  });
+
   it("resolves the date type by default", () => {
     const result = parseJSON("2024-04-10T07:00:00Z");
     expect(result).toBeInstanceOf(Date);


### PR DESCRIPTION
## What

Same bug as #4127 (fixed for `parseISO`), in the sibling function. `parseJSON`'s docstring says:

> Any other input type or invalid date strings will return an `Invalid Date`.

but the implementation calls `dateStr.match(...)` unconditionally, so:

```js
parseJSON(null)
// TypeError: Cannot read properties of null (reading 'match')
```

throws instead of returning `Invalid Date`, despite the documented contract. Same common real-world cause as the `parseISO` case: values coming from an untyped API response are frequently `null`/`undefined` at runtime even where a type elsewhere claims `string`.

## Fix

Same one-line guard pattern as #4127:

```diff
  ): ResultDate {
+   if (typeof dateStr !== "string") return toDate(NaN, options?.in);
+
    const parts = dateStr.match(
```

## Scope note

The docstring also says Date instances and numbers are supported "for convenience... via [toDate]" (cloned / treated as a timestamp, respectively). That part of the contract isn't actually implemented -- the same unconditional `.match()` call throws for a `Date` or `number` argument too, both before and after this change -- and there's no existing test coverage for it either. I left that out of this PR since it's a separate, larger behavior gap (would need new delegation logic plus new tests for previously-untested functionality) rather than a straightforward crash fix. Happy to take a pass at implementing it properly as a follow-up if that's wanted.

## Testing

- Added two tests to the existing `describe("parseJSON", ...)` block: `null` and `undefined`, both asserting `Invalid Date` instead of a thrown error.
- Verified as a negative control: both fail on unfixed source with the exact reported `TypeError` shape, and pass with the fix (23/23 in the file, 21 unaffected).
- Ran the full `pkgs/core` suite: 3150 passing, 28 skipped, no regressions -- same 37 pre-existing, unrelated `*.test.tp.ts` (`Temporal is not defined`) failures as the baseline.
- `oxfmt` formatting applied and clean.

## Notes for reviewers

Same local tooling caveat as my other recent PRs here (#4303, #4304): `pnpm lint` / `tsc --build` fail with environment errors that reproduce identically on a clean checkout with no changes (Windows-specific `@typescript/native-preview` binary gap). Happy to have CI be the first real run of those.
