### PR TITLE
feat(locale): add Malagasy (mg) language support

### DIFF
--- a/pkgs/core/src/locale/index.ts
+++ b/pkgs/core/src/locale/index.ts
@@ -62,6 +62,7 @@ export * from "./ko/index.ts";
 export * from "./lb/index.ts";
 export * from "./lt/index.ts";
 export * from "./lv/index.ts";
+export * from "./mg/index.ts";
 export * from "./mk/index.ts";
 export * from "./mn/index.ts";
 export * from "./ms/index.ts";

--- a/pkgs/core/src/locale/mg/_lib/formatDistance/index.ts
+++ b/pkgs/core/src/locale/mg/_lib/formatDistance/index.ts
@@ -1,0 +1,110 @@
+import type { FormatDistanceFn, FormatDistanceLocale } from "../../../types.ts";
+
+type FormatDistanceTokenValue =
+  | string
+  | {
+      one: string;
+      other: string;
+    };
+
+const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
+  lessThanXSeconds: {
+    one: "latsaky ny 1 segondra",
+    other: "latsaky ny {{count}} segondra",
+  },
+
+  xSeconds: {
+    one: "1 segondra",
+    other: "{{count}} segondra",
+  },
+
+  halfAMinute: "antsasaky ny minitra",
+
+  lessThanXMinutes: {
+    one: "latsaky ny 1 minitra",
+    other: "latsaky ny {{count}} minitra",
+  },
+
+  xMinutes: {
+    one: "1 minitra",
+    other: "{{count}} minitra",
+  },
+
+  aboutXHours: {
+    one: "tokony ho 1 ora",
+    other: "tokony ho {{count}} ora",
+  },
+
+  xHours: {
+    one: "1 ora",
+    other: "{{count}} ora",
+  },
+
+  xDays: {
+    one: "1 andro",
+    other: "{{count}} andro",
+  },
+
+  aboutXWeeks: {
+    one: "tokony ho 1 herinandro",
+    other: "tokony ho {{count}} herinandro",
+  },
+
+  xWeeks: {
+    one: "1 herinandro",
+    other: "{{count}} herinandro",
+  },
+
+  aboutXMonths: {
+    one: "tokony ho 1 volana",
+    other: "tokony ho {{count}} volana",
+  },
+
+  xMonths: {
+    one: "1 volana",
+    other: "{{count}} volana",
+  },
+
+  aboutXYears: {
+    one: "tokony ho 1 taona",
+    other: "tokony ho {{count}} taona",
+  },
+
+  xYears: {
+    one: "1 taona",
+    other: "{{count}} taona",
+  },
+
+  overXYears: {
+    one: "mihoatra ny 1 taona",
+    other: "mihoatra ny {{count}} taona",
+  },
+
+  almostXYears: {
+    one: "saika 1 taona",
+    other: "saika {{count}} taona",
+  },
+};
+
+export const formatDistance: FormatDistanceFn = (token, count, options) => {
+  let result;
+
+  const tokenValue = formatDistanceLocale[token];
+  if (typeof tokenValue === "string") {
+    result = tokenValue;
+  } else if (count === 1) {
+    result = tokenValue.one;
+  } else {
+    result = tokenValue.other.replace("{{count}}", count.toString());
+  }
+
+  if (options?.addSuffix) {
+    if (options.comparison && options.comparison > 0) {
+      return "afaka " + result;
+    } else {
+      return result + " lasa izay";
+    }
+  }
+
+  return result;
+};

--- a/pkgs/core/src/locale/mg/_lib/formatLong/index.ts
+++ b/pkgs/core/src/locale/mg/_lib/formatLong/index.ts
@@ -1,0 +1,40 @@
+import type { FormatLong } from "../../../types.ts";
+import { buildFormatLongFn } from "../../../_lib/buildFormatLongFn/index.ts";
+
+const dateFormats = {
+  full: "EEEE d MMMM y",
+  long: "d MMMM y",
+  medium: "d MMM, y",
+  short: "dd/MM/y",
+};
+
+const timeFormats = {
+  full: "HH:mm:ss zzzz",
+  long: "HH:mm:ss z",
+  medium: "HH:mm:ss",
+  short: "HH:mm",
+};
+
+const dateTimeFormats = {
+  full: "{{date}} 'amin''ny' {{time}}",
+  long: "{{date}} 'amin''ny' {{time}}",
+  medium: "{{date}}, {{time}}",
+  short: "{{date}}, {{time}}",
+};
+
+export const formatLong: FormatLong = {
+  date: buildFormatLongFn({
+    formats: dateFormats,
+    defaultWidth: "full",
+  }),
+
+  time: buildFormatLongFn({
+    formats: timeFormats,
+    defaultWidth: "full",
+  }),
+
+  dateTime: buildFormatLongFn({
+    formats: dateTimeFormats,
+    defaultWidth: "full",
+  }),
+};

