### PR TITLE
Fix tzOffset returning the wrong sign for sub-hour western offsets

### DIFF
--- a/pkgs/tz/src/tzOffset/index.ts
+++ b/pkgs/tz/src/tzOffset/index.ts
@@ -54,8 +54,7 @@ function calcOffset(cacheStr: string, values: string[]): number {
   const minutes = +(values[1] || 0);
   // Convert seconds to minutes by dividing by 60 to keep the function return in minutes.
   const seconds = +(values[2] || 0) / 60;
+  const sign = values[0]?.trim().startsWith("-") ? -1 : 1;
   return (offsetCache[cacheStr] =
-    hours * 60 + minutes > 0
-      ? hours * 60 + minutes + seconds
-      : hours * 60 - minutes - seconds);
+    sign * (Math.abs(hours) * 60 + minutes + seconds));
 }

--- a/pkgs/tz/src/tzOffset/tests.ts
+++ b/pkgs/tz/src/tzOffset/tests.ts
@@ -88,6 +88,12 @@ describe("tzOffset", () => {
   });
 
   describe("fractional time zones", () => {
+    it("works with sub-hour western offsets", () => {
+      expect(
+        tzOffset("Africa/Monrovia", new Date("1970-01-01T00:00:00Z")),
+      ).toBe(-44.5);
+    });
+
     it("works negative fractional time zones", () => {
       const dst = new Date("2023-03-15T18:00:00.000Z");
       const date = new Date("2023-03-03T18:00:00.000Z");


### PR DESCRIPTION
I hit this while formatting some historical dates. `tzOffset` returns a positive value for zones that were on a negative offset smaller than an hour.

Monrovia was at UTC-00:44:30 until 1972:

```js
tzOffset('Africa/Monrovia', new Date('1970-01-01T00:00:00Z'))
// -> 44.5, should be -44.5
```

The offset string from `Intl` is `GMT-00:44:30`. In `calcOffset` the sign comes from `hours * 60 + minutes > 0`, but for `-00` the hours part is `-0`, so the only thing carrying the minus is the string, and it gets dropped — the positive branch wins.

I read the sign from the offset string instead of the magnitude, so `-00:44:30` stays negative. The other offsets (`+05:30`, `-08:00`, `-03:30`, …) are unchanged. Added a test for Monrovia.