### PR TITLE
fix(en-US): support narrow noon "n" in day period parsing

### DIFF
--- a/pkgs/core/src/locale/en-US/_lib/match/index.ts
+++ b/pkgs/core/src/locale/en-US/_lib/match/index.ts
@@ -80,7 +80,7 @@ const parseDayPeriodPatterns = {
     am: /^a/i,
     pm: /^p/i,
     midnight: /^mi/i,
-    noon: /^no/i,
+    noon: /^(no|n$)/i,
     morning: /morning/i,
     afternoon: /afternoon/i,
     evening: /evening/i,

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -1226,9 +1226,14 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
     });
 
-    it("narrow", () => {
+    it("narrow midnight", () => {
       const result = parse("mi", "bbbbb", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
+    it("narrow noon", () => {
+      const result = parse("n", "bbbbb", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 12));
     });
 
     describe("validation", () => {


### PR DESCRIPTION
## Problem
Formatting noon with the narrow token `bbbbb` produces `"n"`, but parsing `"n"` back fails to match any day period in the `en-US` locale parser. The parsed date silently falls through to hour 0 (midnight) instead of 12:00.

## Root Cause
In `pkgs/core/src/locale/en-US/_lib/match/index.ts`, `matchDayPeriodPatterns.narrow` matches `"n"`, but `parseDayPeriodPatterns.any.noon` only matches `/^no/i`, which fails to match the single-character string `"n"`.

## Fix
Update `parseDayPeriodPatterns.any.noon` to `/^(no|n$)/i` to support the narrow `"n"` day period token in addition to `"noon"`.

## Testing
Added a unit test for narrow noon parsing with `bbbbb` token in `pkgs/core/src/parse/test.ts` and verified with vitest.