--- a/pkgs/core/src/locale/mg/_lib/formatRelative/index.ts
+++ b/pkgs/core/src/locale/mg/_lib/formatRelative/index.ts
@@ -1,0 +1,17 @@
+import type { FormatRelativeFn } from "../../../types.ts";
+
+const formatRelativeLocale = {
+  lastWeek: "eeee 'lasa teo tamin''ny' p",
+  yesterday: "'omaly tamin''ny' p",
+  today: "'anio tamin''ny' p",
+  tomorrow: "'rahampitso tamin''ny' p",
+  nextWeek: "eeee 'manaraka tamin''ny' p",
+  other: "P",
+};
+
+export const formatRelative: FormatRelativeFn = (
+  token,
+  _date,
+  _baseDate,
+  _options,
+) => formatRelativeLocale[token];

--- a/pkgs/core/src/locale/mg/_lib/localize/index.ts
+++ b/pkgs/core/src/locale/mg/_lib/localize/index.ts
@@ -1,0 +1,135 @@
+import type { Localize, LocalizeFn } from "../../../types.ts";
+import type { Quarter } from "../../../../types.ts";
+import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+
+const eraValues = {
+  narrow: ["BC", "AD"] as const,
+  abbreviated: ["BC", "AD"] as const,
+  wide: ["Alohan'i Kristy", "Aorian'i Kristy"] as const,
+};
+
+const quarterValues = {
+  narrow: ["1", "2", "3", "4"] as const,
+  abbreviated: ["T1", "T2", "T3", "T4"] as const,
+  wide: [
+    "Telovolana voalohany",
+    "Telovolana faharoa",
+    "Telovolana fahatelo",
+    "Telovolana fahefatra",
+  ] as const,
+};
+
+const monthValues = {
+  narrow: ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"] as const,
+  abbreviated: [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "Mey",
+    "Jon",
+    "Jol",
+    "Aog",
+    "Sep",
+    "Okt",
+    "Nov",
+    "Des",
+  ] as const,
+  wide: [
+    "Janoary",
+    "Febroary",
+    "Martsa",
+    "Aprily",
+    "Mey",
+    "Jona",
+    "Jolay",
+    "Aogositra",
+    "Septambra",
+    "Oktobra",
+    "Novambra",
+    "Desambra",
+  ] as const,
+};
+
+const dayValues = {
+  narrow: ["A", "A", "T", "A", "A", "Z", "A"] as const,
+  short: ["Ah", "At", "Ta", "Ar", "Ak", "Zo", "As"] as const,
+  abbreviated: ["Alh", "Alt", "Tal", "Ala", "Alk", "Zom", "Asb"] as const,
+  wide: [
+    "Alahady",
+    "Alatsinainy",
+    "Talata",
+    "Alarobia",
+    "Alakamisy",
+    "Zoma",
+    "Asabotsy",
+  ] as const,
+};
+
+const dayPeriodValues = {
+  narrow: {
+    am: "AM",
+    pm: "PM",
+    midnight: "misasakalina",
+    noon: "mitataovovonana",
+    morning: "maraina",
+    afternoon: "tolakandro",
+    evening: "hariva",
+    night: "alina",
+  },
+  abbreviated: {
+    am: "AM",
+    pm: "PM",
+    midnight: "misasakalina",
+    noon: "mitataovovonana",
+    morning: "maraina",
+    afternoon: "tolakandro",
+    evening: "hariva",
+    night: "alina",
+  },
+  wide: {
+    am: "AM",
+    pm: "PM",
+    midnight: "misasakalina",
+    noon: "mitataovovonana",
+    morning: "maraina",
+    afternoon: "tolakandro",
+    evening: "hariva",
+    night: "alina",
+  },
+};
+
+const ordinalNumber: LocalizeFn<number> = (dirtyNumber, _options) => {
+  const number = Number(dirtyNumber);
+  return "faha-" + number;
+};
+
+export const localize: Localize = {
+  ordinalNumber,
+
+  era: buildLocalizeFn({
+    values: eraValues,
+    defaultWidth: "wide",
+  }),
+
+  quarter: buildLocalizeFn({
+    values: quarterValues,
+    defaultWidth: "wide",
+    argumentCallback: (quarter) => (quarter - 1) as Quarter,
+  }),
+
+  month: buildLocalizeFn({
+    values: monthValues,
+    defaultWidth: "wide",
+  }),
+
+  day: buildLocalizeFn({
+    values: dayValues,
+    defaultWidth: "wide",
+  }),
+
+  dayPeriod: buildLocalizeFn({
+    values: dayPeriodValues,
+    defaultWidth: "wide",
+  }),
+};

