### PR TITLE
Fix formatISO basic format keeping colon in timezone offset

### DIFF
--- a/pkgs/core/src/_lib/test/index.ts
+++ b/pkgs/core/src/_lib/test/index.ts
@@ -18,7 +18,7 @@ export function resetDefaultOptions(): void {
 }
 
 // This makes sure we create the consistent offsets across timezones, no matter where these tests are ran.
-export function generateOffset(originalDate: Date) {
+export function generateOffset(originalDate: Date, delimiter: string = ":") {
   // Add the timezone.
   let offset = "";
   const tzOffset = originalDate.getTimezoneOffset();
@@ -30,7 +30,7 @@ export function generateOffset(originalDate: Date) {
     // If less than 0, the sign is +, because it is ahead of time.
     const sign = tzOffset < 0 ? "+" : "-";
 
-    offset = `${sign}${hourOffset}:${minuteOffset}`;
+    offset = `${sign}${hourOffset}${delimiter}${minuteOffset}`;
   } else {
     offset = "Z";
   }

--- a/pkgs/core/src/formatISO/index.ts
+++ b/pkgs/core/src/formatISO/index.ts
@@ -84,7 +84,7 @@ export function formatISO(
       // If less than 0, the sign is +, because it is ahead of time.
       const sign = offset < 0 ? "+" : "-";
 
-      tzOffset = `${sign}${hourOffset}:${minuteOffset}`;
+      tzOffset = `${sign}${hourOffset}${timeDelimiter}${minuteOffset}`;
     } else {
       tzOffset = "Z";
     }

--- a/pkgs/core/src/formatISO/test.ts
+++ b/pkgs/core/src/formatISO/test.ts
@@ -32,7 +32,7 @@ describe("formatISO", () => {
 
   it("formats ISO-8601 basic format", () => {
     const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
-    const tzOffsetBasic = generateOffset(date);
+    const tzOffsetBasic = generateOffset(date, "");
     expect(formatISO(date, { format: "basic" })).toBe(
       `20191004T123013${tzOffsetBasic}`,
     );
@@ -51,13 +51,14 @@ describe("formatISO", () => {
 
   it("formats only time", () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
-    const tzOffset = generateOffset(date);
+    const tzOffsetExtended = generateOffset(date);
+    const tzOffsetBasic = generateOffset(date, "");
 
     expect(
       formatISO(date, { representation: "time", format: "extended" }),
-    ).toBe(`19:00:52${tzOffset}`);
+    ).toBe(`19:00:52${tzOffsetExtended}`);
     expect(formatISO(date, { representation: "time", format: "basic" })).toBe(
-      `190052${tzOffset}`,
+      `190052${tzOffsetBasic}`,
     );
   });
 


### PR DESCRIPTION
Fixes `formatISO`'s basic format so the timezone offset actually follows ISO 8601 basic notation (no separators), matching how the date and time parts are already handled.

Repro:

```js
formatISO(new Date(), { format: 'basic' })
// before: 20260830T234218+01:00  (colon still there)
// after:  20260830T234218+0100
```

Reported as #3291. There's an older PR for the same issue (#3308) but it's been open for a few years, has merge conflicts now, and its fix only touched the source without noticing the test helper has the identical bug baked into it (more on that below), so I put together a fresh one instead of trying to rebase it.

Cause: the timezone-offset branch in `formatISO` always joined hours and minutes with a literal colon, ignoring the `timeDelimiter` the rest of the function already derives from the `format` option. Extended format happened to want a colon anyway, so only the basic format case was ever visibly wrong.

The reason the existing tests didn't catch this: the shared `generateOffset` test helper in `_lib/test/index.ts` builds its expected offset with that same hardcoded colon, so the basic format tests were comparing the (wrong) actual output against an (equally wrong) expected value and always passed. I gave `generateOffset` an optional delimiter argument, defaulting to `:` so `formatRFC3339`'s tests (which always want the colon form) are unaffected, and pass an empty string from the basic format assertions in `formatISO`'s test file.

Verified the regression test actually catches the bug: reverting just the source fix while keeping the updated test makes `formats ISO-8601 basic format` fail with exactly the `+01:00` vs `+0100` mismatch; restoring the fix makes it and the rest of the suite pass again.

Ran `pnpm vitest run` in `pkgs/core`. The only failures are pre-existing and unrelated to this change (locale-dependent `intlFormatDistance` assertions that need an `en-US` ICU locale, and the `*.tp.ts` temporal test files) and reproduce identically on a clean checkout with none of these changes applied.
