### PR TITLE
feat(fromUnixTime): support bigint input

### DIFF
--- a/pkgs/core/src/fromUnixTime/index.ts
+++ b/pkgs/core/src/fromUnixTime/index.ts
@@ -16,7 +16,7 @@ export interface FromUnixTimeOptions<
  * @description
  * Create a date from a Unix timestamp (in seconds). Decimal values will be discarded.
  *
- * @param unixTime - The given Unix timestamp (in seconds)
+ * @param unixTime - The given Unix timestamp (in seconds). Accepts a `number` or `bigint`.
  * @param options - An object with options. Allows to pass a context.
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
@@ -29,8 +29,9 @@ export interface FromUnixTimeOptions<
  * //=> Wed Feb 29 2012 11:45:05
  */
 export function fromUnixTime<DateType extends Date = Date>(
-  unixTime: number,
+  unixTime: number | bigint,
   options?: FromUnixTimeOptions<DateType> | undefined,
 ): DateType {
-  return toDate(unixTime * 1000, options?.in);
+  const timestamp = typeof unixTime === "bigint" ? Number(unixTime) : unixTime;
+  return toDate(timestamp * 1000, options?.in);
 }

--- a/pkgs/core/src/fromUnixTime/test.ts
+++ b/pkgs/core/src/fromUnixTime/test.ts
@@ -9,6 +9,11 @@ describe("fromUnixTime", () => {
     expect(result.getTime()).toBe(1330515499000);
   });
 
+  it("returns the date derived from a bigint UNIX timestamp", () => {
+    const result = fromUnixTime(1330515499n);
+    expect(result.getTime()).toBe(1330515499000);
+  });
+
   it("returns invalid if the given timestamp is invalid", () => {
     const result = fromUnixTime(NaN);
     expect(isNaN(result.getTime())).toBe(true);


### PR DESCRIPTION
Fixes #4126 

## What
Extends `fromUnixTime` to accept a `bigint` in addition to `number`, converting it internally before performing date math.

## Fix
- Widened the `unixTime` parameter type on `fromUnixTime` to `number | bigint`
- Added an internal conversion (`Number(unixTime)`) when a `bigint` is passed, before the existing multiplication logic runs
- Updated the JSDoc comment to document that `bigint` is now accepted
- Added a test case confirming a `bigint` timestamp produces the same result as the equivalent `number` timestamp

## Testing
- Ran `pnpm vitest run` inside `pkgs/core` — all `fromUnixTime` tests pass (6/6), including the new bigint test
- Ran `pnpm exec oxlint --type-aware --tsconfig pkgs/core/tsconfig.json` — no errors