--- a/pkgs/core/src/locale/mg/_lib/match/index.ts
+++ b/pkgs/core/src/locale/mg/_lib/match/index.ts
@@ -1,0 +1,133 @@
+import type { Quarter } from "../../../../types.ts";
+import type { Match } from "../../../types.ts";
+import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
+
+const matchOrdinalNumberPattern = /^(faha-)?\d+/i;
+const parseOrdinalNumberPattern = /\d+/i;
+
+const matchEraPatterns = {
+  narrow: /^(bc|ad)/i,
+  abbreviated: /^(bc|ad)/i,
+  wide: /^(alohan'i kristy|aorian'i kristy)/i,
+};
+const parseEraPatterns = {
+  any: [/^al/i, /^ao/i] as const,
+};
+
+const matchQuarterPatterns = {
+  narrow: /^[1234]/i,
+  abbreviated: /^t[1234]/i,
+  wide: /^telovolana faha-?[1234]/i,
+};
+const parseQuarterPatterns = {
+  any: [/1/i, /2/i, /3/i, /4/i] as const,
+};
+
+const matchMonthPatterns = {
+  narrow: /^[jfmasonod]/i,
+  abbreviated: /^(jan|feb|mar|apr|mey|jon|jol|aog|sep|okt|nov|des)/i,
+  wide: /^(janoary|febroary|martsa|aprily|mey|jona|jolay|aogositra|septambra|oktobra|novambra|desambra)/i,
+};
+const parseMonthPatterns = {
+  narrow: [
+    /^j/i,
+    /^f/i,
+    /^m/i,
+    /^a/i,
+    /^m/i,
+    /^j/i,
+    /^j/i,
+    /^a/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i,
+  ] as const,
+  any: [
+    /^jan/i,
+    /^f/i,
+    /^mar/i,
+    /^ap/i,
+    /^mey/i,
+    /^jon/i,
+    /^jol/i,
+    /^aog/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i,
+  ] as const,
+};
+
+const matchDayPatterns = {
+  narrow: /^[atz]/i,
+  short: /^(ah|at|ta|ar|ak|zo|as)/i,
+  abbreviated: /^(alh|alt|tal|ala|alk|zom|asb)/i,
+  wide: /^(alahady|alatsinainy|talata|alarobia|alakamisy|zoma|asabotsy)/i,
+};
+const parseDayPatterns = {
+  narrow: [/^a/i, /^a/i, /^t/i, /^a/i, /^a/i, /^z/i, /^a/i] as const,
+  any: [/^alh|^ah/i, /^alt|^at/i, /^tal|^ta/i, /^ala|^ar/i, /^alk|^ak/i, /^zom|^zo/i, /^asb|^as/i] as const,
+};
+
+const matchDayPeriodPatterns = {
+  narrow: /^(am|pm|misasakalina|mitataovovonana|maraina|tolakandro|hariva|alina)/i,
+  any: /^(am|pm|misasakalina|mitataovovonana|maraina|tolakandro|hariva|alina)/i,
+};
+const parseDayPeriodPatterns = {
+  any: {
+    am: /^am/i,
+    pm: /^pm/i,
+    midnight: /^misasakalina/i,
+    noon: /^mitataovovonana/i,
+    morning: /^maraina/i,
+    afternoon: /^tolakandro/i,
+    evening: /^hariva/i,
+    night: /^alina/i,
+  },
+};
+
+export const match: Match = {
+  ordinalNumber: buildMatchPatternFn({
+    matchPattern: matchOrdinalNumberPattern,
+    parsePattern: parseOrdinalNumberPattern,
+    valueCallback: (value) => parseInt(value, 10),
+  }),
+
+  era: buildMatchFn({
+    matchPatterns: matchEraPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseEraPatterns,
+    defaultParseWidth: "any",
+  }),
+
+  quarter: buildMatchFn({
+    matchPatterns: matchQuarterPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseQuarterPatterns,
+    defaultParseWidth: "any",
+    valueCallback: (index) => (index + 1) as Quarter,
+  }),
+
+  month: buildMatchFn({
+    matchPatterns: matchMonthPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseMonthPatterns,
+    defaultParseWidth: "any",
+  }),
+
+  day: buildMatchFn({
+    matchPatterns: matchDayPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseDayPatterns,
+    defaultParseWidth: "any",
+  }),
+
+  dayPeriod: buildMatchFn({
+    matchPatterns: matchDayPeriodPatterns,
+    defaultMatchWidth: "any",
+    parsePatterns: parseDayPeriodPatterns,
+    defaultParseWidth: "any",
+  }),
+};

