### PR TITLE
Fix differenceInMonths losing a month near the end of February

### DIFF
--- a/pkgs/core/src/differenceInMonths/index.ts
+++ b/pkgs/core/src/differenceInMonths/index.ts
@@ -44,7 +44,11 @@ export function differenceInMonths(
 
   if (difference < 1) return 0;
 
-  if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
+  if (
+    sign > 0 &&
+    workingLaterDate.getMonth() === 1 &&
+    workingLaterDate.getDate() > 27
+  )
     workingLaterDate.setDate(30);
 
   workingLaterDate.setMonth(workingLaterDate.getMonth() - sign * difference);

--- a/pkgs/core/src/differenceInMonths/test.ts
+++ b/pkgs/core/src/differenceInMonths/test.ts
@@ -29,6 +29,30 @@ describe("differenceInMonths", () => {
   });
 
   describe("edge cases", () => {
+    it("it returns diff of -1 month between Feb 29 2020 and Mar 31 2020", () => {
+      const result = differenceInMonths(
+        new Date(2020, 1 /* Feb */, 29),
+        new Date(2020, 2 /* Mar */, 31),
+      );
+      expect(result).toBe(-1);
+    });
+
+    it("it returns diff of -1 month between Feb 28 2021 and Mar 31 2021", () => {
+      const result = differenceInMonths(
+        new Date(2021, 1 /* Feb */, 28),
+        new Date(2021, 2 /* Mar */, 31),
+      );
+      expect(result).toBe(-1);
+    });
+
+    it("it returns diff of 1 month between Mar 31 2020 and Feb 29 2020", () => {
+      const result = differenceInMonths(
+        new Date(2020, 2 /* Mar */, 31),
+        new Date(2020, 1 /* Feb */, 29),
+      );
+      expect(result).toBe(1);
+    });
+
     it("it returns diff of 1 month between Feb 28 2021 and Jan 30 2021", () => {
       const result = differenceInMonths(
         new Date(2021, 1 /* Feb */, 28),


### PR DESCRIPTION
`differenceInMonths` isn't symmetric when one of the dates is the end of February:

```js
differenceInMonths(new Date(2020, 1, 29), new Date(2020, 2, 31)) // 0, expected -1
differenceInMonths(new Date(2020, 2, 31), new Date(2020, 1, 29)) //  1  (correct)
```

The reverse direction is right, so the first call should give `-1`.

There's a February end-of-month compensation that does `setDate(30)`, which overflows a Feb 28/29 date into early March. That nudge is only needed when we later subtract months (the forward direction). When the February date is the earlier argument the code adds months instead, and the bump just pushes the anchor past the target, so a whole month gets dropped.

I gated that compensation on the forward direction (`sign > 0`). The existing forward cases — including the timezone-context ones — still pass. Added tests for the leap and non-leap reverse cases.