### PR TITLE
Fix parseISO to return Invalid Date for non-string arguments

### DIFF
--- a/pkgs/core/src/parseISO/index.ts
+++ b/pkgs/core/src/parseISO/index.ts
@@ -55,6 +55,8 @@ export function parseISO<
 >(argument: string, options?: ParseISOOptions<ResultDate>): ResultDate {
   const invalidDate = () => constructFrom(options?.in, NaN);
 
+  if (typeof argument !== "string") return invalidDate();
+
   const additionalDigits = options?.additionalDigits ?? 2;
   const dateStrings = splitDateString(argument);
 

--- a/pkgs/core/src/parseISO/test.ts
+++ b/pkgs/core/src/parseISO/test.ts
@@ -362,6 +362,27 @@ describe("parseISO", () => {
       expect(result instanceof Date).toBe(true);
       expect(isNaN(result.getTime())).toBe(true);
     });
+
+    it("returns Invalid Date if argument is null", () => {
+      // @ts-expect-error - We want to pass null here
+      const result = parseISO(null);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is undefined", () => {
+      // @ts-expect-error - We want to pass undefined here
+      const result = parseISO(undefined);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is a number", () => {
+      // @ts-expect-error - We want to pass a number here
+      const result = parseISO(123);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
   });
 
   it("resolves the date type by default", () => {


### PR DESCRIPTION
# What

parseISO's own docstring says:

> If the argument isn't a string, the function cannot parse the string or the values are invalid, it returns Invalid Date.

The implementation never checked this. It calls `splitDateString(argument)` unconditionally, which does `dateString.split(patterns.dateTimeDelimiter)` — so a non-string argument throws instead of returning Invalid Date:

```js
parseISO(null)
// TypeError: Cannot read properties of null (reading 'split')
```

This is a common real-world case despite the TS signature declaring `argument: string` — values coming from an untyped API response, a form field, etc. are frequently `null`/`undefined` at runtime even when a type elsewhere claims `string`.

# Fix

One-line guard at the top of the function, matching the documented contract exactly:

```diff
   const invalidDate = () => constructFrom(options?.in, NaN);

+  if (typeof argument !== "string") return invalidDate();
+
   const additionalDigits = options?.additionalDigits ?? 2;
```

# Testing

Added three tests to the existing `describe("invalid argument", ...)` block in `parseISO/test.ts`: `null`, `undefined`, and a number, all asserting Invalid Date rather than a thrown error.

Verified as a negative control: all three fail on unfixed source with the exact reported `TypeError`, and pass with the fix (61/61 in the file total, 58 unaffected).

Ran the full `pkgs/core` suite: 3215 passing, 1 skipped, no regressions.

`oxfmt` formatting applied and clean.

# Scope note

`parseJSON` has an analogous docstring promise ("Any other input type or invalid date strings will return an Invalid Date") and the same unguarded `dateStr.match(...)` shape, so it likely has the identical bug for `null`/`undefined`. Not fixed here — kept this PR scoped to `parseISO`.

---
Tiden intent branch: [intent/2026-08-27-parseiso-returns-invalid-date](https://app.tiden.ai/36f12696-f456-40a1-8ef8-06d7f05aa7f1/products/795808d6-3553-4eef-9fe0-db76f82ea1ed/branches/1a54a38d-270f-41c9-811d-350faa966518)