--- a/pkgs/core/src/locale/mg/index.ts
+++ b/pkgs/core/src/locale/mg/index.ts
@@ -1,0 +1,26 @@
+import { formatDistance } from "./_lib/formatDistance/index.ts";
+import { formatLong } from "./_lib/formatLong/index.ts";
+import { formatRelative } from "./_lib/formatRelative/index.ts";
+import { localize } from "./_lib/localize/index.ts";
+import { match } from "./_lib/match/index.ts";
+import type { Locale } from "../types.ts";
+
+/**
+ * @category Locales
+ * @summary Malagasy locale.
+ * @language Malagasy
+ * @iso-639-2 mlg
+ * @author date-fns
+ */
+export const mg: Locale = {
+  code: "mg",
+  formatDistance: formatDistance,
+  formatLong: formatLong,
+  formatRelative: formatRelative,
+  localize: localize,
+  match: match,
+  options: {
+    weekStartsOn: 1 /* Monday */,
+    firstWeekContainsDate: 4,
+  },
+};

--- a/pkgs/core/src/locale/mg/test.ts
+++ b/pkgs/core/src/locale/mg/test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { format } from "../../format/index.ts";
+import { formatDistance } from "../../formatDistance/index.ts";
+import { formatRelative } from "../../formatRelative/index.ts";
+import { parse } from "../../parse/index.ts";
+import { mg } from "./index.ts";
+
+describe("mg locale", () => {
+  it("formats date with long tokens", () => {
+    const date = new Date(2026, 5 /* June */, 26, 12, 0, 0);
+    const formatted = format(date, "PPPP", { locale: mg });
+    expect(formatted).toBe("Zoma 26 Jona 2026");
+  });
+
+  it("formats distance with includeSeconds", () => {
+    const d1 = new Date(2026, 0, 1);
+    const d2 = new Date(2026, 0, 1, 0, 0, 30);
+    expect(formatDistance(d1, d2, { locale: mg, includeSeconds: true })).toBe("antsasaky ny minitra");
+  });
+
+  it("formats relative", () => {
+    const baseDate = new Date(2026, 0, 1, 12, 0);
+    const yesterday = new Date(2025, 11, 31, 12, 0);
+    expect(formatRelative(yesterday, baseDate, { locale: mg })).toBe("omaly tamin'ny 12:00");
+  });
+
+  it("parses formatted date", () => {
+    const date = parse("Zoma 26 Jona 2026", "PPPP", new Date(2026, 0, 1), { locale: mg });
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(5);
+    expect(date.getDate()).toBe(26);
+  });
+});


### PR DESCRIPTION
## Problem
Malagasy (`mg`) language support is currently unavailable in `date-fns/locale`.

## Root Cause
Missing locale definition, formatters, and matchers for the Malagasy language (`mg` / `mlg`).

## Fix
- Added Malagasy (`mg`) locale in `pkgs/core/src/locale/mg/` with localized months, weekdays, day periods, relative formats, and long date/time formats conforming to CLDR standards.
- Exported `mg` locale from `pkgs/core/src/locale/index.ts`.
- Added unit test suite in `pkgs/core/src/locale/mg/test.ts` covering date formatting, distance, relative formatting, and parsing.

## Testing
Verified all tests in `pkgs/core/src/locale/mg/test.ts` with vitest.