### PR TITLE
Fix intervalToDuration returning negative hours and minutes

### DIFF
--- a/pkgs/core/src/intervalToDuration/index.ts
+++ b/pkgs/core/src/intervalToDuration/index.ts
@@ -45,10 +45,20 @@ export function intervalToDuration(
   if (years) duration.years = years;
 
   const remainingMonths = add(start, { years: duration.years });
-  const months = differenceInMonths(end, remainingMonths);
+  let months = differenceInMonths(end, remainingMonths);
+  let remainingDays = add(remainingMonths, { months });
+
+  // Don't add a month that would pass `end`; later units would change sign (#4150).
+  const monthSign = months < 0 ? -1 : months > 0 ? 1 : 0;
+  while (
+    monthSign !== 0 &&
+    (monthSign > 0 ? +remainingDays > +end : +remainingDays < +end)
+  ) {
+    months -= monthSign;
+    remainingDays = add(remainingMonths, { months });
+  }
   if (months) duration.months = months;
 
-  const remainingDays = add(remainingMonths, { months: duration.months });
   const days = differenceInDays(end, remainingDays);
   if (days) duration.days = days;
 

--- a/pkgs/core/src/intervalToDuration/test.ts
+++ b/pkgs/core/src/intervalToDuration/test.ts
@@ -73,6 +73,28 @@ describe("intervalToDuration", () => {
   });
 
   describe("edge cases", () => {
+    it("returns non-negative components when end is after start - issue 4150", () => {
+      const result = intervalToDuration({
+        start: new Date(2026, 0 /* Jan */, 28, 22, 45),
+        end: new Date(2026, 1 /* Feb */, 28, 16, 23),
+      });
+
+      expect(result).toEqual({
+        days: 30,
+        hours: 17,
+        minutes: 38,
+      });
+    });
+
+    it("counts the month once the time of day is reached - issue 4150", () => {
+      const result = intervalToDuration({
+        start: new Date(2026, 0 /* Jan */, 28, 16, 23),
+        end: new Date(2026, 1 /* Feb */, 28, 16, 23),
+      });
+
+      expect(result).toEqual({ months: 1 });
+    });
+
     it("returns correct duration for dates in the end of Feb - issue 2255", () => {
       expect(
         intervalToDuration({


### PR DESCRIPTION
## Summary
`intervalToDuration` can return negative hours and minutes even when `end` is after `start`. That happens when `differenceInMonths` counts an unfinished month (the later date lands on a month-end before the start time-of-day has been reached). Adding that month overshoots `end`, so the remaining time units flip sign.

This PR keeps the month count from passing `end` inside `intervalToDuration`, which is the function that exhibited the bug.

## Related Issue (Fixes #4150)
Fixes #4150

## Changes Made
- After taking the month difference, add that many months to the remaining start date. If the result is past `end`, step the month count back until it is not.
- Add a regression test for the reported interval (`2026-01-28 22:45` → `2026-02-28 16:23`) and a guard that a full month is still counted once the time of day is reached.

This is scoped to `intervalToDuration` and does not change `differenceInMonths` public behavior.

## Testing
```sh
cd pkgs/core
pnpm vitest run src/intervalToDuration/test.ts
pnpm oxlint src/intervalToDuration/index.ts src/intervalToDuration/test.ts
```
Result: 22 passed (20 existing + 2 new). Lint clean.

## Notes
Related open PRs take different approaches:
- #4294 changes `differenceInMonths` itself (including a documented month-end edge case).
- #4153 patches `intervalToDuration` with ad-hoc unit borrowing and no longer applies cleanly to `main`.

This change only prevents `intervalToDuration` from adding a month that would pass `end`, so later units keep the same sign as the interval.

Signed-off-by: elix3r <157088510+22elix3r@users.noreply.github.com>